### PR TITLE
Fix/uth 276 show vat for non scored parking spaces

### DIFF
--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -99,26 +99,50 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
               )}/mån`}</Typography>
             </Box>
           </Box>
+          {parkingSpaceListing.rentalRule === 'NON_SCORED' && (
+            <Box display="flex" justifyContent="space-between" flex="1">
+              <Typography>Hyra inkl. moms</Typography>
+              <Box>
+                <Typography fontWeight="bold">{`${numberFormatter.format(
+                  parkingSpaceListing.rentalObject.monthlyRent * 1.25
+                )}/mån`}</Typography>
+              </Box>
+            </Box>
+          )}
           <Box display="flex" justifyContent="space-between" flex="1">
-            <Typography>Sökande</Typography>
+            <Typography>Uthyrningsmetod</Typography>
             <Box>
               <Typography fontWeight="bold">
-                {parkingSpaceListing.applicants?.length ?? 0}
+                {parkingSpaceListing.rentalRule === 'NON_SCORED'
+                  ? 'Poängfri'
+                  : 'Intern'}
               </Typography>
             </Box>
           </Box>
-          <Box display="flex" justifyContent="space-between" flex="1">
-            <Typography>Datum tilldelas</Typography>
-            <Box>
-              <Typography fontWeight="bold">
-                {parkingSpaceListing.publishedTo
-                  ? dateFormatter.format(
-                      new Date(parkingSpaceListing.publishedTo)
-                    )
-                  : '-'}
-              </Typography>
-            </Box>
-          </Box>
+          {parkingSpaceListing.rentalRule === 'SCORED' && (
+            <>
+              <Box display="flex" justifyContent="space-between" flex="1">
+                <Typography>Sökande</Typography>
+                <Box>
+                  <Typography fontWeight="bold">
+                    {parkingSpaceListing.applicants?.length ?? 0}
+                  </Typography>
+                </Box>
+              </Box>
+              <Box display="flex" justifyContent="space-between" flex="1">
+                <Typography>Datum tilldelas</Typography>
+                <Box>
+                  <Typography fontWeight="bold">
+                    {parkingSpaceListing.publishedTo
+                      ? dateFormatter.format(
+                          new Date(parkingSpaceListing.publishedTo)
+                        )
+                      : '-'}
+                  </Typography>
+                </Box>
+              </Box>
+            </>
+          )}
           <Box display="flex" justifyContent="space-between" flex="1">
             <Typography>Ledig från och med</Typography>
             <Box>

--- a/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
@@ -363,7 +363,7 @@ const getColumns = (
       headerName: 'Sökande',
       ...sharedColumnProps,
       flex: 0.5,
-      valueFormatter: (v) => v.value.length,
+      valueGetter: (v) => (v.row.rentalRule == 'SCORED' ? v.value.length : '-'),
     },
     {
       field: 'publishedTo',

--- a/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
@@ -296,6 +296,7 @@ const getColumns = (
       headerName: 'Bilplats',
       ...sharedColumnProps,
       flex: 1.25,
+      valueGetter: (params) => params.row.rentalObject?.address ?? 0,
       renderCell: (v) => (
         <span>
           <span style={{ display: 'block' }}>{v.row.rentalObject.address}</span>
@@ -308,6 +309,7 @@ const getColumns = (
       headerName: 'Distrikt',
       ...sharedColumnProps,
       valueGetter: (params) => params.row.rentalObject?.districtCaption ?? '',
+      flex: 0.6,
     },
     {
       field: 'residentialAreaCaption',
@@ -331,19 +333,36 @@ const getColumns = (
         if (params.row.rentalRule === 'SCORED') return 'Intern'
         return ''
       },
+      flex: 0.7,
     },
     {
       field: 'monthlyRent',
       headerName: 'Hyra',
       ...sharedColumnProps,
       valueGetter: (params) => params.row.rentalObject?.monthlyRent ?? 0,
-      valueFormatter: (v) => `${numberFormatter.format(v.value)}/mån`,
+      // valueFormatter: (v) => `${numberFormatter.format(v.value)}/mån`,
+      renderCell: (v) => {
+        const rent = v.row.rentalObject?.monthlyRent ?? 0
+        const showInclVat = v.row.rentalRule === 'NON_SCORED'
+        return (
+          <span>
+            <span style={{ display: 'block' }}>
+              {`${numberFormatter.format(rent)}/mån`}
+            </span>
+            {showInclVat && (
+              <span>
+                {`${numberFormatter.format(rent * 1.25)}/mån inkl. moms`}
+              </span>
+            )}
+          </span>
+        )
+      },
     },
     {
       field: 'applicants',
       headerName: 'Sökande',
       ...sharedColumnProps,
-      flex: 0.75,
+      flex: 0.5,
       valueFormatter: (v) => v.value.length,
     },
     {
@@ -352,6 +371,7 @@ const getColumns = (
       ...sharedColumnProps,
       valueFormatter: (v) =>
         v.value ? dateFormatter.format(new Date(v.value)) : '-',
+      flex: 0.6,
     },
     {
       field: 'vacantFrom',
@@ -359,6 +379,7 @@ const getColumns = (
       ...sharedColumnProps,
       valueGetter: (params) => params.row.rentalObject?.vacantFrom ?? '',
       valueFormatter: (v) => printVacantFrom(dateFormatter, v.value),
+      flex: 0.6,
     },
   ]
 }


### PR DESCRIPTION
NON_SCORED parking spaces is rented out with VAT if the customer doesn't have a contract in the same area as the parking space. VAT needs to be shown in the internal portal.

* VAT shown for NON_SCORED parking spaces in the parking space list.
* VAT shown för NON_SCORED parking spaces on the parking space view.
* fixed column sizet to make it easier to read
* applicants and assign date is now hidden för NON_SCORED parking spaces as well