### PR TITLE
core: app as proxy

### DIFF
--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -15,6 +15,7 @@ import { routes as swagggerRoutes } from './services/swagger'
 import { requireAuth } from './middlewares/keycloak-auth'
 
 const app = new Koa()
+app.proxy = true
 
 app.use(
   cors({


### PR DESCRIPTION
**Problem** 
Keycloak auth is not working in prod.

We get an error when trying to set the cookie about context not being secure.
Auth cookie is set as `secure` based on `NODE_ENV === 'production'`. This condition is currently true in prod, and false in dev.

I think this is the cause of the error.
I believe that since core is behind an ingress, the communication between ingress and core is not "secure" by the same standard, so we get an error. And the ingress _should_ forward proxy headers but koa doesn't pick them up.

Koa docs says:
> app.proxy when true proxy header fields will be trusted

**Solution**
Set app.proxy = true

