### PR TITLE
Fix:DEV-33 Blocked Parking Spaces Gets the Wrong Vacant From Date

### DIFF
--- a/apps/internal-portal/frontend/src/common/formattingUtils.ts
+++ b/apps/internal-portal/frontend/src/common/formattingUtils.ts
@@ -2,7 +2,8 @@ export const printVacantFrom = (
   dateFormatter: Intl.DateTimeFormat,
   vacantFrom: string | Date
 ) => {
-  if (new Date(vacantFrom) > new Date())
+  if (!vacantFrom) return '(Saknas - spärr)'
+  else if (new Date(vacantFrom) > new Date())
     return dateFormatter.format(new Date(vacantFrom))
   else return 'Omgående'
 }

--- a/apps/internal-portal/frontend/src/common/formattingUtils.ts
+++ b/apps/internal-portal/frontend/src/common/formattingUtils.ts
@@ -1,6 +1,6 @@
 export const printVacantFrom = (
   dateFormatter: Intl.DateTimeFormat,
-  vacantFrom: string | Date
+  vacantFrom?: string | Date
 ) => {
   if (!vacantFrom) return '(Saknas - spärr)'
   else if (new Date(vacantFrom) > new Date())

--- a/core/src/processes/parkingspaces/internal/create-offer.ts
+++ b/core/src/processes/parkingspaces/internal/create-offer.ts
@@ -25,6 +25,7 @@ import config from '../../../common/config'
 type CreateOfferError =
   | CreateOfferErrorCodes.NoListing
   | CreateOfferErrorCodes.ListingNotExpired
+  | CreateOfferErrorCodes.RentalObjectNotVacant
   | CreateOfferErrorCodes.NoApplicants
   | CreateOfferErrorCodes.CreateOfferFailure
   | CreateOfferErrorCodes.UpdateApplicantStatusFailure
@@ -84,7 +85,7 @@ export const createOfferForInternalParkingSpace = async (
     if (!listing.rentalObject.vacantFrom) {
       return endFailingProcess(
         log,
-        CreateOfferErrorCodes.NoApplicants,
+        CreateOfferErrorCodes.RentalObjectNotVacant,
         500,
         `Listing with id ${listingId} has no vacantFrom date`
       )

--- a/core/src/processes/parkingspaces/internal/create-offer.ts
+++ b/core/src/processes/parkingspaces/internal/create-offer.ts
@@ -81,6 +81,15 @@ export const createOfferForInternalParkingSpace = async (
       )
     }
 
+    if (!listing.rentalObject.vacantFrom) {
+      return endFailingProcess(
+        log,
+        CreateOfferErrorCodes.NoApplicants,
+        500,
+        `Listing with id ${listingId} has no vacantFrom date`
+      )
+    }
+
     const allApplicants =
       await leasingAdapter.getDetailedApplicantsByListingId(listingId)
 

--- a/libs/types/src/error-types/create-offer-error-codes.ts
+++ b/libs/types/src/error-types/create-offer-error-codes.ts
@@ -1,6 +1,7 @@
 enum CreateOfferErrorCodes {
   NoListing = 'no-listing',
   ListingNotExpired = 'listing-not-expired',
+  RentalObjectNotVacant = 'rental-object-not-vacant',
   NoApplicants = 'no-applicants',
   UpdateListingStatusFailure = 'update-listing-status-failure',
   NoContact = 'no-contact',

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -349,7 +349,7 @@ interface RentalObject {
   residentialAreaCode: string
   objectTypeCaption: string
   objectTypeCode: string
-  vacantFrom: Date
+  vacantFrom?: Date
   braArea?: number
   btaArea?: number
   boaArea?: number

--- a/services/leasing/src/common/test/matchers.ts
+++ b/services/leasing/src/common/test/matchers.ts
@@ -18,6 +18,16 @@ expect.extend({
         `expected ${actual} and ${expected} to be less than 100ms apart`,
     }
   },
+  toBeStartOfDayUTC(actual: Date) {
+    const pass =
+      actual.getUTCHours() === 0 &&
+      actual.getUTCMinutes() === 0 &&
+      actual.getUTCSeconds() === 0
+    return {
+      pass,
+      message: () => `expected ${actual} to be start of day UTC`,
+    }
+  },
 })
 
 declare global {
@@ -26,6 +36,7 @@ declare global {
     interface Matchers<R> {
       toBeSameDayAs(expected: Date): R
       toBeNearDate(expected: Date): R
+      toBeStartOfDayUTC(): R
     }
   }
 }

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -345,7 +345,7 @@ const buildSubQueries = () => {
       [1, '3', '5', '_1WP0JXVK8', '_1WP0KDMOO']
     )
 
-  //query that gets contracts with the last block date. If there is a block without blockenddate, it will return NULL for blockenddate
+  //query that gets the block with the last block date. If there is a block without blockenddate, it will return NULL for blockenddate
   const rentalBlockDatesQuery = xpandDb.raw(`
     (
       SELECT sub.keycmobj, sub.fdate AS blockstartdate, sub.tdate AS blockenddate

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -434,7 +434,8 @@ const getParkingSpace = async (
 
     if (!result) {
       logger.error(
-        `Parking space not found by Rental Object Code: ${rentalObjectCode}`
+        { rentalObjectCode },
+        'Parking space not found by Rental Object Code'
       )
       return { ok: false, err: 'parking-space-not-found' }
     }
@@ -442,7 +443,10 @@ const getParkingSpace = async (
     const rentalObject = trimRow(transformFromXpandRentalObject(result))
     return { ok: true, data: rentalObject }
   } catch (err) {
-    logger.error(err, 'tenantLeaseAdapter.getRentalObject')
+    logger.error(
+      { err, rentalObjectCode },
+      'Unknown error in rentalObjectAdapter.getRentalObject'
+    )
     return { ok: false, err: 'unknown' }
   }
 }
@@ -472,9 +476,24 @@ const getParkingSpaces = async (
 
     if (!results || results.length === 0) {
       logger.error(
-        `No parking spaces found for rental object codes: ${includeRentalObjectCodes}`
+        { includeRentalObjectCodes: includeRentalObjectCodes },
+        `No parking spaces found for rental object codes`
       )
       return { ok: false, err: 'parking-spaces-not-found' }
+    }
+
+    if (
+      includeRentalObjectCodes &&
+      results.length < includeRentalObjectCodes.length
+    ) {
+      logger.error(
+        {
+          includeRentalObjectCodes: includeRentalObjectCodes.filter(
+            (code) => !results.some((row) => row.rentalObjectCode === code)
+          ),
+        },
+        `Some rental object codes could not be found (the rest will be returned)`
+      )
     }
 
     const rentalObjects = results.map((row) =>
@@ -482,7 +501,10 @@ const getParkingSpaces = async (
     )
     return { ok: true, data: rentalObjects }
   } catch (err) {
-    logger.error(err, 'tenantLeaseAdapter.getRentalObjects')
+    logger.error(
+      { err, includeRentalObjectCodes },
+      'Unknown error in rentalObjectAdapter.getRentalObjects'
+    )
     return { ok: false, err: 'unknown' }
   }
 }

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -90,7 +90,7 @@ function transformFromXpandRentalObject(row: any): RentalObject {
     vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
   } else if (lastBlockStartDate && !lastBlockEndDate) {
-    //TODO: if there is a block but no end date, vacantFrom should be undefined
+    //if there is a block but no end date, vacantFrom should be undefined
     vacantFrom = undefined
   } else if (lastDebitDate) {
     //if there is no block but a last debit date, vacantFrom should be the day after

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -85,19 +85,20 @@ function transformFromXpandRentalObject(row: any): RentalObject {
   const lastBlockEndDate = row.blockenddate
   let vacantFrom
   if (lastBlockEndDate && lastBlockEndDate >= new Date()) {
-    //if there is a block end date, vacantFrom should be the day after
+    //if the object is blocked to a date in the future, vacantFrom should be the day after
     vacantFrom = new Date(lastBlockEndDate)
     vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
   } else if (lastBlockStartDate && !lastBlockEndDate) {
-    //TODO: if lastBlockStartDate is present and lastBlockEndDate is missing then vacantFrom should be undefined
+    //TODO: if there is a block but no end date, vacantFrom should be undefined
     vacantFrom = undefined
   } else if (lastDebitDate) {
+    //if there is no block but a last debit date, vacantFrom should be the day after
     vacantFrom = new Date(lastDebitDate)
     vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
   } else {
-    //when last debit date is missing and there is no block, the parking space is vacant as of today
+    //there is no block and no last debit date, the parking space is vacant as of today
     vacantFrom = new Date()
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
   }
@@ -255,7 +256,7 @@ const buildSubQueries = () => {
     })
     .leftJoin('bafst', 'bafst.keycmobj', 'babuf.keyobjfst')
     .leftJoin('babya', 'bafst.keybabya', 'babya.keybabya')
-    .where('babuf.cmpcode', '=', '001')
+    .where('babuf.cmpcode', '=', '001') //only gets parking spaces with company code 001
 
   const activeRentalBlocksQuery = xpandDb
     .from('hyspt')

--- a/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/rental-object-adapter.ts
@@ -89,6 +89,9 @@ function transformFromXpandRentalObject(row: any): RentalObject {
     vacantFrom = new Date(lastBlockEndDate)
     vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
+  } else if (lastBlockStartDate && !lastBlockEndDate) {
+    //TODO: if lastBlockStartDate is present and lastBlockEndDate is missing then vacantFrom should be undefined
+    vacantFrom = undefined
   } else if (lastDebitDate) {
     vacantFrom = new Date(lastDebitDate)
     vacantFrom.setUTCDate(vacantFrom.getUTCDate() + 1)
@@ -98,11 +101,6 @@ function transformFromXpandRentalObject(row: any): RentalObject {
     vacantFrom = new Date()
     vacantFrom.setUTCHours(0, 0, 0, 0) // Set to start of the day UTC
   }
-
-  //TODO: if lastBlockStartDate is present and lastBlockEndDate is missing then vacantFrom should be undefined
-  // if (lastBlockStartDate && !lastBlockEndDate) {
-  //   vacantFrom = undefined
-  // }
 
   return {
     rentalObjectCode: row.rentalObjectCode,

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
@@ -27,7 +27,7 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    let expectedVacantFrom = addDays(lastDebitDate, 1)
+    const expectedVacantFrom = addDays(lastDebitDate, 1)
     expect(result.vacantFrom).toBeDefined()
     expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })
@@ -43,7 +43,7 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    let expectedVacantFrom = addDays(blockEndDate, 1)
+    const expectedVacantFrom = addDays(blockEndDate, 1)
     expect(result.vacantFrom).toBeDefined()
     expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })
@@ -62,7 +62,7 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    let expectedVacantFrom = addDays(lastDebitDate, 1)
+    const expectedVacantFrom = addDays(lastDebitDate, 1)
     expect(result.vacantFrom).toBeDefined()
     expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
@@ -1,0 +1,104 @@
+import * as rentalObjectAdapter from '../../../adapters/xpand/rental-object-adapter'
+
+describe('transformFromXpandRentalObject', () => {
+  it('should set vacantFrom to today when lastDebitDate and blockEndDate are missing', () => {
+    const row = {
+      lastdebitdate: null,
+      blockenddate: null,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const today = new Date()
+    const vacantFrom = new Date(result.vacantFrom)
+    expect(vacantFrom.getUTCFullYear()).toBe(today.getUTCFullYear())
+    expect(vacantFrom.getUTCMonth()).toBe(today.getUTCMonth())
+    expect(vacantFrom.getUTCDate()).toBe(today.getUTCDate())
+  })
+
+  it('should set vacantFrom to the day after lastDebitDate when lastDebitDate is present and blockEndDate is missing', () => {
+    const lastDebitDate = new Date()
+    lastDebitDate.setUTCMonth(lastDebitDate.getUTCMonth() + 1)
+
+    const row = {
+      lastdebitdate: lastDebitDate,
+      blockenddate: null,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const vacantFrom = new Date(result.vacantFrom)
+    expect(vacantFrom.getUTCFullYear()).toBe(lastDebitDate.getUTCFullYear())
+    expect(vacantFrom.getUTCMonth()).toBe(lastDebitDate.getUTCMonth())
+    expect(vacantFrom.getUTCDate()).toBe(lastDebitDate.getUTCDate() + 1)
+  })
+
+  it('should set vacantFrom to the day after blockEndDate when blockEndDate is in the future', () => {
+    const blockEndDate = new Date()
+    blockEndDate.setUTCMonth(blockEndDate.getUTCMonth() + 1)
+
+    const row = {
+      lastdebitdate: new Date(),
+      blockenddate: blockEndDate,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const vacantFrom = new Date(result.vacantFrom)
+    expect(vacantFrom.getUTCFullYear()).toBe(blockEndDate.getUTCFullYear())
+    expect(vacantFrom.getUTCMonth()).toBe(blockEndDate.getUTCMonth())
+    expect(vacantFrom.getUTCDate()).toBe(blockEndDate.getUTCDate() + 1)
+  })
+
+  it('should set vacantFrom to the day after lastDebitDate when blockEndDate is in the past and lastDebitDate is present', () => {
+    const lastDebitDate = new Date()
+    lastDebitDate.setUTCMonth(lastDebitDate.getUTCMonth() + 1)
+
+    const blockEndDate = new Date()
+    blockEndDate.setUTCMonth(blockEndDate.getUTCMonth() - 1)
+
+    const row = {
+      lastdebitdate: lastDebitDate,
+      blockenddate: blockEndDate,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const vacantFrom = new Date(result.vacantFrom)
+    expect(vacantFrom.getUTCFullYear()).toBe(lastDebitDate.getUTCFullYear())
+    expect(vacantFrom.getUTCMonth()).toBe(lastDebitDate.getUTCMonth())
+    expect(vacantFrom.getUTCDate()).toBe(lastDebitDate.getUTCDate() + 1)
+  })
+
+  it('should set vacantFrom to today when blockEndDate is in the past and lastDebitDate is missing', () => {
+    const blockEndDate = new Date()
+    blockEndDate.setUTCMonth(blockEndDate.getUTCMonth() - 1)
+
+    const row = {
+      lastdebitdate: null,
+      blockenddate: blockEndDate,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const vacantFrom = new Date(result.vacantFrom)
+    const today = new Date()
+    expect(vacantFrom.getUTCFullYear()).toBe(today.getUTCFullYear())
+    expect(vacantFrom.getUTCMonth()).toBe(today.getUTCMonth())
+    expect(vacantFrom.getUTCDate()).toBe(today.getUTCDate())
+  })
+
+  it('should set vacantFrom to start of day UTC', () => {
+    const row = {
+      lastdebitdate: null,
+      blockenddate: null,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    const vacantFrom = new Date(result.vacantFrom)
+    expect(vacantFrom.getUTCHours()).toBe(0)
+    expect(vacantFrom.getUTCMinutes()).toBe(0)
+    expect(vacantFrom.getUTCSeconds()).toBe(0)
+  })
+})

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/rental-object-adapter.test.ts
@@ -1,4 +1,5 @@
 import * as rentalObjectAdapter from '../../../adapters/xpand/rental-object-adapter'
+import { addDays, addMonths } from 'date-fns'
 
 describe('transformFromXpandRentalObject', () => {
   it('should set vacantFrom to today when lastDebitDate and blockEndDate are missing', () => {
@@ -10,10 +11,9 @@ describe('transformFromXpandRentalObject', () => {
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
     const today = new Date()
-    const vacantFrom = new Date(result.vacantFrom)
-    expect(vacantFrom.getUTCFullYear()).toBe(today.getUTCFullYear())
-    expect(vacantFrom.getUTCMonth()).toBe(today.getUTCMonth())
-    expect(vacantFrom.getUTCDate()).toBe(today.getUTCDate())
+
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeSameDayAs(today)
   })
 
   it('should set vacantFrom to the day after lastDebitDate when lastDebitDate is present and blockEndDate is missing', () => {
@@ -27,10 +27,9 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    const vacantFrom = new Date(result.vacantFrom)
-    expect(vacantFrom.getUTCFullYear()).toBe(lastDebitDate.getUTCFullYear())
-    expect(vacantFrom.getUTCMonth()).toBe(lastDebitDate.getUTCMonth())
-    expect(vacantFrom.getUTCDate()).toBe(lastDebitDate.getUTCDate() + 1)
+    let expectedVacantFrom = addDays(lastDebitDate, 1)
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })
 
   it('should set vacantFrom to the day after blockEndDate when blockEndDate is in the future', () => {
@@ -44,10 +43,9 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    const vacantFrom = new Date(result.vacantFrom)
-    expect(vacantFrom.getUTCFullYear()).toBe(blockEndDate.getUTCFullYear())
-    expect(vacantFrom.getUTCMonth()).toBe(blockEndDate.getUTCMonth())
-    expect(vacantFrom.getUTCDate()).toBe(blockEndDate.getUTCDate() + 1)
+    let expectedVacantFrom = addDays(blockEndDate, 1)
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })
 
   it('should set vacantFrom to the day after lastDebitDate when blockEndDate is in the past and lastDebitDate is present', () => {
@@ -64,10 +62,9 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    const vacantFrom = new Date(result.vacantFrom)
-    expect(vacantFrom.getUTCFullYear()).toBe(lastDebitDate.getUTCFullYear())
-    expect(vacantFrom.getUTCMonth()).toBe(lastDebitDate.getUTCMonth())
-    expect(vacantFrom.getUTCDate()).toBe(lastDebitDate.getUTCDate() + 1)
+    let expectedVacantFrom = addDays(lastDebitDate, 1)
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeSameDayAs(expectedVacantFrom)
   })
 
   it('should set vacantFrom to today when blockEndDate is in the past and lastDebitDate is missing', () => {
@@ -81,11 +78,9 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    const vacantFrom = new Date(result.vacantFrom)
     const today = new Date()
-    expect(vacantFrom.getUTCFullYear()).toBe(today.getUTCFullYear())
-    expect(vacantFrom.getUTCMonth()).toBe(today.getUTCMonth())
-    expect(vacantFrom.getUTCDate()).toBe(today.getUTCDate())
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeSameDayAs(today)
   })
 
   it('should set vacantFrom to start of day UTC', () => {
@@ -96,9 +91,19 @@ describe('transformFromXpandRentalObject', () => {
 
     const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
 
-    const vacantFrom = new Date(result.vacantFrom)
-    expect(vacantFrom.getUTCHours()).toBe(0)
-    expect(vacantFrom.getUTCMinutes()).toBe(0)
-    expect(vacantFrom.getUTCSeconds()).toBe(0)
+    expect(result.vacantFrom).toBeDefined()
+    expect(result.vacantFrom).toBeStartOfDayUTC()
+  })
+
+  it('should set vacantFrom to undefined when there is a block without an end date', () => {
+    const row = {
+      blockstartdate: new Date(),
+      blockenddate: null,
+      lastdebitdate: null,
+    }
+
+    const result = rentalObjectAdapter.transformFromXpandRentalObject(row)
+
+    expect(result.vacantFrom).toBeUndefined()
   })
 })


### PR DESCRIPTION
Fix:DEV-33 Blocked Parking Spaces Gets the Wrong Vacant From Date

VacantFrom should be calculated by both Blocked End Date and Last Debit Date

* Block is present and in the future: Vacant From is 1 day after Block End Date
* Block is present and has no end date: Vacant From is set to undefined (will never be Vacant)
* Block is not present or in the past: Vacant From is 1 day after Last Debit Date
* Block is not present or in the past and there is a Last Debit Date: Vacant From is 1 day after Last Debit Date
* Block is missing and Last Debit Date is missing: Vacant From is today