### PR TITLE
MIM-563: Incorrect message timestamps

### DIFF
--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/utils.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/utils.ts
@@ -93,5 +93,5 @@ export const transformMessages = (
     body: striptags(message.body, ['br']).replaceAll('<br>', '\n'),
     messageType: message.message_type,
     author: last(message.author_id[1].split(', ')) ?? '', // author name is in format "YourCompany, Mitchell Admin"
-    createDate: new Date(message.create_date),
+    createDate: new Date(message.create_date + ' UTC'), // Create new date as UTC (odoo db stores dates without time zone)
   }))


### PR DESCRIPTION
Dates returned from workorder api seemed to return a local date instead of UTC (message dates are stored without timezone in odoo)

The timestamp for messages were therefore displayed incorrectly in mimer.nu.

Now it localizes the UTC to Swedish time correctly.