### PR TITLE
Fix: UTH-261 Offer ExpiredAt Time

### DIFF
--- a/core/src/processes/parkingspaces/internal/create-offer.ts
+++ b/core/src/processes/parkingspaces/internal/create-offer.ts
@@ -158,9 +158,18 @@ export const createOfferForInternalParkingSpace = async (
       ...eligibleApplicant,
       status: ApplicantStatus.Offered,
     }
+
+    const offerExpiresDate = utils.date.addBusinessDays(new Date(), 3)
+    // Set swedish time (CET/CEST) 23:59:59
+    offerExpiresDate.setHours(23, 59, 59, 0)
+    // Convert to UTC time
+    const utcOfferExpiresDate = new Date(
+      offerExpiresDate.getTime() - offerExpiresDate.getTimezoneOffset() * 60000
+    )
+
     const offer = await leasingAdapter.createOffer({
       applicantId: eligibleApplicant.id,
-      expiresAt: utils.date.addBusinessDays(new Date(), 3),
+      expiresAt: utcOfferExpiresDate,
       listingId: listing.id,
       status: OfferStatus.Active,
       selectedApplicants: [updatedApplicant, ...activeApplicants].map(


### PR DESCRIPTION
When setting ExpiredAt when an offer is created only date is explicitly set, time will be whatever time the offer is created. This is a problem since users expect to have the whole day to reply to offers. IE: Offers shouldn't expire until midnight

* New offers will now get 23:59:59 set explicitly
* Saved as UTC in database