### PR TITLE
Fix: UTH-282 Publish Status Message Not Visible Enough

### DIFF
--- a/apps/internal-portal/frontend/src/pages/PublishParkingSpacesListings/PublishParkingSpacesListingsPage.tsx
+++ b/apps/internal-portal/frontend/src/pages/PublishParkingSpacesListings/PublishParkingSpacesListingsPage.tsx
@@ -12,6 +12,7 @@ import {
   DialogActions,
 } from '@mui/material'
 import { type GridRowId, type GridColDef } from '@mui/x-data-grid'
+import { toast } from 'react-toastify'
 
 import { RentalObjectWithListingHistory } from '../../types'
 import { DataGridTable } from '../../components'
@@ -105,6 +106,14 @@ export const PublishParkingSpacesListingsPage = () => {
       initializeRentalRules(parkingSpaces)
     }
   }, [parkingSpaces, initializeRentalRules])
+
+  useEffect(() => {
+    toast(message?.text, {
+      type: message?.severity,
+      hideProgressBar: true,
+      autoClose: message?.severity === 'info' ? 15000 : 10000,
+    })
+  }, [message])
 
   return (
     <Box>

--- a/apps/internal-portal/frontend/src/pages/PublishParkingSpacesListings/hooks/usePublishParkingSpaces.ts
+++ b/apps/internal-portal/frontend/src/pages/PublishParkingSpacesListings/hooks/usePublishParkingSpaces.ts
@@ -9,16 +9,16 @@ interface UsePublishParkingSpacesResult {
     rentalRules: Record<string, 'SCORED' | 'NON_SCORED'>
   ) => void
   isPending: boolean
-  message: { text: string; severity: 'success' | 'error' } | null
+  message: { text: string; severity: 'success' | 'error' | 'info' } | null
   setMessage: (
-    message: { text: string; severity: 'success' | 'error' } | null
+    message: { text: string; severity: 'success' | 'error' | 'info' } | null
   ) => void
 }
 
 export const usePublishParkingSpaces = (): UsePublishParkingSpacesResult => {
   const [message, setMessage] = useState<{
     text: string
-    severity: 'success' | 'error'
+    severity: 'success' | 'error' | 'info'
   } | null>(null)
 
   const { mutate: createMultipleListings, isPending } =
@@ -76,7 +76,7 @@ export const usePublishParkingSpaces = (): UsePublishParkingSpacesResult => {
     if (ids.length > 200) {
       setMessage({
         text: `Publicerar ${ids.length} parkeringsplatser i batchar om ${BATCH_SIZE}. Detta kan ta en stund...`,
-        severity: 'success',
+        severity: 'info',
       })
     }
 


### PR DESCRIPTION
* Added toastify on the publish page as well. The messages will now appear in the same way as if the user is adding a note of interest och the parking space page