### PR TITLE
internal-portal: Don't show invoice expiration date if there is none 

### DIFF
--- a/apps/internal-portal/frontend/src/pages/Contact/components/ContactCard.tsx
+++ b/apps/internal-portal/frontend/src/pages/Contact/components/ContactCard.tsx
@@ -199,7 +199,11 @@ function InvoiceTableRow(props: { invoice: InvoiceWithRows }) {
       >
         <TableCell>{invoice.invoiceId}</TableCell>
         <TableCell>{yyyymmdd(new Date(invoice.invoiceDate))}</TableCell>
-        <TableCell>{yyyymmdd(new Date(invoice.expirationDate))}</TableCell>
+        <TableCell>
+          {invoice.expirationDate
+            ? yyyymmdd(new Date(invoice.expirationDate))
+            : '-'}
+        </TableCell>
         <TableCell>{invoice.amount}</TableCell>
         <TableCell>{invoice.reference}</TableCell>
         <TableCell>

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -205,7 +205,7 @@ interface Invoice {
   fromDate: Date
   toDate: Date
   invoiceDate: Date
-  expirationDate: Date
+  expirationDate?: Date
   debitStatus: number
   paymentStatus: PaymentStatus
   transactionType: InvoiceTransactionType

--- a/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
@@ -43,7 +43,9 @@ const makeXledgerRequest = async (query: { query: string }): Promise<any> => {
     await sleep(3000)
     return await makeXledgerRequest(query)
   } else {
-    const error = new Error(result.data)
+    const error = new Error(
+      result.data.map((error: any) => error.message).join('\n')
+    )
     logger.error(
       result.data,
       `Error making Xledger request (${getCallerFromError(error)})`

--- a/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
@@ -275,7 +275,11 @@ export const getInvoicesByContactCode = async (contactCode: string) => {
   }
 
   const result = await makeXledgerRequest(query)
-  return transformToInvoice(result.data?.arTransactions?.edges ?? [])
+  const invoiceEdges =
+    result.data?.arTransactions?.edges.filter(
+      (edge: any) => edge.node.slTransactionType.name === 'INVOICE'
+    ) ?? []
+  return transformToInvoice(invoiceEdges)
 }
 
 export async function getInvoiceByInvoiceNumber(invoiceNumber: string) {

--- a/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/invoice-service/adapters/xledger-adapter.ts
@@ -277,11 +277,7 @@ export const getInvoicesByContactCode = async (contactCode: string) => {
   }
 
   const result = await makeXledgerRequest(query)
-  const invoiceEdges =
-    result.data?.arTransactions?.edges.filter(
-      (edge: any) => edge.node.slTransactionType.name === 'INVOICE'
-    ) ?? []
-  return transformToInvoice(invoiceEdges)
+  return transformToInvoice(result.data?.arTransactions?.edges ?? [])
 }
 
 export async function getInvoiceByInvoiceNumber(invoiceNumber: string) {


### PR DESCRIPTION
~Noticed that some tenants had multiple invoices with the same invoice number in internal-portal, where one had a negative amount and no expiration date. Found that these were not invoices at all but transactions with type `ELECTRONIC_PAYMENT` in xledger. This PR filters out only transactions with type `INVOICE` before returning from xledger-adapter.~