### PR TITLE
Fix:UTH-285 Contact Gets the Wrong Address

### DIFF
--- a/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -410,7 +410,8 @@ const getContactQuery = () => {
     .leftJoin('cmeml', 'cmeml.keycmobj', 'cmctc.keycmobj')
     .leftJoin('bkqte', 'bkqte.keycmctc', 'cmctc.keycmctc')
     .leftJoin('bkkty', 'bkkty.keybkkty', 'bkqte.keybkkty')
-    .where('cmadr.tdate', null) //only get active addresss
+    .whereNotNull('cmadr.fdate') //only get addresses that has from date since a few contacts has addresses without from date and todate and those has never been active and should not be considered
+    .where('cmadr.tdate', null) //only get active address
 }
 
 const getPhoneNumbersForContact = async (keycmobj: string) => {

--- a/services/leasing/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/listing-adapter/get-listings-with-applicants.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert'
-import { ApplicantStatus, ListingStatus, OfferStatus } from '@onecore/types'
+import { ListingStatus, OfferStatus } from '@onecore/types'
 
 import * as listingAdapter from '../../../adapters/listing-adapter'
 import * as offerAdapter from '../../../adapters/offer-adapter'

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -57,7 +57,6 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
       false
     )
 
-
     expect(contact).toStrictEqual({
       ok: true,
       data: {

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -11,6 +11,7 @@ jest.mock('knex', () => () => ({
   innerJoin: jest.fn().mockReturnThis(),
   leftJoin: jest.fn().mockReturnThis(),
   where: jest.fn().mockReturnThis(),
+  whereNotNull: jest.fn().mockReturnThis(),
   limit: jest.fn().mockReturnThis(),
   then: jest
     .fn()
@@ -55,6 +56,8 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
       'P123456',
       false
     )
+
+    console.log('contactResult', contact)
 
     expect(contact).toStrictEqual({
       ok: true,

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -57,7 +57,6 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
       false
     )
 
-    console.log('contactResult', contact)
 
     expect(contact).toStrictEqual({
       ok: true,


### PR DESCRIPTION
An active address is considered to be an address where to date is null in the database. It turns out a few addresses is also missing from date. Those addresses without from date should never be considered to be active

* Addresses without from dates is now filtered out in the sql query