### PR TITLE
fix:Remove bail-out on no vacantFrom date during createOffer - it wil…

### DIFF
--- a/core/src/processes/parkingspaces/internal/create-offer.ts
+++ b/core/src/processes/parkingspaces/internal/create-offer.ts
@@ -82,6 +82,15 @@ export const createOfferForInternalParkingSpace = async (
       )
     }
 
+    if (!listing.rentalObject.vacantFrom) {
+      return endFailingProcess(
+        log,
+        CreateOfferErrorCodes.RentalObjectNotVacant,
+        500,
+        `Listing with id ${listingId} has no vacantFrom date`
+      )
+    }
+
     const allApplicants =
       await leasingAdapter.getDetailedApplicantsByListingId(listingId)
 

--- a/core/src/processes/parkingspaces/internal/tests/create-offer.test.ts
+++ b/core/src/processes/parkingspaces/internal/tests/create-offer.test.ts
@@ -499,7 +499,7 @@ describe('createOfferForInternalParkingSpace', () => {
     expect(expiresAt.getUTCMinutes()).toBe(59)
   })
 
-  it('creates offer on a listing with an undefined vacantFrom date', async () => {
+  it('should fail on attempting to create listing on rental object with no vacantFrom date', async () => {
     const listing = factory.listing.build({ status: ListingStatus.Expired })
     jest
       .spyOn(leasingAdapter, 'getListingByListingId')
@@ -514,39 +514,15 @@ describe('createOfferForInternalParkingSpace', () => {
         })
         .build(),
     })
-    jest
-      .spyOn(leasingAdapter, 'getDetailedApplicantsByListingId')
-      .mockResolvedValueOnce({
-        ok: true,
-        data: factory.detailedApplicant.buildList(1),
-      })
-    jest
-      .spyOn(leasingAdapter, 'getContactByContactCode')
-      .mockResolvedValueOnce({ ok: true, data: factory.contact.build() })
-    jest
-      .spyOn(leasingAdapter, 'updateApplicantStatus')
-      .mockResolvedValueOnce(null)
-
-    jest
-      .spyOn(communicationAdapter, 'sendParkingSpaceOfferEmail')
-      .mockResolvedValueOnce(null)
-
-    jest
-      .spyOn(leasingAdapter, 'createOffer')
-      .mockResolvedValueOnce({ ok: true, data: factory.offer.build() })
-
-    const updateOfferSentAtSpy = jest
-      .spyOn(leasingAdapter, 'updateOfferSentAt')
-      .mockResolvedValue({ ok: true, data: null })
 
     const result = await createOfferForInternalParkingSpace(123)
 
-    expect(result).toEqual({
-      processStatus: ProcessStatus.successful,
-      data: null,
-      httpStatus: 200,
+    expect(result).toMatchObject({
+      processStatus: ProcessStatus.failed,
+      httpStatus: 500,
+      response: {
+        errorCode: 'rental-object-not-vacant',
+      },
     })
-
-    expect(updateOfferSentAtSpy).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
### WHAT
- Fixes failing test

### HOW?
- The way I read the code, there is no way execution will reach the point where the missing vacantFrom-date gets today's date patched in. So I done went and removed the guard that flunks it, allowing it to be assigned further down in Giant McFunction.

### BUT...
- Is this the way?
- Are there other implications?
- Who actually DID frame Roger Rabbit?