### PR TITLE
Feat: UTH-277 Remove Needs Republish Tab

### DIFF
--- a/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpaces/index.tsx
@@ -81,11 +81,6 @@ const ParkingSpaces = () => {
           />
           <Tab disableRipple label="Erbjudna" value="offered" />
           <Tab disableRipple label="Historik" value="historical" />
-          <Tab
-            disableRipple
-            label="Behov av publicering"
-            value="needs-republish"
-          />
         </Tabs>
         <Box paddingTop="1rem">
           <TabPanel value="published" sx={{ padding: 0 }}>
@@ -126,16 +121,6 @@ const ParkingSpaces = () => {
               rows={filterListings(parkingSpaces.data ?? [], searchString)}
               loading={parkingSpaces.status === 'pending'}
               key="historical"
-            />
-          </TabPanel>
-          <TabPanel value="needs-republish" sx={{ padding: 0 }}>
-            <Listings
-              columns={getColumns(dateFormatter, numberFormatter).concat(
-                getActionColumns()
-              )}
-              rows={filterListings(parkingSpaces.data ?? [], searchString)}
-              loading={parkingSpaces.status === 'pending'}
-              key="needs-republish"
             />
           </TabPanel>
         </Box>


### PR DESCRIPTION
The tab "behov av publicering" is no longer needed as of the publishing parking space moving from xpand to onecore.

* it has been done (removed)!