### PR TITLE
Fix: UTH-236 XPand-DB Parking Space Query Gets the Wrong VacantFrom Date

### DIFF
--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -313,9 +313,12 @@ const getAllVacantParkingSpaces = async (): Promise<
         )
       })
       //exclude parking spaces with active contracts
-      .whereNull('ac.keycmobj')
-      .orWhere('ac.lastdebitdate', '>', xpandDb.fn.now())
+      .where(function () {
+        this.whereNull('ac.keycmobj').orWhereNotNull('ac.lastdebitdate')
+      })
       .orderBy('ps.rentalObjectCode', 'asc')
+
+    console.log('antal lediga platser: ', results.length)
 
     const listings: RentalObject[] = results.map((row) =>
       trimRow(transformFromXpandRentalObject(row))

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -79,6 +79,18 @@ function transformFromXpandRentalObject(row: any): RentalObject {
     monthlyRent = totalYearRent / 12
   }
 
+  // Determine vacantFrom date
+  const lastDebitDate = row.lastdebitdate
+  let vacantFrom
+  if (lastDebitDate) {
+    vacantFrom = new Date(lastDebitDate)
+    vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
+  } else {
+    //when last debit date is missing, the parking space is vacant as of today
+    vacantFrom = new Date()
+  }
+  vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
+
   return {
     rentalObjectCode: row.rentalObjectCode,
     address: row.postaladdress,
@@ -89,20 +101,20 @@ function transformFromXpandRentalObject(row: any): RentalObject {
     residentialAreaCaption: row.residentialareacaption,
     objectTypeCaption: row.vehiclespacetypecaption,
     objectTypeCode: row.vehiclespacetypecode,
-    vacantFrom: row.lastdebitdate || new Date(),
+    vacantFrom: vacantFrom,
     districtCaption: district,
     districtCode: districtCode,
     braArea: row.braarea,
   }
 }
 
-const buildMainQuery = (
-  parkingSpacesQuery: any,
-  activeRentalBlocksQuery?: any,
+const buildMainQuery = (queries: {
+  parkingSpacesQuery: any
+  activeRentalBlocksQuery?: any
   activeContractsQuery?: any
-) => {
+}) => {
   let query = xpandDb
-    .from(parkingSpacesQuery.as('ps'))
+    .from(queries.parkingSpacesQuery.as('ps'))
     .select(
       'ps.rentalObjectCode',
       'ps.estatecode',
@@ -118,7 +130,7 @@ const buildMainQuery = (
       'ps.residentialareacaption'
     )
 
-  if (activeRentalBlocksQuery && activeContractsQuery) {
+  if (queries.activeRentalBlocksQuery && queries.activeContractsQuery) {
     query = query
       .select(
         xpandDb.raw(`
@@ -138,8 +150,16 @@ const buildMainQuery = (
         'rent.yearrentrows',
         'cmvalbar.value as braarea'
       )
-      .leftJoin(activeRentalBlocksQuery.as('rb'), 'rb.keycmobj', 'ps.keycmobj')
-      .leftJoin(activeContractsQuery.as('ac'), 'ac.keycmobj', 'ps.keycmobj')
+      .leftJoin(
+        queries.activeRentalBlocksQuery.as('rb'),
+        'rb.keycmobj',
+        'ps.keycmobj'
+      )
+      .leftJoin(
+        queries.activeContractsQuery.as('ac'),
+        'ac.keycmobj',
+        'ps.keycmobj'
+      )
   }
 
   return query
@@ -225,6 +245,7 @@ const buildSubQueries = () => {
       )
     })
 
+  //query that gets active contracts
   const activeContractsQuery = xpandDb
     .from('hyobj')
     .select(
@@ -246,9 +267,26 @@ const buildSubQueries = () => {
     .whereIn('hyobj.keyhyobt', ['3', '5', '_1WP0JXVK8', '_1WP0KDMOO'])
     .whereNull('hyobj.makuldatum')
     .andWhere('hyobj.deletemark', '=', 0)
-    .whereNull('hyobj.sistadeb')
+    //pick the last debit date from the active contracts
+    .whereRaw(
+      `hyobj.sistadeb = (
+    SELECT MAX(h2.sistadeb)
+    FROM hyobj h2
+    INNER JOIN hykop h2kop ON h2kop.keyhyobj = h2.keyhyobj AND h2kop.ordning = ?
+    INNER JOIN hyinf h2inf ON h2inf.keycmobj = h2kop.keycmobj
+    WHERE h2inf.keycmobj = hyinf.keycmobj
+      AND h2.keyhyobt IN (?, ?, ?, ?)
+      AND h2.makuldatum IS NULL
+      AND h2.deletemark = 0
+  )`,
+      [1, '3', '5', '_1WP0JXVK8', '_1WP0KDMOO']
+    )
 
-  return { parkingSpacesQuery, activeRentalBlocksQuery, activeContractsQuery }
+  return {
+    parkingSpacesQuery,
+    activeRentalBlocksQuery,
+    activeContractsQuery,
+  }
 }
 
 const getAllVacantParkingSpaces = async (): Promise<
@@ -261,11 +299,11 @@ const getAllVacantParkingSpaces = async (): Promise<
       activeContractsQuery,
     } = buildSubQueries()
 
-    const results = await buildMainQuery(
+    const results = await buildMainQuery({
       parkingSpacesQuery,
       activeRentalBlocksQuery,
-      activeContractsQuery
-    )
+      activeContractsQuery,
+    })
       .where(function () {
         this.whereNull('rb.keycmobj').orWhere(
           'rb.blockenddate',
@@ -273,8 +311,12 @@ const getAllVacantParkingSpaces = async (): Promise<
           xpandDb.fn.now()
         )
       })
+      //exclude parking spaces with active contracts
       .whereNull('ac.keycmobj')
       .orderBy('ps.rentalObjectCode', 'asc')
+
+    console.log(results.slice(0, 50))
+    console.log('antal: ', results.length)
 
     const listings: RentalObject[] = results.map((row) =>
       trimRow(transformFromXpandRentalObject(row))
@@ -298,11 +340,11 @@ const getParkingSpace = async (
       activeContractsQuery,
     } = buildSubQueries()
 
-    const result = await buildMainQuery(
+    const result = await buildMainQuery({
       parkingSpacesQuery,
+      activeContractsQuery,
       activeRentalBlocksQuery,
-      activeContractsQuery
-    )
+    })
       .where('ps.rentalObjectCode', '=', rentalObjectCode)
       .first()
 
@@ -333,11 +375,11 @@ const getParkingSpaces = async (
       activeContractsQuery,
     } = buildSubQueries()
 
-    let query = buildMainQuery(
+    let query = buildMainQuery({
       parkingSpacesQuery,
       activeRentalBlocksQuery,
-      activeContractsQuery
-    )
+      activeContractsQuery,
+    })
     if (includeRentalObjectCodes && includeRentalObjectCodes.length) {
       query = query.whereIn('ps.rentalObjectCode', includeRentalObjectCodes)
     }

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -317,9 +317,6 @@ const getAllVacantParkingSpaces = async (): Promise<
       .orWhere('ac.lastdebitdate', '>', xpandDb.fn.now())
       .orderBy('ps.rentalObjectCode', 'asc')
 
-    console.log(results.slice(0, 50))
-    console.log('antal: ', results.length)
-
     const listings: RentalObject[] = results.map((row) =>
       trimRow(transformFromXpandRentalObject(row))
     )

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -267,6 +267,7 @@ const buildSubQueries = () => {
     .whereIn('hyobj.keyhyobt', ['3', '5', '_1WP0JXVK8', '_1WP0KDMOO'])
     .whereNull('hyobj.makuldatum')
     .andWhere('hyobj.deletemark', '=', 0)
+
     //pick the last debit date from the active contracts
     .whereRaw(
       `hyobj.sistadeb = (
@@ -313,6 +314,7 @@ const getAllVacantParkingSpaces = async (): Promise<
       })
       //exclude parking spaces with active contracts
       .whereNull('ac.keycmobj')
+      .orWhere('ac.lastdebitdate', '>', xpandDb.fn.now())
       .orderBy('ps.rentalObjectCode', 'asc')
 
     console.log(results.slice(0, 50))

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -318,8 +318,6 @@ const getAllVacantParkingSpaces = async (): Promise<
       })
       .orderBy('ps.rentalObjectCode', 'asc')
 
-    console.log('antal lediga platser: ', results.length)
-
     const listings: RentalObject[] = results.map((row) =>
       trimRow(transformFromXpandRentalObject(row))
     )

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -264,10 +264,10 @@ const buildSubQueries = () => {
       )
     })
     .innerJoin('hyinf', 'hyinf.keycmobj', 'hykop.keycmobj')
+    //contract types to include
     .whereIn('hyobj.keyhyobt', ['3', '5', '_1WP0JXVK8', '_1WP0KDMOO'])
     .whereNull('hyobj.makuldatum')
     .andWhere('hyobj.deletemark', '=', 0)
-
     //pick the last debit date from the active contracts
     .whereRaw(
       `hyobj.sistadeb = (


### PR DESCRIPTION
Parking spaces doesn't get the correct VacantFrom date from the xpand-db query to get parking spaces

Fix:
* A sub query to pick the latest sistadeb date of the contracts of a parking space
* Logic to add take sistadb and add a day to set VacantFrom date

<img width="1328" height="675" alt="Skärmavbild 2025-08-26 kl  14 16 10" src="https://github.com/user-attachments/assets/1f12d1e6-d0c7-402c-bf6b-6fcbf5e544d6" />