### PR TITLE
MIM-591: Bug - creating work order through odoo.create throws error due to model error

### DIFF
--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -203,7 +203,6 @@ const createRentalPropertyRecord = async (
       entrance: apartmentProperty.entrance,
       floor: apartmentProperty.floor,
       has_elevator: apartmentProperty.hasElevator ? 'Ja' : 'Nej',
-      wash_space: apartmentProperty.washSpace,
       estate_code: apartmentProperty.estateCode,
       estate: apartmentProperty.estate,
       building_code: apartmentProperty.buildingCode,


### PR DESCRIPTION
Note: this should be released together with odoo

odoo.create throws error because wash_space no longer exists in the model in current odoo code (develop)
