### PR TITLE
chore: add turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ lib-cov
 *.njsproj
 *.sln
 *.sw?
+.turbo

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 Monorepo containing all base services and applications of the ONECore platform.
 
-
 ## Overview
 
 ### Repository structure
@@ -34,10 +33,26 @@ Apart from the core orchestration service, packages belong to one of three categ
     └── work-order/
 ```
 
-See the respective packages of this repository for more information.
+### Local development
 
+[Turborepo](https://turborepo.com/) lets us run multiple packages simultaneously in a tidy manner using its "tui" configuration.
+
+```sh
+npm run dev # runs everything
+npm run dev -- --filter='!@onecore/property' # runs everything except for @onecore/property
+npm run dev -- --filter='@onecore/property' # runs only @onecore/property
+```
+
+Furthermore, turborepo handles different packages dependencies. If we run @onecore/leasing, which uses libs/types and libs/utilities, both of these packages will be built before leasing starts.
+
+More information on running tasks [can be found here](https://turborepo.com/docs/crafting-your-repository/running-tasks).
+
+More information on filtering [can be found here](https://turborepo.com/docs/reference/run#advanced-filtering-examples).
+
+More information on the terminal UI [can be found here](https://turborepo.com/docs/crafting-your-repository/developing-applications#using-the-terminal-ui).
+
+See the respective packages of this repository for more information.
 
 ## License
 
 © 2025 Bostads AB Mimer. [AGPL-3.0-only Licensed](./LICENSE)
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "eslint": "^9.31.0",
         "prettier": "^3.6.2",
         "syncpack": "^13.0.4",
+        "turbo": "^2.5.5",
         "typescript": "^5.6.2"
       },
       "engines": {
@@ -23923,6 +23924,101 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/turbo": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.5.5.tgz",
+      "integrity": "sha512-eZ7wI6KjtT1eBqCnh2JPXWNUAxtoxxfi6VdBdZFvil0ychCOTxbm7YLRBi1JSt7U3c+u3CLxpoPxLdvr/Npr3A==",
+      "dev": true,
+      "bin": {
+        "turbo": "bin/turbo"
+      },
+      "optionalDependencies": {
+        "turbo-darwin-64": "2.5.5",
+        "turbo-darwin-arm64": "2.5.5",
+        "turbo-linux-64": "2.5.5",
+        "turbo-linux-arm64": "2.5.5",
+        "turbo-windows-64": "2.5.5",
+        "turbo-windows-arm64": "2.5.5"
+      }
+    },
+    "node_modules/turbo-darwin-64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.5.5.tgz",
+      "integrity": "sha512-RYnTz49u4F5tDD2SUwwtlynABNBAfbyT2uU/brJcyh5k6lDLyNfYKdKmqd3K2ls4AaiALWrFKVSBsiVwhdFNzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-darwin-arm64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.5.5.tgz",
+      "integrity": "sha512-Tk+ZeSNdBobZiMw9aFypQt0DlLsWSFWu1ymqsAdJLuPoAH05qCfYtRxE1pJuYHcJB5pqI+/HOxtJoQ40726Btw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/turbo-linux-64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.5.5.tgz",
+      "integrity": "sha512-2/XvMGykD7VgsvWesZZYIIVXMlgBcQy+ZAryjugoTcvJv8TZzSU/B1nShcA7IAjZ0q7OsZ45uP2cOb8EgKT30w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-linux-arm64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.5.5.tgz",
+      "integrity": "sha512-DW+8CjCjybu0d7TFm9dovTTVg1VRnlkZ1rceO4zqsaLrit3DgHnN4to4uwyuf9s2V/BwS3IYcRy+HG9BL596Iw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/turbo-windows-64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.5.5.tgz",
+      "integrity": "sha512-q5p1BOy8ChtSZfULuF1BhFMYIx6bevXu4fJ+TE/hyNfyHJIfjl90Z6jWdqAlyaFLmn99X/uw+7d6T/Y/dr5JwQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/turbo-windows-arm64": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.5.5.tgz",
+      "integrity": "sha512-AXbF1KmpHUq3PKQwddMGoKMYhHsy5t1YBQO8HZ04HLMR0rWv9adYlQ8kaeQJTko1Ay1anOBFTqaxfVOOsu7+1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.3",
   "private": true,
   "author": "Bostads AB Mimer",
-  "packageManager": "npm@9.9.3",
+  "packageManager": "npm@10.9.2",
   "engines": {
     "node": ">=20"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.3",
   "private": true,
   "author": "Bostads AB Mimer",
-  "packageManager": "npm",
+  "packageManager": "npm@9.9.3",
   "engines": {
     "node": ">=20"
   },
@@ -32,6 +32,7 @@
     "build:work-order": "npm run build --workspace=@onecore/work-order",
     "db:init": "./scripts/db/initialize.sh",
     "dev:init": "npm run db:init && npm run dev:init --workspaces --if-present",
+    "dev": "turbo run dev",
     "generate:static": "npm run generate:static --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "lint:fix": "npm run lint:fix --workspaces --if-present",
@@ -43,6 +44,7 @@
     "eslint": "^9.31.0",
     "prettier": "^3.6.2",
     "syncpack": "^13.0.4",
+    "turbo": "^2.5.5",
     "typescript": "^5.6.2"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turborepo.com/schema.json",
+  "ui": "tui",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["./dist/**", "./build/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {
+      "dependsOn": ["^lint"]
+    },
+    "dev": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "persistent": true
+    }
+  }
+}


### PR DESCRIPTION
Adds [turborepo](https://turborepo.com/docs/getting-started/add-to-existing-repository) with basic configuration.

As a starting point, turbo terminal UI lets us run multiple packages in parallell for local development.
I've added some documentation on this in the README, and also linked to turbo docs where more information can be found.

Turborepo can also help us build our packages (with its dependencies to other packages, etc) in the future.
