### PR TITLE
Fix: No Priority For Applicants

### DIFF
--- a/services/leasing/src/services/lease-service/priority-list-service.ts
+++ b/services/leasing/src/services/lease-service/priority-list-service.ts
@@ -60,10 +60,12 @@ const assignPriorityToApplicantBasedOnRentalRules = (
   }
 
   if (
-    listing.rentalObject.districtCode &&
-    isListingInAreaWithSpecificRentalRules(listing.rentalObject.districtCode) &&
+    listing.rentalObject.residentialAreaCode &&
+    isListingInAreaWithSpecificRentalRules(
+      listing.rentalObject.residentialAreaCode
+    ) &&
     !isHousingContractsOfApplicantInSameAreaAsListing(
-      listing.rentalObject.districtCode,
+      listing.rentalObject.residentialAreaCode,
       applicant
     )
   ) {
@@ -90,7 +92,7 @@ const assignPriorityToApplicantBasedOnRentalRules = (
     if (applicant.currentHousingContract) {
       if (
         applicant.currentHousingContract?.residentialArea?.code ===
-        listing.rentalObject.districtCode
+        listing.rentalObject.residentialAreaCode
       ) {
         logger.info(
           applicant.name +
@@ -108,7 +110,7 @@ const assignPriorityToApplicantBasedOnRentalRules = (
     if (applicant.upcomingHousingContract) {
       if (
         applicant.upcomingHousingContract?.residentialArea?.code ===
-        listing.rentalObject.districtCode
+        listing.rentalObject.residentialAreaCode
       ) {
         logger.info(
           applicant.name +

--- a/services/leasing/src/services/lease-service/routes/listings.ts
+++ b/services/leasing/src/services/lease-service/routes/listings.ts
@@ -702,7 +702,6 @@ export const routes = (router: KoaRouter) => {
         }
       }
 
-
       const rentalObjectResult = await rentalObjectAdapter.getParkingSpace(
         listingWithoutRentalObject.rentalObjectCode
       )

--- a/services/leasing/src/services/lease-service/routes/listings.ts
+++ b/services/leasing/src/services/lease-service/routes/listings.ts
@@ -702,7 +702,6 @@ export const routes = (router: KoaRouter) => {
         }
       }
 
-      //TODO: get rental object from new xpand-adapter that gets rental objects from db
 
       const rentalObjectResult = await rentalObjectAdapter.getParkingSpace(
         listingWithoutRentalObject.rentalObjectCode

--- a/services/leasing/src/services/lease-service/tests/priority-list-service.test.ts
+++ b/services/leasing/src/services/lease-service/tests/priority-list-service.test.ts
@@ -290,7 +290,7 @@ describe('assignPriorityToApplicantBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -324,7 +324,7 @@ describe('assignPriorityToApplicantBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -392,7 +392,7 @@ describe('assignPriorityToApplicantBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -431,7 +431,7 @@ describe('assignPriorityToApplicantBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -546,7 +546,7 @@ describe('assignPriorityToApplicantBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'CEN',
+            residentialAreaCode: 'CEN',
           })
           .build(),
       })
@@ -581,7 +581,7 @@ describe('sortApplicantsBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -752,7 +752,7 @@ describe('sortApplicantsBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -827,7 +827,7 @@ describe('sortApplicantsBasedOnRentalRules', () => {
       .params({
         rentalObject: factory.rentalObject
           .params({
-            districtCode: 'XYZ',
+            residentialAreaCode: 'XYZ',
           })
           .build(),
       })
@@ -896,8 +896,7 @@ describe('sortApplicantsBasedOnRentalRules', () => {
       publishedTo: new Date('2024-10-19T22:59:59.000Z'),
       status: 4,
       rentalObject: factory.rentalObject.build({
-        districtCaption: 'Vallby',
-        districtCode: 'VAL',
+        residentialAreaCode: 'VAL',
         objectTypeCaption: 'Parkeringsplats med el',
         objectTypeCode: 'PPLMEL',
         vacantFrom: new Date('2022-04-30T22:00:00.000Z'),

--- a/services/leasing/src/services/lease-service/tests/routes/listings.test.ts
+++ b/services/leasing/src/services/lease-service/tests/routes/listings.test.ts
@@ -4,6 +4,7 @@ import KoaRouter from '@koa/router'
 import bodyParser from 'koa-bodyparser'
 
 import * as listingAdapter from '../../adapters/listing-adapter'
+import * as rentalObjectAdapter from '../../adapters/xpand/rental-object-adapter'
 import * as factory from './../factories'
 import * as getTenantService from '../../get-tenant'
 
@@ -64,11 +65,19 @@ describe('GET /listing/:listingId/applicants/details', () => {
       .spyOn(getTenantService, 'getTenant')
       .mockResolvedValue({ ok: true, data: factory.tenant.build() })
 
+    const getRentalObjectSpy = jest
+      .spyOn(rentalObjectAdapter, 'getParkingSpace')
+      .mockResolvedValue({
+        ok: true,
+        data: factory.rentalObject.build(),
+      })
+
     const res = await request(app.callback()).get(
       '/listing/1337/applicants/details'
     )
     expect(getListingSpy).toHaveBeenCalled()
     expect(getTenantSpy).toHaveBeenCalled()
+    expect(getRentalObjectSpy).toHaveBeenCalled()
     expect(res.status).toBe(200)
     expect(res.body).toBeDefined()
   })


### PR DESCRIPTION
Since replacing the functionaty for getting rental objects from SOAP to Xpand-DB and changing the listing model the residantial area code is no longer in district code.

* The priority service is now using listing.rentalObject.residentialAreaCode