### PR TITLE
Fix: Email Missing in Email Confirmation

### DIFF
--- a/services/leasing/src/services/lease-service/routes/leases.ts
+++ b/services/leasing/src/services/lease-service/routes/leases.ts
@@ -389,7 +389,7 @@ export const routes = (router: KoaRouter) => {
       )
       if (createLeaseResult.ok) {
         ctx.body = {
-          content: { LeaseId: createLeaseResult.data },
+          content: createLeaseResult.data,
           ...metadata,
         }
       } else if (createLeaseResult.err === 'create-lease-not-allowed') {

--- a/services/leasing/src/services/lease-service/tests/index.test.ts
+++ b/services/leasing/src/services/lease-service/tests/index.test.ts
@@ -269,7 +269,7 @@ describe('lease-service', () => {
       const result = await request(app.callback()).post('/leases')
 
       expect(xpandAdapterSpy).toHaveBeenCalled()
-      expect(result.body.content).toEqual({ LeaseId: '123-123-123/1' })
+      expect(result.body.content).toEqual('123-123-123/1')
     })
 
     it('handles lease-not-found errors', async () => {


### PR DESCRIPTION
Create Lease returns an adapter result that is the leaseId only. Code has been changed accordingly