### PR TITLE
Fix:UTH-264 Poor Error Handling When Creating Lease

### DIFF
--- a/core/src/adapters/leasing-adapter/index.ts
+++ b/core/src/adapters/leasing-adapter/index.ts
@@ -215,11 +215,15 @@ const createLease = async (
     result.data.error === 'Lease cannot be created on this rental object'
   ) {
     logger.error(
-      `Lease could not be created for rental object ${objectId}, contact ${contactId}, fromDate: ${fromDate}`
+      { objectId, contactId, fromDate },
+      'Lease could not be created for rental object'
     )
     return { ok: false, err: 'create-lease-failed' }
   } else {
-    logger.error('Unknwn error when creating lease: ' + result.data.error)
+    logger.error(
+      { error: result.data.error },
+      'Unknown error when creating lease'
+    )
     return { ok: false, err: 'unknown' }
   }
 }

--- a/core/src/processes/parkingspaces/external/index.ts
+++ b/core/src/processes/parkingspaces/external/index.ts
@@ -134,14 +134,14 @@ export const createLeaseForExternalParkingSpace = async (
 
     if (creditCheck) {
       // Step 4A. Create lease
-      const lease = await createLease(
+      const leaseId = await createLease(
         parkingSpace.parkingSpaceId,
         applicantContact.contactCode,
         startDate != undefined ? startDate : new Date().toISOString(),
         '001'
       )
 
-      log.push(`Kontrakt skapat: ${lease.LeaseId}`)
+      log.push(`Kontrakt skapat: ${leaseId}`)
 
       log.push(
         'Kontrollera om moms ska läggas på kontraktet. Detta måste göras manuellt innan det skickas för påskrift.'
@@ -150,7 +150,7 @@ export const createLeaseForExternalParkingSpace = async (
       await sendNotificationToContact(
         applicantContact,
         'Godkänd ansökan om bilplats',
-        `Din ansökan om bilplats har godkänts!\n\nDet här händer nu:\n\n * Kontraktet: Du kommer snart få ett digitalt kontrakt att skriva under. En av våra medarbetare kommer att göra i ordning kontraktet och skicka det till dig för digital signering. Kontraktet skickas vanligtvis kommande arbetsdag men under semesterperioden kan det dröja lite längre, håll utkik i din inkorg. Kontraktsnumret är: ${lease.LeaseId}.\n\n * Faktura: Din första faktura finns på Mina sidor. Logga in och klicka på Mina fakturor för att se förfallodatum och betalningsuppgifter.\n\n * Eventuella nycklar: Om det behövs nycklar till bilplatsen så hämtar du dom på Mimers kundcenter, Gasverksgatan 7, efter kl. 12.00 den dag kontraktet börjar gälla. Om det är en helgdag, kan du hämta dem kommande vardag efter kl. 12.00.\n\nHälsningar\n\nBostads AB Mimer\n`
+        `Din ansökan om bilplats har godkänts!\n\nDet här händer nu:\n\n * Kontraktet: Du kommer snart få ett digitalt kontrakt att skriva under. En av våra medarbetare kommer att göra i ordning kontraktet och skicka det till dig för digital signering. Kontraktet skickas vanligtvis kommande arbetsdag men under semesterperioden kan det dröja lite längre, håll utkik i din inkorg. Kontraktsnumret är: ${leaseId}.\n\n * Faktura: Din första faktura finns på Mina sidor. Logga in och klicka på Mina fakturor för att se förfallodatum och betalningsuppgifter.\n\n * Eventuella nycklar: Om det behövs nycklar till bilplatsen så hämtar du dom på Mimers kundcenter, Gasverksgatan 7, efter kl. 12.00 den dag kontraktet börjar gälla. Om det är en helgdag, kan du hämta dem kommande vardag efter kl. 12.00.\n\nHälsningar\n\nBostads AB Mimer\n`
       )
       await sendNotificationToRole(
         'leasing',
@@ -160,9 +160,9 @@ export const createLeaseForExternalParkingSpace = async (
 
       return {
         processStatus: ProcessStatus.successful,
-        data: { lease },
+        data: { LeaseId: leaseId },
         response: {
-          lease,
+          leaseId,
           message: 'Parking space lease created.',
         },
         httpStatus: 200,

--- a/core/src/processes/parkingspaces/external/tests/index.test.ts
+++ b/core/src/processes/parkingspaces/external/tests/index.test.ts
@@ -13,7 +13,6 @@ import {
   mockedParkingSpace,
   successfulConsumerReport,
   failedConsumerReport,
-  mockedLease,
   mockedApplicantWithoutLeases,
   mockedApplicantWithLeases,
   mockedApplicantWithoutAddress,
@@ -84,7 +83,7 @@ describe('parkingspaces', () => {
         .mockResolvedValue({})
       createContractSpy = jest
         .spyOn(leasingAdapter, 'createLease')
-        .mockResolvedValue(mockedLease)
+        .mockResolvedValue({ ok: true, data: '123-123-123/1' })
     })
 
     it('gets the parking space', async () => {

--- a/core/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
+++ b/core/src/processes/parkingspaces/internal/tests/reply-to-offer.test.ts
@@ -92,7 +92,10 @@ describe('replyToOffer', () => {
       })
 
       closeOfferSpy.mockResolvedValueOnce({ ok: true, data: null })
-      createLeaseSpy.mockResolvedValueOnce(factory.lease.build())
+      createLeaseSpy.mockResolvedValueOnce({
+        ok: true,
+        data: '123-123-123-123/1',
+      })
       getOffersForContactSpy.mockResolvedValueOnce({
         ok: true,
         data: factory.offerWithRentalObjectCode.buildList(2, {
@@ -184,7 +187,10 @@ describe('replyToOffer', () => {
       denyOfferSpy.mockResolvedValue({
         processStatus: ProcessStatus.successful,
       } as ProcessResult)
-      createLeaseSpy.mockResolvedValueOnce(factory.lease.build())
+      createLeaseSpy.mockResolvedValueOnce({
+        ok: true,
+        data: '123-123-123-123/1',
+      })
       getOffersForContactSpy.mockResolvedValueOnce({
         ok: true,
         data: factory.offerWithRentalObjectCode.buildList(2, {
@@ -235,7 +241,10 @@ describe('replyToOffer', () => {
       })
 
       closeOfferSpy.mockResolvedValueOnce({ ok: true, data: null })
-      createLeaseSpy.mockResolvedValueOnce(factory.lease.build())
+      createLeaseSpy.mockResolvedValueOnce({
+        ok: true,
+        data: '123-123-123-123/1',
+      })
 
       jest.spyOn(leasingAdapter, 'getOffersForContact').mockResolvedValueOnce({
         ok: true,
@@ -288,7 +297,10 @@ describe('replyToOffer', () => {
       })
 
       closeOfferSpy.mockResolvedValueOnce({ ok: true, data: null })
-      createLeaseSpy.mockResolvedValueOnce(factory.lease.build())
+      createLeaseSpy.mockResolvedValueOnce({
+        ok: true,
+        data: '123-123-123-123/1',
+      })
 
       jest.spyOn(leasingAdapter, 'getOffersForContact').mockResolvedValueOnce({
         ok: true,

--- a/services/leasing/package.json
+++ b/services/leasing/package.json
@@ -24,8 +24,8 @@
     "prettier": "prettier --check ./src",
     "script:expire-listings": "node scripts/expire-listings.js",
     "start": "npm run migrate:up && node -r dotenv/config index",
-    "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config node_modules/jest/bin/jest --config jest.config.js",
-    "test:ci": "DOTENV_CONFIG_PATH=.env.ci node -r dotenv/config node_modules/jest/bin/jest --config jest.config.js",
+    "test": "DOTENV_CONFIG_PATH=.env.test node -r dotenv/config ../../node_modules/.bin/jest --config jest.config.js",
+    "test:ci": "DOTENV_CONFIG_PATH=.env.ci node -r dotenv/config ../../node_modules/.bin/jest --config jest.config.js",
     "test:watch": "DOTENV_CONFIG_PATH=.env.test jest --watch",
     "ts:watch": "tsc --watch --noEmit",
     "typecheck": "tsc --noEmit"

--- a/services/leasing/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -72,12 +72,14 @@ const createLease = async (
       return { data: parsedResponse.ObjectDescription, ok: true }
     } else if (parsedResponse.Message == 'Hyresobjekt saknas.') {
       logger.info(
-        `XPand could not create lease for rental object ${rentalPropertyId}, contact ${tenantCode}, fromDate: ${fromDate.toString()}. XPand error: ${parsedResponse.Message}`
+        { objectId: rentalPropertyId, contactId: tenantCode, fromDate },
+        'XPand could not create lease for rental object'
       )
       return { ok: false, err: 'create-lease-not-allowed' }
     } else {
       logger.error(
-        `Create lease response from XPand cannot be interpreted: ${parsedResponse.Message}`
+        { message: parsedResponse.Message },
+        'Create lease response from XPand cannot be interpreted'
       )
       return { ok: false, err: 'unknown' }
     }

--- a/services/leasing/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/xpand-soap-adapter.ts
@@ -12,7 +12,7 @@ const createLease = async (
   rentalPropertyId: string,
   tenantCode: string,
   companyCode: string
-) => {
+): Promise<AdapterResult<string, 'create-lease-not-allowed' | 'unknown'>> => {
   const headers = getHeaders()
 
   const xml = `<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:ser="http://incit.xpand.eu/service/" xmlns:inc="http://incit.xpand.eu/" xmlns:data="http://incit.xpand.eu/data/">
@@ -69,19 +69,24 @@ const createLease = async (
       parser.parse(body)['s:Envelope']['s:Body'].CreateNewEntityResult
 
     if (parsedResponse.Success === true) {
-      return parsedResponse.ObjectDescription
+      return { data: parsedResponse.ObjectDescription, ok: true }
     } else if (parsedResponse.Message == 'Hyresobjekt saknas.') {
-      throw createHttpError(
-        404,
-        'Parking space not found when creating lease',
-        rentalPropertyId
+      logger.info(
+        `XPand could not create lease for rental object ${rentalPropertyId}, contact ${tenantCode}, fromDate: ${fromDate.toString()}. XPand error: ${parsedResponse.Message}`
       )
+      return { ok: false, err: 'create-lease-not-allowed' }
+    } else {
+      logger.error(
+        `Create lease response from XPand cannot be interpreted: ${parsedResponse.Message}`
+      )
+      return { ok: false, err: 'unknown' }
     }
-    throw createHttpError(500, parsedResponse.Message)
     //TODO: handle more errors...
   } catch (error: unknown) {
-    logger.error(error, 'Error creating lease Xpand SOAP API')
-    throw error
+    let errorMsg = 'Error creating lease Xpand SOAP API: '
+    if (error instanceof Error) errorMsg += error.message
+    logger.error(error, errorMsg)
+    return { ok: false, err: 'unknown' }
   }
 }
 

--- a/services/leasing/src/services/lease-service/routes/leases.ts
+++ b/services/leasing/src/services/lease-service/routes/leases.ts
@@ -381,15 +381,29 @@ export const routes = (router: KoaRouter) => {
     try {
       const request = <CreateLeaseRequest>ctx.request.body
 
-      const newLeaseId = await createLease(
+      const createLeaseResult = await createLease(
         new Date(request.fromDate),
         request.parkingSpaceId,
         request.contactCode,
         request.companyCode
       )
-      ctx.body = {
-        content: { LeaseId: newLeaseId },
-        ...metadata,
+      if (createLeaseResult.ok) {
+        ctx.body = {
+          content: { LeaseId: createLeaseResult.data },
+          ...metadata,
+        }
+      } else if (createLeaseResult.err === 'create-lease-not-allowed') {
+        ctx.status = 404
+        ctx.body = {
+          error: 'Lease cannot be created on this rental object',
+          ...metadata,
+        }
+      } else {
+        ctx.status = 500
+        ctx.body = {
+          error: 'Unknown error when creating lease',
+          ...metadata,
+        }
       }
     } catch (error: unknown) {
       ctx.status = 500


### PR DESCRIPTION
The error handling when creating lease was not sufficent on either the XPand or the OneCore end. At lease we can fix the onecore end. Create lease error where only written to the pod log in kubernetes and not to the onecore logger.

* Better error handling in leasing xpand-adapter and route as well as in cores leasing adapter