### PR TITLE
Feature/mim 1629 hamta komponenter pa rum i besiktningsflodet

### DIFF
--- a/apps/property-tree/src/features/inspections/constants/components.ts
+++ b/apps/property-tree/src/features/inspections/constants/components.ts
@@ -115,6 +115,8 @@ export interface InspectionRow {
 
 // Swedish category names that supersede a default surface row when present in
 // the fetched components. Matches the existing DB convention (e.g. 'Vitvaror').
+// Variants like 'Innertak' won't match and would render alongside the default —
+// add them here when those categories get imported.
 const SURFACE_CATEGORY: Record<string, ComponentType> = {
   Väggar: 'walls',
   Golv: 'floor',

--- a/apps/property-tree/src/features/inspections/constants/components.ts
+++ b/apps/property-tree/src/features/inspections/constants/components.ts
@@ -97,3 +97,81 @@ export function isValidComponentKey(key: string): key is ComponentFieldKey {
 export function getAllComponentKeys(): ComponentFieldKey[] {
   return ROOM_COMPONENTS.map((c) => c.key)
 }
+
+type FetchedComponent = components['schemas']['Component']
+
+/**
+ * A row rendered in the inspection form. Either a hardcoded surface default
+ * (key matches an InspectionRoom field like 'wall1') or a real component
+ * instance fetched from the API (keyed by component.id).
+ */
+export interface InspectionRow {
+  key: string
+  label: string
+  type: ComponentType
+  isDefault: boolean
+  componentId?: string
+}
+
+// Swedish category names that supersede a default surface row when present in
+// the fetched components. Matches the existing DB convention (e.g. 'Vitvaror').
+const SURFACE_CATEGORY: Record<string, ComponentType> = {
+  Väggar: 'walls',
+  Golv: 'floor',
+  Tak: 'ceiling',
+}
+
+function getCategoryName(component: FetchedComponent): string | undefined {
+  return component.model?.subtype?.componentType?.category?.categoryName
+}
+
+function getDisplayName(component: FetchedComponent): string {
+  return (
+    component.model?.subtype?.subTypeName ||
+    component.model?.modelName ||
+    component.id
+  )
+}
+
+function getComponentType(component: FetchedComponent): ComponentType {
+  const categoryName = getCategoryName(component)
+  return (categoryName && SURFACE_CATEGORY[categoryName]) || 'details'
+}
+
+/**
+ * Merge fetched components with hardcoded surface defaults.
+ *
+ * Defaults are dropped per type when ANY fetched component carries the
+ * matching Swedish category name (Väggar/Golv/Tak). Once Mimer imports real
+ * surface components, the defaults disappear entirely. `details` is an
+ * inspection-only concept with no API equivalent and is always rendered.
+ */
+export function mergeComponentsWithDefaults(
+  fetched: readonly FetchedComponent[]
+): InspectionRow[] {
+  const supersededTypes = new Set<ComponentType>()
+  for (const component of fetched) {
+    const categoryName = getCategoryName(component)
+    const supersededType = categoryName && SURFACE_CATEGORY[categoryName]
+    if (supersededType) supersededTypes.add(supersededType)
+  }
+
+  const defaults: InspectionRow[] = ROOM_COMPONENTS.filter(
+    (c) => !supersededTypes.has(c.type)
+  ).map((c) => ({
+    key: c.key,
+    label: c.label,
+    type: c.type,
+    isDefault: true,
+  }))
+
+  const equipment: InspectionRow[] = fetched.map((component) => ({
+    key: component.id,
+    label: getDisplayName(component),
+    type: getComponentType(component),
+    isDefault: false,
+    componentId: component.id,
+  }))
+
+  return [...defaults, ...equipment]
+}

--- a/apps/property-tree/src/features/inspections/hooks/useRoomComponents.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useRoomComponents.ts
@@ -7,8 +7,8 @@ import { componentService } from '@/services/api/core/componentService'
 // stairwells, etc.), so callers must pass `room.propertyObjectId`.
 export function useRoomComponents(propertyObjectId: string | undefined) {
   return useQuery({
-    queryKey: ['room-components', propertyObjectId],
-    queryFn: () => componentService.getByRoomId(propertyObjectId as string),
+    queryKey: ['components', 'by-room', propertyObjectId],
+    queryFn: () => componentService.getByRoomId(propertyObjectId!),
     enabled: Boolean(propertyObjectId),
   })
 }

--- a/apps/property-tree/src/features/inspections/hooks/useRoomComponents.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useRoomComponents.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { componentService } from '@/services/api/core/componentService'
+
+// NOTE: the endpoint is named `roomId` but actually expects a propertyObjectId.
+// componentInstallations.spaceId stores propertyObject IDs (rooms, buildings,
+// stairwells, etc.), so callers must pass `room.propertyObjectId`.
+export function useRoomComponents(propertyObjectId: string | undefined) {
+  return useQuery({
+    queryKey: ['room-components', propertyObjectId],
+    queryFn: () => componentService.getByRoomId(propertyObjectId as string),
+    enabled: Boolean(propertyObjectId),
+  })
+}

--- a/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
+++ b/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
@@ -121,19 +121,27 @@ export function RoomInspectionEditor({
           })}
 
           {equipmentRows.map((row) => (
-            <ComponentInspectionCard
+            <div
               key={row.key}
-              componentKey={row.key}
-              label={row.label}
-              condition=""
-              note=""
-              photoCount={0}
-              actions={[]}
-              onConditionChange={noop}
-              onNoteChange={noop}
-              onPhotoCapture={noop}
-              onOpenDetail={noop}
-            />
+              className="opacity-60 pointer-events-none"
+              aria-disabled
+            >
+              <ComponentInspectionCard
+                componentKey={row.key}
+                label={row.label}
+                condition=""
+                note=""
+                photoCount={0}
+                actions={[]}
+                onConditionChange={noop}
+                onNoteChange={noop}
+                onPhotoCapture={noop}
+                onOpenDetail={noop}
+              />
+              <p className="text-xs text-muted-foreground -mt-2 mb-3 px-1">
+                Sparas inte än
+              </p>
+            </div>
           ))}
         </div>
 

--- a/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
+++ b/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
@@ -4,6 +4,8 @@ import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
 
 import { Card, CardContent } from '@/shared/ui/Card'
+import { Separator } from '@/shared/ui/Separator'
+import { Skeleton } from '@/shared/ui/Skeleton'
 
 import { mergeComponentsWithDefaults } from '../constants'
 import { useRoomComponents } from '../hooks/useRoomComponents'

--- a/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
+++ b/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
@@ -1,12 +1,12 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
 
 import { Card, CardContent } from '@/shared/ui/Card'
-import { Separator } from '@/shared/ui/Separator'
 
-import { ROOM_COMPONENTS } from '../constants'
+import { mergeComponentsWithDefaults } from '../constants'
+import { useRoomComponents } from '../hooks/useRoomComponents'
 import { ComponentDetailSheet } from './ComponentDetailSheet'
 import { ComponentInspectionCard } from './ComponentInspectionCard'
 import { DetailComponentsSection } from './DetailComponentsSection'
@@ -53,9 +53,28 @@ export function RoomInspectionEditor({
   onDetailComponentRemove,
   onDetailComponentNoteUpdate,
 }: RoomInspectionEditorProps) {
-  const [openDetailComponent, setOpenDetailComponent] = useState<
+  const [openDetailKey, setOpenDetailKey] = useState<
     keyof InspectionRoom['conditions'] | null
   >(null)
+
+  const {
+    data: fetchedComponents,
+    isLoading,
+    isError,
+  } = useRoomComponents(room.propertyObjectId)
+
+  const rows = useMemo(
+    () => mergeComponentsWithDefaults(fetchedComponents ?? []),
+    [fetchedComponents]
+  )
+
+  const defaultRows = rows.filter((r) => r.isDefault)
+  const equipmentRows = rows.filter((r) => !r.isDefault)
+
+  // Equipment rows render with the same UI as defaults for visual consistency,
+  // but inputs are non-persisted in this card — see follow-up "Spara
+  // besiktningsframsteg per komponent".
+  const noop = () => {}
 
   return (
     <Card>
@@ -64,26 +83,56 @@ export function RoomInspectionEditor({
           <h3 className="font-semibold text-lg">{room.name}</h3>
         </div>
 
+        {isLoading && (
+          <div className="space-y-3 py-2">
+            <Skeleton className="h-12 w-full" />
+            <Skeleton className="h-12 w-full" />
+          </div>
+        )}
+
+        {isError && (
+          <p className="text-sm text-destructive py-2">
+            Kunde inte hämta komponenter för rummet. Visar endast standardytor.
+          </p>
+        )}
+
         <div>
-          {ROOM_COMPONENTS.map((component) => (
+          {defaultRows.map((row) => {
+            const surfaceKey = row.key as keyof InspectionRoom['conditions']
+            return (
+              <ComponentInspectionCard
+                key={row.key}
+                componentKey={row.key}
+                label={row.label}
+                condition={inspectionData.conditions[surfaceKey]}
+                note={inspectionData.componentNotes[surfaceKey]}
+                photoCount={inspectionData.componentPhotos[surfaceKey].length}
+                actions={inspectionData.actions[surfaceKey]}
+                onConditionChange={(value) =>
+                  onConditionUpdate(surfaceKey, value)
+                }
+                onNoteChange={(note) => onComponentNoteUpdate(surfaceKey, note)}
+                onPhotoCapture={(photoDataUrl) =>
+                  onComponentPhotoAdd(surfaceKey, photoDataUrl)
+                }
+                onOpenDetail={() => setOpenDetailKey(surfaceKey)}
+              />
+            )
+          })}
+
+          {equipmentRows.map((row) => (
             <ComponentInspectionCard
-              key={component.key}
-              componentKey={component.key}
-              label={component.label}
-              condition={inspectionData.conditions[component.key]}
-              note={inspectionData.componentNotes[component.key]}
-              photoCount={inspectionData.componentPhotos[component.key].length}
-              actions={inspectionData.actions[component.key]}
-              onConditionChange={(value) =>
-                onConditionUpdate(component.key, value)
-              }
-              onNoteChange={(note) =>
-                onComponentNoteUpdate(component.key, note)
-              }
-              onPhotoCapture={(photoDataUrl) =>
-                onComponentPhotoAdd(component.key, photoDataUrl)
-              }
-              onOpenDetail={() => setOpenDetailComponent(component.key)}
+              key={row.key}
+              componentKey={row.key}
+              label={row.label}
+              condition=""
+              note=""
+              photoCount={0}
+              actions={[]}
+              onConditionChange={noop}
+              onNoteChange={noop}
+              onPhotoCapture={noop}
+              onOpenDetail={noop}
             />
           ))}
         </div>
@@ -97,29 +146,32 @@ export function RoomInspectionEditor({
           onNoteUpdate={onDetailComponentNoteUpdate}
         />
 
-        {/* Detail sheets for each component */}
-        {ROOM_COMPONENTS.map((component) => (
-          <ComponentDetailSheet
-            key={`detail-${component.key}`}
-            isOpen={openDetailComponent === component.key}
-            onClose={() => setOpenDetailComponent(null)}
-            componentKey={component.key}
-            label={component.label}
-            condition={inspectionData.conditions[component.key]}
-            note={inspectionData.componentNotes[component.key]}
-            photos={inspectionData.componentPhotos[component.key]}
-            actions={inspectionData.actions[component.key]}
-            componentType={component.type}
-            onNoteChange={(note) => onComponentNoteUpdate(component.key, note)}
-            onPhotoAdd={(photoDataUrl) =>
-              onComponentPhotoAdd(component.key, photoDataUrl)
-            }
-            onPhotoRemove={(index) =>
-              onComponentPhotoRemove(component.key, index)
-            }
-            onActionToggle={(action) => onActionUpdate(component.key, action)}
-          />
-        ))}
+        {/* Detail sheets for surface defaults only */}
+        {defaultRows.map((row) => {
+          const surfaceKey = row.key as keyof InspectionRoom['conditions']
+          return (
+            <ComponentDetailSheet
+              key={`detail-${row.key}`}
+              isOpen={openDetailKey === surfaceKey}
+              onClose={() => setOpenDetailKey(null)}
+              componentKey={row.key}
+              label={row.label}
+              condition={inspectionData.conditions[surfaceKey]}
+              note={inspectionData.componentNotes[surfaceKey]}
+              photos={inspectionData.componentPhotos[surfaceKey]}
+              actions={inspectionData.actions[surfaceKey]}
+              componentType={row.type}
+              onNoteChange={(note) => onComponentNoteUpdate(surfaceKey, note)}
+              onPhotoAdd={(photoDataUrl) =>
+                onComponentPhotoAdd(surfaceKey, photoDataUrl)
+              }
+              onPhotoRemove={(index) =>
+                onComponentPhotoRemove(surfaceKey, index)
+              }
+              onActionToggle={(action) => onActionUpdate(surfaceKey, action)}
+            />
+          )
+        })}
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
Replaces the hardcoded room component list with a real GET /components/by-room/{roomId} fetch. Hardcoded surfaces (Vägg 1–4, Golv, Tak, Detaljer) act as fallbacks and are dropped when the API returns a real component with matching category (Väggar/Golv/Tak).


Test:

110-002-02-0201

check if inspection form renders tvättmaskin and torktumlare


Follow-up
[MIM-1683](https://linear.app/mimer-onecore/issue/MIM-1683) > extend InspectionRoom schema so equipment-row inspection data persists.