### PR TITLE
feat: Helm chart för ONECore installation

### DIFF
--- a/helm-project-overview.md
+++ b/helm-project-overview.md
@@ -419,11 +419,182 @@ helm install onecore ./onecore-chart \
 - Aktivera RBAC för klustret
 - Använd network policies för att begränsa trafik
 
+### Resource Configuration
+
+```yaml
+# Resurser för alla komponenter
+resources:
+  defaults:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+
+  # Överrida per komponent
+  core:
+    requests:
+      memory: 256Mi
+      cpu: 200m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+```
+
+### Advanced Configuration (via Bitnami Common Library)
+
+```yaml
+# Bitnami common library ger oss avancerade features som:
+components:
+  core:
+    # Extra environment variables
+    extraEnv:
+      - name: CUSTOM_VAR
+        value: 'custom-value'
+      - name: SECRET_VAR
+        valueFrom:
+          secretKeyRef:
+            name: my-secret
+            key: secret-key
+
+    # Extra volumes
+    extraVolumes:
+      - name: custom-volume
+        configMap:
+          name: custom-config
+
+    extraVolumeMounts:
+      - name: custom-volume
+        mountPath: /etc/custom/config
+        readOnly: true
+
+    # Sidecar containers
+    sidecars:
+      - name: log-collector
+        image: fluent/fluent-bit:latest
+
+    # Init containers
+    initContainers:
+      - name: init-db
+        image: busybox:latest
+        command: ['sh', '-c', 'echo init']
+
+    # Security context
+    podSecurityContext:
+      fsGroup: 1001
+      runAsNonRoot: true
+
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+
+    # Health checks
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 80
+      initialDelaySeconds: 30
+
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      initialDelaySeconds: 10
+
+    startupProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      failureThreshold: 30
+
+    # Scheduling
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/application
+                  operator: In
+                  values:
+                    - onecore
+
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: onecore
+        effect: NoSchedule
+
+    nodeSelector:
+      node-role.kubernetes.io/application: onecore
+
+    # Service account
+    serviceAccount:
+      create: true
+      name: ''
+      annotations: {}
+
+    # Pod labels and annotations
+    podLabels:
+      component: core
+      app: onecore
+
+    podAnnotations:
+      prometheus.io/scrape: 'true'
+```
+
+## 🔧 Bitnami Common Library Integration
+
+Vi använder **Bitnami Common Library Chart** som bas för att få tillgång till avancerade Helm features utan att behöva implementera dem själva.
+
+### Fördelar med Bitnami Common Library
+
+- ✅ **Färdiga helpers** för labels, names, secrets, image handling
+- ✅ **Advanced features** som extraEnv, sidecars, init containers
+- ✅ **Security context** management
+- ✅ **Health checks** (liveness, readiness, startup)
+- ✅ **Affinity/tolerations** och scheduling
+- ✅ **Resource management** med presets
+- ✅ **Validation helpers** för values
+- ✅ **Compatibility layer** för olika Kubernetes versioner
+- ✅ **Secret management** med existing secret support
+- ✅ **Image handling** med pull secrets och version management
+
+### Chart Dependency
+
+```yaml
+# Chart.yaml
+dependencies:
+  - name: common
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 2.x.x
+    tags:
+      - bitnami-common
+    condition: global.common.enabled
+```
+
+### Installation
+
+```bash
+# Installera dependencies
+helm dependency update ./onecore-chart
+
+# Installera med alla features
+helm install onecore ./onecore-chart -f values.yaml
+
+# Använd Bitnami common features
+helm install onecore ./onecore-chart \
+  --set components.core.extraEnv[0].name=CUSTOM_VAR \
+  --set components.core.extraEnv[0].value=custom-value
+```
+
 ## 🚀 Nästa Steg
 
-1. Skapa Helm chart struktur
-2. Implementera templates för alla komponenter
-3. Skapa values.yaml med default värden
-4. Skapa dokumentation
-5. Testa installation i test-kluster
-6. Skapa CI/CD för chartet
+1. Skapa Helm chart struktur med Bitnami common dependency
+2. Implementera templates som använder Bitnami common helpers
+3. Skapa values.yaml med default värden + advanced options
+4. Testa advanced features (extraEnv, sidecars, etc)
+5. Skapa dokumentation för alla available features
+6. Testa installation i test-kluster
+7. Skapa CI/CD för chartet

--- a/helm-project-overview.md
+++ b/helm-project-overview.md
@@ -68,7 +68,7 @@ helm install onecore ./onecore-chart -f values.yaml
 helm install onecore ./onecore-chart \
   --set components.core.enabled=true \
   --set components.propertyTree.enabled=true \
-  --set hostname=onecore.example.com
+  --set global.hostname=onecore.example.com
 ```
 
 ### Uppdatera installation

--- a/helm-project-overview.md
+++ b/helm-project-overview.md
@@ -1,0 +1,429 @@
+# ONECore Helm Chart - Project Overview
+
+## 📋 Sammanfattning
+
+Detta Helm chart gör det möjligt att installera hela ONECore-plattformen i ett Kubernetes-kluster med ett enda kommando. Chartet är modulärt och gör det möjligt att installera alla eller delar av komponenterna med enkel konfiguration.
+
+## 🎯 Målbild
+
+En användare ska kunna köra:
+
+```bash
+helm install onecore ./onecore-chart -f values.yaml
+```
+
+Och få en fullt fungerande ONECore-miljö med:
+
+- Alla valda applikationer installerade
+- Ingress konfigurerad med SSL-certifikat
+- Databaser och infrastruktur uppsatta
+- Environment variables korrekt konfigurerade
+
+## 🏗️ Komponenter
+
+### Backend Services (11 st)
+
+- **core** - API Gateway och central orkestrering
+- **communication** - Kommunikationstjänst
+- **contacts** - Kontaktregister
+- **economy** - Ekonomitjänst
+- **file-storage** - Filhantering
+- **inspection** - Besiktningstjänst
+- **keys** - Nyckelhantering
+- **leasing** - Uthyrningstjänst + cronjob
+- **property** - Fastighetsdata
+- **property-management** - Fastighetsförvaltning
+- **work-order** - Arbetsorderhantering
+
+### Frontend Applications (3 st)
+
+- **internal-portal** - Intern portal (frontend + backend)
+- **keys-portal** - Nyckelportal
+- **property-tree** - Fastighetsträd
+
+### Infrastructure Dependencies
+
+- **MSSQL** - Databas
+- **Elasticsearch** - Loggning
+- **Keycloak** - Autentisering
+- **MinIO** - Object storage
+- **Traefik** - Ingress controller (krävs i klustret)
+
+## 🚀 Installation
+
+### Förutsättningar
+
+- Kubernetes kluster (minikube, kind, eller cloud provider)
+- Helm 3.x installerat
+- Traefik ingress controller installerad
+- cert-manager installerad (för SSL-certifikat)
+
+### Grundläggande installation
+
+```bash
+# Installera alla komponenter
+helm install onecore ./onecore-chart -f values.yaml
+
+# Installera bara core + property-tree
+helm install onecore ./onecore-chart \
+  --set components.core.enabled=true \
+  --set components.propertyTree.enabled=true \
+  --set hostname=onecore.example.com
+```
+
+### Uppdatera installation
+
+```bash
+helm upgrade onecore ./onecore-chart -f values.yaml
+```
+
+### Ta bort installation
+
+```bash
+helm uninstall onecore
+```
+
+## 🔧 Values.yaml Struktur
+
+### Global Configuration
+
+```yaml
+# Global settings
+global:
+  # Miljönamn (används i resource names)
+  environment: dev
+
+  # Hostname för alla applikationer
+  hostname: onecore.example.com
+
+  # Cluster domain för auth等服务
+  clusterDomain: dev.mimer.nu
+
+  # Namespace där allt ska installeras
+  namespace: onecore
+
+  # Image pull secret för GHCR
+  imagePullSecret: regcred
+
+  # Common labels för alla resurser
+  labels:
+    app: onecore
+    environment: dev
+```
+
+### Component Toggles
+
+```yaml
+# Aktivera/inaktivera komponenter
+components:
+  # Backend services
+  core:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-core
+      tag: latest
+
+  communication:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-communication
+      tag: latest
+
+  # ... fler backend services
+
+  # Frontend applications
+  propertyTree:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/property-tree
+      tag: latest
+
+  keysPortal:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-keys-portal
+      tag: latest
+
+  internalPortal:
+    enabled: false # Default avstängd
+    frontend:
+      enabled: false
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-frontend
+        tag: latest
+    backend:
+      enabled: false
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-backend
+        tag: latest
+```
+
+### Infrastructure Configuration
+
+```yaml
+# Databaser och externt beroenden
+infrastructure:
+  # MSSQL Database
+  mssql:
+    enabled: true # Installera via subchart eller använd befintlig
+    host: mssql
+    port: 1433
+    databasePrefix: ''
+    secrets:
+      username: sa
+      password: '' # Sätt via --set eller values-secret.yaml
+
+  # Elasticsearch för loggning
+  elasticsearch:
+    enabled: true
+    host: elasticsearch.logging.svc.cluster.local
+    port: 9200
+
+  # Keycloak för autentisering
+  keycloak:
+    enabled: true
+    url: https://auth.dev.mimer.nu
+    realm: onecore
+    clientId: onecore
+
+  # MinIO för filstorage
+  minio:
+    enabled: true
+    host: minio
+    port: 9000
+    accessKey: ''
+    secretKey: ''
+```
+
+### Ingress Configuration
+
+```yaml
+# Ingress inställningar
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+  # Hostname patterns för olika komponenter
+  hosts:
+    core: api.${global.hostname}
+    propertyTree: property-tree.${global.hostname}
+    keysPortal: keys-portal.${global.hostname}
+    internalPortal: internal-portal.${global.hostname}
+```
+
+### Secrets Configuration
+
+```yaml
+# Secrets (rekommenderas att hanteras via sealed-secrets eller vault)
+secrets:
+  # Core secrets
+  core:
+    auth:
+      jwtSecret: ''
+      keycloakClientSecret: ''
+
+  # Service-specific secrets
+  communication:
+    infobipApiKey: ''
+
+  economy:
+    database:
+      user: ''
+      password: ''
+    xledger:
+      apiToken: ''
+      url: ''
+      sftp:
+        host: ''
+        username: ''
+        password: ''
+
+  leasing:
+    database:
+      url: ''
+    xpand:
+      url: ''
+      apiKey: ''
+
+  # ... fler secrets
+```
+
+### CronJobs Configuration
+
+```yaml
+# CronJobs för schemalagda uppgifter
+cronJobs:
+  leasing:
+    expireListings:
+      enabled: true
+      schedule: '0 2 * * *' # Dagligen kl 02:00
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/onecore-leasing
+        tag: latest
+```
+
+### Resource Configuration
+
+```yaml
+# Resurser för alla komponenter
+resources:
+  defaults:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+
+  # Överrida per komponent
+  core:
+    requests:
+      memory: 256Mi
+      cpu: 200m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+```
+
+## 📁 Exempel på values-full.yaml
+
+```yaml
+global:
+  environment: dev
+  hostname: onecore.dev.mimer.nu
+  clusterDomain: dev.mimer.nu
+  namespace: onecore
+  imagePullSecret: regcred
+
+components:
+  core:
+    enabled: true
+    replicas: 1
+  propertyTree:
+    enabled: true
+    replicas: 1
+  keysPortal:
+    enabled: true
+    replicas: 1
+  communication:
+    enabled: true
+    replicas: 1
+  leasing:
+    enabled: true
+    replicas: 1
+  property:
+    enabled: true
+    replicas: 1
+  economy:
+    enabled: true
+    replicas: 1
+  contacts:
+    enabled: true
+    replicas: 1
+  keys:
+    enabled: true
+    replicas: 1
+  workOrder:
+    enabled: true
+    replicas: 1
+  propertyManagement:
+    enabled: true
+    replicas: 1
+  inspection:
+    enabled: false
+    replicas: 1
+  fileStorage:
+    enabled: false
+    replicas: 1
+
+infrastructure:
+  mssql:
+    enabled: true
+    host: mssql
+    port: 1433
+  elasticsearch:
+    enabled: true
+    host: elasticsearch.logging.svc.cluster.local
+    port: 9200
+  keycloak:
+    enabled: true
+    url: https://auth.dev.mimer.nu
+    realm: onecore
+    clientId: onecore
+
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+cronJobs:
+  leasing:
+    expireListings:
+      enabled: true
+      schedule: '0 2 * * *'
+
+secrets:
+  # Sätt dessa via --set-file eller k8s secrets
+  core:
+    auth:
+      jwtSecret: ''
+  communication:
+    infobipApiKey: ''
+  economy:
+    database:
+      user: ''
+      password: ''
+  leasing:
+    database:
+      url: ''
+```
+
+## 🎯 Exempel på Minimal Installation
+
+```bash
+# Installera bara core + property-tree för snabb test
+helm install onecore ./onecore-chart \
+  --set global.hostname=onecore.test.com \
+  --set components.core.enabled=true \
+  --set components.propertyTree.enabled=true \
+  --set infrastructure.mssql.enabled=false \
+  --set infrastructure.elasticsearch.enabled=false
+```
+
+## 🔄 Workflow för Ny Miljö
+
+1. **Skapa values.yaml** för miljön
+2. **Generera secrets** (använd sealed-secrets eller k8s secrets)
+3. **Installera infrastructure** (MSSQL, Elasticsearch, etc) om de inte finns
+4. **Installera onecore** med helm
+5. **Verifiera installation** med `helm test onecore`
+
+## 📚 Dokumentation
+
+- `values.yaml` - Alla konfigurationsalternativ
+- `README.md` - Detaljerad installationsguide
+- `ARCHITECTURE.md` - Arkitekturbeskrivning
+- `TROUBLESHOOTING.md` - Vanliga problem och lösningar
+
+## 🔐 Säkerhet
+
+- Secrets ska aldrig committas till git
+- Använd sealed-secrets eller Vault för produktionsmiljöer
+- Aktivera RBAC för klustret
+- Använd network policies för att begränsa trafik
+
+## 🚀 Nästa Steg
+
+1. Skapa Helm chart struktur
+2. Implementera templates för alla komponenter
+3. Skapa values.yaml med default värden
+4. Skapa dokumentation
+5. Testa installation i test-kluster
+6. Skapa CI/CD för chartet

--- a/helm-project-overview.md
+++ b/helm-project-overview.md
@@ -96,7 +96,7 @@ global:
   # Hostname för alla applikationer
   hostname: onecore.example.com
 
-  # Cluster domain för auth等服务
+  # Cluster domain för auth
   clusterDomain: dev.mimer.nu
 
   # Namespace där allt ska installeras

--- a/onecore-chart/.helmignore
+++ b/onecore-chart/.helmignore
@@ -27,16 +27,11 @@
 .kubeconfig
 # Helm configuration files
 .gitlab-ci.yml
-# Documentation files
-README.md
-LICENSE
-CHANGELOG.md
 # Test files
 *.test
 tests/
 # CI/CD
 .github/
-.gitlab-ci.yml
 # Build artifacts
 dist/
 build/
@@ -58,7 +53,5 @@ AGENTS.md
 opencode.json
 *.aider*
 tui.json
-.DS_Store
 # Local development
-.aider*
 helm-project-overview.md

--- a/onecore-chart/.helmignore
+++ b/onecore-chart/.helmignore
@@ -1,0 +1,64 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+*/.vscode/
+# Owncloud
+.sync_*
+.kubeconfig
+# Helm configuration files
+.gitlab-ci.yml
+# Documentation files
+README.md
+LICENSE
+CHANGELOG.md
+# Test files
+*.test
+tests/
+# CI/CD
+.github/
+.gitlab-ci.yml
+# Build artifacts
+dist/
+build/
+# Node modules
+node_modules/
+# Package manager lock files
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+# Environment files
+.env
+.env.local
+.env.*.local
+# Logs
+logs/
+*.log
+# Development files
+AGENTS.md
+opencode.json
+*.aider*
+tui.json
+.DS_Store
+# Local development
+.aider*
+helm-project-overview.md

--- a/onecore-chart/Chart.lock
+++ b/onecore-chart/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.38.0
+digest: sha256:0c3c3547e10960119c4fc007f5790290ae241711e8ed55e18f96375ce87f701e
+generated: "2026-04-15T19:47:57.64706+02:00"

--- a/onecore-chart/Chart.yaml
+++ b/onecore-chart/Chart.yaml
@@ -17,7 +17,7 @@ maintainers:
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
-    version: 2.x.x
+    version: 2.38.0
     tags:
       - bitnami-common
     condition: global.common.enabled

--- a/onecore-chart/Chart.yaml
+++ b/onecore-chart/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: onecore
+description: ONECore - Holistic property management platform
+type: application
+version: 0.1.0
+appVersion: '1.5.0'
+
+keywords:
+  - onecore
+  - property-management
+  - housing
+
+maintainers:
+  - name: Bostads AB Mimer
+    email: dev@mimer.nu
+
+dependencies:
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 2.x.x
+    tags:
+      - bitnami-common
+    condition: global.common.enabled

--- a/onecore-chart/README.md
+++ b/onecore-chart/README.md
@@ -43,15 +43,20 @@ components:
     ingress:
       enabled: true
       host: api.${global.hostname}
-
-  propertyTree:
-    enabled: true
-    image: ghcr.io/bostads-ab-mimer/onecore-property-tree:latest
-    env:
-      VITE_API_URL: https://api.${global.hostname}
-    ingress:
+    cronJobs:
+      expire-listings:
+        enabled: true
+        schedule: '0 2 * * *'
+        command: ['npm', 'run', 'script:expire-listings']
+    autoscaling:
       enabled: true
-      host: property-tree.${global.hostname}
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+    serviceAccount:
+      create: true
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/onecore-core
 ```
 
 ### Struktur per komponent
@@ -67,6 +72,8 @@ Varje komponent stödjer:
 - `ingress` - Exponera via Traefik
 - `health` - Liveness/readiness probes
 - `cronJobs` - Schemalagda jobb
+- `autoscaling` - Horizontal Pod Autoscaler
+- `serviceAccount` - Kubernetes Service Account
 
 ## Global konfiguration
 
@@ -80,6 +87,12 @@ ingress:
   enabled: true
   className: traefik
   certManagerClusterIssuer: letsencrypt
+  middlewares:
+    cors:
+      enabled: true
+    basicAuth:
+      enabled: false
+      secretName: basic-auth
 ```
 
 ## Komponenter
@@ -102,6 +115,19 @@ ingress:
 - **keysPortal** - Nyckelportal
 - **internalPortal** - Intern portal (frontend/backend)
 
+## Generated Resources
+
+| Resource | Count | Beskrivning |
+|----------|-------|-------------|
+| Deployment | 11 | Alla backend + frontend |
+| Service | 11 | ClusterIP per komponent |
+| ConfigMap | 11 | Env-variabler per komponent |
+| Ingress | 3 | Traefik med SSL |
+| Secret | 5 | Hemliga värden |
+| CronJob | 1 | Schemalagda jobb |
+| Middleware | 1 | CORS etc |
+| **Total** | **43** | |
+
 ## Tips
 
 ```bash
@@ -113,4 +139,7 @@ helm lint ./onecore-chart
 
 # Visa alla values
 helm show values ./onecore-chart
+
+# Rendera endast specifik komponent
+helm template onecore ./onecore-chart --set components.core.enabled=true --set components.propertyTree.enabled=false
 ```

--- a/onecore-chart/README.md
+++ b/onecore-chart/README.md
@@ -1,273 +1,116 @@
 # ONECore Helm Chart
 
-[![License](https://img.shields.io/badge/license-AGPL--3.0--only-green.svg)](LICENSE)
-[![Helm](https://img.shields.io/badge/Helm-3%2B-blue.svg)](https://helm.sh)
-
 Helm chart för att installera hela ONECore-plattformen i ett Kubernetes-kluster.
-
-## Prerequisites
-
-- Kubernetes 1.23+
-- Helm 3.8.0+
-- Traefik ingress controller
-- cert-manager (för SSL-certifikat)
 
 ## Installation
 
-### Ladda ner dependencies
-
-Chartet använder **Bitnami Common Library** för avancerade features. Ladda ner dependencies:
-
 ```bash
-cd onecore-chart
-HELM_EXPERIMENTAL_OCI=1 helm dependency update
-```
+# Installera dependencies
+cd onecore-chart && HELM_EXPERIMENTAL_OCI=1 helm dependency update
 
-### Installera chartet
-
-```bash
-# Installera alla komponenter med default values
+# Installera med default värden
 helm install onecore ./onecore-chart
 
 # Installera med custom values
-helm install onecore ./onecore-chart -f values.yaml
+helm install onecore ./onecore-chart -f my-values.yaml
 
-# Installera bara core + property-tree
+# Installera bara specifika komponenter
 helm install onecore ./onecore-chart \
   --set components.core.enabled=true \
-  --set components.propertyTree.enabled=true \
-  --set global.hostname=onecore.example.com
+  --set components.propertyTree.enabled=true
 ```
 
-### Uppgradera chartet
+## Konfiguration
 
-```bash
-helm upgrade onecore ./onecore-chart
-```
-
-### Ta bort installation
-
-```bash
-helm uninstall onecore
-```
-
-## Configuration
-
-Se [values.yaml](values.yaml) för alla konfigurationsalternativ.
-
-### Global Configuration
-
-```yaml
-global:
-  environment: dev
-  hostname: onecore.example.com
-  clusterDomain: dev.mimer.nu
-  namespace: onecore
-  imagePullSecret: regcred
-```
-
-### Component Toggles
-
-Aktivera/inaktivera specifika komponenter:
+All konfiguration sker i `values.yaml` under `components`:
 
 ```yaml
 components:
   core:
     enabled: true
     replicas: 2
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-core:latest
+    env:
+      APPLICATION_NAME: core
+      SERVICE_URL__LEASING: http://leasing
+    secrets:
+      - name: db-url        # Skapar env-variabeln DB_URL
+      - name: api-key
+        envName: API_KEY    # Använd custom env-namn
+    resources:
+      limits:
+        memory: 512Mi
+    ingress:
+      enabled: true
+      host: api.${global.hostname}
+
   propertyTree:
     enabled: true
-    replicas: 1
-  communication:
-    enabled: false
+    image: ghcr.io/bostads-ab-mimer/onecore-property-tree:latest
+    env:
+      VITE_API_URL: https://api.${global.hostname}
+    ingress:
+      enabled: true
+      host: property-tree.${global.hostname}
 ```
 
-### Bitnami Common Library Features
+### Struktur per komponent
 
-Chartet använder Bitnami Common Library vilket ger tillgång till avancerade features:
+Varje komponent stödjer:
 
-#### Extra Environment Variables
+- `enabled` - Aktivera/inaktivera
+- `replicas` - Antal poddar
+- `image` - Container image
+- `env` - Miljövariabler (renderas som ConfigMap)
+- `secrets` - Hemliga värden (refererar till Secret)
+- `resources` - CPU/minne limits
+- `ingress` - Exponera via Traefik
+- `health` - Liveness/readiness probes
+- `cronJobs` - Schemalagda jobb
 
-```yaml
-components:
-  core:
-    extraEnv:
-      - name: CUSTOM_VAR
-        value: 'custom-value'
-      - name: SECRET_VAR
-        valueFrom:
-          secretKeyRef:
-            name: my-secret
-            key: secret-key
-```
-
-#### Extra Volumes
+## Global konfiguration
 
 ```yaml
-components:
-  core:
-    extraVolumes:
-      - name: custom-volume
-        configMap:
-          name: custom-config
-    extraVolumeMounts:
-      - name: custom-volume
-        mountPath: /etc/custom/config
-        readOnly: true
-```
+global:
+  hostname: onecore.example.com
+  namespace: onecore
+  imagePullSecret: regcred
 
-#### Sidecar Containers
-
-```yaml
-components:
-  core:
-    sidecars:
-      - name: log-collector
-        image: fluent/fluent-bit:latest
-        volumeMounts:
-          - name: logs
-            mountPath: /var/log
-```
-
-#### Init Containers
-
-```yaml
-components:
-  core:
-    initContainers:
-      - name: init-db
-        image: busybox:latest
-        command: ['sh', '-c', 'echo init']
-```
-
-#### Security Context
-
-```yaml
-components:
-  core:
-    podSecurityContext:
-      fsGroup: 1001
-      runAsNonRoot: true
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-```
-
-#### Health Checks
-
-```yaml
-components:
-  core:
-    livenessProbe:
-      httpGet:
-        path: /health
-        port: 80
-      initialDelaySeconds: 30
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: 80
-      initialDelaySeconds: 10
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: 80
-      failureThreshold: 30
-```
-
-#### Scheduling
-
-```yaml
-components:
-  core:
-    affinity:
-      nodeAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-                - key: node-role.kubernetes.io/application
-                  operator: In
-                  values:
-                    - onecore
-    tolerations:
-      - key: dedicated
-        operator: Equal
-        value: onecore
-        effect: NoSchedule
-    nodeSelector:
-      node-role.kubernetes.io/application: onecore
+ingress:
+  enabled: true
+  className: traefik
+  certManagerClusterIssuer: letsencrypt
 ```
 
 ## Komponenter
 
-### Backend Services (11 st)
-
-- **core** - API Gateway och central orkestrering
+### Backend Services
+- **core** - API Gateway
 - **communication** - Kommunikationstjänst
 - **contacts** - Kontaktregister
 - **economy** - Ekonomitjänst
-- **file-storage** - Filhantering
-- **inspection** - Besiktningstjänst
 - **keys** - Nyckelhantering
-- **leasing** - Uthyrningstjänst
+- **leasing** - Uthyrning (med cronjob)
 - **property** - Fastighetsdata
-- **property-management** - Fastighetsförvaltning
-- **work-order** - Arbetsorderhantering
+- **propertyManagement** - Fastighetsförvaltning
+- **workOrder** - Arbetsorder
+- **fileStorage** - Fillagring (valfri)
+- **inspection** - Besiktning (valfri)
 
-### Frontend Applications (3 st)
-
-- **internal-portal** - Intern portal (frontend + backend)
-- **keys-portal** - Nyckelportal
-- **property-tree** - Fastighetsträd
+### Frontend Applications
+- **propertyTree** - Fastighetsträd
+- **keysPortal** - Nyckelportal
+- **internalPortal** - Intern portal (frontend/backend)
 
 ## Tips
 
-### Testa installation lokalt
-
 ```bash
-# Rendera manifests utan att installera
-helm template onecore ./onecore-chart -f values.yaml
+# Se genererade manifests utan att installera
+helm template onecore ./onecore-chart
 
 # Linta chartet
 helm lint ./onecore-chart
-```
 
-### Visa alla values
-
-```bash
+# Visa alla values
 helm show values ./onecore-chart
 ```
-
-### Debug installation
-
-```bash
-# Installera med debug output
-helm install --debug onecore ./onecore-chart
-
-# Få mer detaljerad info
-helm get manifest onecore
-helm get values onecore
-```
-
-## Bitnami Common Library
-
-Detta chart använder [Bitnami Common Library Chart](https://github.com/bitnami/charts/tree/main/bitnami/common) som ger tillgång till:
-
-- Standard helpers för labels, names, secrets
-- Advanced features (extraEnv, sidecars, initContainers)
-- Security context management
-- Health checks
-- Affinity/tolerations
-- Resource management
-- Validation helpers
-
-Se [Bitnami Common Library dokumentation](https://github.com/bitnami/charts/tree/main/bitnami/common) för alla tillgängliga features.
-
-## Support
-
-För support och frågor, kontakta dev@mimer.nu eller öppna en issue på GitHub.
-
-## License
-
-AGPL-3.0-only - Se [LICENSE](LICENSE) för detaljer.

--- a/onecore-chart/README.md
+++ b/onecore-chart/README.md
@@ -1,0 +1,273 @@
+# ONECore Helm Chart
+
+[![License](https://img.shields.io/badge/license-AGPL--3.0--only-green.svg)](LICENSE)
+[![Helm](https://img.shields.io/badge/Helm-3%2B-blue.svg)](https://helm.sh)
+
+Helm chart för att installera hela ONECore-plattformen i ett Kubernetes-kluster.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.8.0+
+- Traefik ingress controller
+- cert-manager (för SSL-certifikat)
+
+## Installation
+
+### Ladda ner dependencies
+
+Chartet använder **Bitnami Common Library** för avancerade features. Ladda ner dependencies:
+
+```bash
+cd onecore-chart
+HELM_EXPERIMENTAL_OCI=1 helm dependency update
+```
+
+### Installera chartet
+
+```bash
+# Installera alla komponenter med default values
+helm install onecore ./onecore-chart
+
+# Installera med custom values
+helm install onecore ./onecore-chart -f values.yaml
+
+# Installera bara core + property-tree
+helm install onecore ./onecore-chart \
+  --set components.core.enabled=true \
+  --set components.propertyTree.enabled=true \
+  --set global.hostname=onecore.example.com
+```
+
+### Uppgradera chartet
+
+```bash
+helm upgrade onecore ./onecore-chart
+```
+
+### Ta bort installation
+
+```bash
+helm uninstall onecore
+```
+
+## Configuration
+
+Se [values.yaml](values.yaml) för alla konfigurationsalternativ.
+
+### Global Configuration
+
+```yaml
+global:
+  environment: dev
+  hostname: onecore.example.com
+  clusterDomain: dev.mimer.nu
+  namespace: onecore
+  imagePullSecret: regcred
+```
+
+### Component Toggles
+
+Aktivera/inaktivera specifika komponenter:
+
+```yaml
+components:
+  core:
+    enabled: true
+    replicas: 2
+  propertyTree:
+    enabled: true
+    replicas: 1
+  communication:
+    enabled: false
+```
+
+### Bitnami Common Library Features
+
+Chartet använder Bitnami Common Library vilket ger tillgång till avancerade features:
+
+#### Extra Environment Variables
+
+```yaml
+components:
+  core:
+    extraEnv:
+      - name: CUSTOM_VAR
+        value: 'custom-value'
+      - name: SECRET_VAR
+        valueFrom:
+          secretKeyRef:
+            name: my-secret
+            key: secret-key
+```
+
+#### Extra Volumes
+
+```yaml
+components:
+  core:
+    extraVolumes:
+      - name: custom-volume
+        configMap:
+          name: custom-config
+    extraVolumeMounts:
+      - name: custom-volume
+        mountPath: /etc/custom/config
+        readOnly: true
+```
+
+#### Sidecar Containers
+
+```yaml
+components:
+  core:
+    sidecars:
+      - name: log-collector
+        image: fluent/fluent-bit:latest
+        volumeMounts:
+          - name: logs
+            mountPath: /var/log
+```
+
+#### Init Containers
+
+```yaml
+components:
+  core:
+    initContainers:
+      - name: init-db
+        image: busybox:latest
+        command: ['sh', '-c', 'echo init']
+```
+
+#### Security Context
+
+```yaml
+components:
+  core:
+    podSecurityContext:
+      fsGroup: 1001
+      runAsNonRoot: true
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+```
+
+#### Health Checks
+
+```yaml
+components:
+  core:
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 80
+      initialDelaySeconds: 30
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      initialDelaySeconds: 10
+    startupProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      failureThreshold: 30
+```
+
+#### Scheduling
+
+```yaml
+components:
+  core:
+    affinity:
+      nodeAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/application
+                  operator: In
+                  values:
+                    - onecore
+    tolerations:
+      - key: dedicated
+        operator: Equal
+        value: onecore
+        effect: NoSchedule
+    nodeSelector:
+      node-role.kubernetes.io/application: onecore
+```
+
+## Komponenter
+
+### Backend Services (11 st)
+
+- **core** - API Gateway och central orkestrering
+- **communication** - Kommunikationstjänst
+- **contacts** - Kontaktregister
+- **economy** - Ekonomitjänst
+- **file-storage** - Filhantering
+- **inspection** - Besiktningstjänst
+- **keys** - Nyckelhantering
+- **leasing** - Uthyrningstjänst
+- **property** - Fastighetsdata
+- **property-management** - Fastighetsförvaltning
+- **work-order** - Arbetsorderhantering
+
+### Frontend Applications (3 st)
+
+- **internal-portal** - Intern portal (frontend + backend)
+- **keys-portal** - Nyckelportal
+- **property-tree** - Fastighetsträd
+
+## Tips
+
+### Testa installation lokalt
+
+```bash
+# Rendera manifests utan att installera
+helm template onecore ./onecore-chart -f values.yaml
+
+# Linta chartet
+helm lint ./onecore-chart
+```
+
+### Visa alla values
+
+```bash
+helm show values ./onecore-chart
+```
+
+### Debug installation
+
+```bash
+# Installera med debug output
+helm install --debug onecore ./onecore-chart
+
+# Få mer detaljerad info
+helm get manifest onecore
+helm get values onecore
+```
+
+## Bitnami Common Library
+
+Detta chart använder [Bitnami Common Library Chart](https://github.com/bitnami/charts/tree/main/bitnami/common) som ger tillgång till:
+
+- Standard helpers för labels, names, secrets
+- Advanced features (extraEnv, sidecars, initContainers)
+- Security context management
+- Health checks
+- Affinity/tolerations
+- Resource management
+- Validation helpers
+
+Se [Bitnami Common Library dokumentation](https://github.com/bitnami/charts/tree/main/bitnami/common) för alla tillgängliga features.
+
+## Support
+
+För support och frågor, kontakta dev@mimer.nu eller öppna en issue på GitHub.
+
+## License
+
+AGPL-3.0-only - Se [LICENSE](LICENSE) för detaljer.

--- a/onecore-chart/README.md
+++ b/onecore-chart/README.md
@@ -6,7 +6,7 @@ Helm chart för att installera hela ONECore-plattformen i ett Kubernetes-kluster
 
 ```bash
 # Installera dependencies
-cd onecore-chart && HELM_EXPERIMENTAL_OCI=1 helm dependency update
+cd onecore-chart && helm dependency update
 
 # Installera med default värden
 helm install onecore ./onecore-chart
@@ -42,7 +42,7 @@ components:
         memory: 512Mi
     ingress:
       enabled: true
-      host: api.${global.hostname}
+      host: api.onecore.example.com
     cronJobs:
       expire-listings:
         enabled: true

--- a/onecore-chart/templates/_helpers.tpl
+++ b/onecore-chart/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- define "onecore.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "onecore.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "onecore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "onecore.componentName" -}}
+{{- printf "%s-%s" (include "onecore.fullname" .root) (lower .name) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "onecore.labels" -}}
+helm.sh/chart: {{ include "onecore.chart" .root }}
+app.kubernetes.io/name: {{ include "onecore.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ lower .name }}
+{{- if .root.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+{{- end }}
+
+{{- define "onecore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "onecore.name" .root }}
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ lower .name }}
+{{- end }}
+
+{{- define "onecore.envPort" -}}
+{{- $port := 80 -}}
+{{- if kindIs "map" .env -}}
+{{- if hasKey .env "PORT" -}}
+{{- $port = int (get .env "PORT") -}}
+{{- end -}}
+{{- end -}}
+{{- $port -}}
+{{- end }}

--- a/onecore-chart/templates/configmap.yaml
+++ b/onecore-chart/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- range $name, $config := $.Values.components }}
+{{- if and (kindIs "map" $config) ($config.enabled) ($config.env) }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "onecore.componentName" (dict "root" $ "name" $name) }}-env
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+data:
+{{- range $key, $value := $config.env }}
+{{- if kindIs "string" $value }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/cronjobs.yaml
+++ b/onecore-chart/templates/cronjobs.yaml
@@ -1,0 +1,57 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+# CronJobs definierade per komponent
+{{- range $name, $config := $.Values.components }}
+{{- if kindIs "map" $config }}
+{{- if $config.enabled }}
+{{- if $config.cronJobs }}
+{{- range $cronName, $cronConfig := $config.cronJobs }}
+{{- if $cronConfig.enabled }}
+{{- $jobName := printf "%s-%s" $name $cronName }}
+{{- $image := $cronConfig.image | default $config.image }}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "onecore.componentName" (dict "root" $ "name" $jobName) }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $jobName) | indent 4 }}
+spec:
+  schedule: {{ $cronConfig.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+{{ include "onecore.selectorLabels" (dict "root" $ "name" $jobName) | indent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          {{- if $.Values.global.imagePullSecret }}
+          imagePullSecrets:
+            - name: {{ $.Values.global.imagePullSecret }}
+          {{- end }}
+          containers:
+            - name: job
+              image: {{ $image }}
+              {{- if $cronConfig.command }}
+              command:
+{{- toYaml $cronConfig.command | nindent 16 }}
+              {{- end }}
+              {{- if $cronConfig.env }}
+              env:
+{{- range $key, $value := $cronConfig.env }}
+                - name: {{ $key }}
+                  value: {{ $value | quote }}
+{{- end }}
+              {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/deployment.yaml
+++ b/onecore-chart/templates/deployment.yaml
@@ -1,0 +1,65 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- range $name, $config := $.Values.components }}
+{{- if and (kindIs "map" $config) ($config.enabled) }}
+{{- $port := int (include "onecore.envPort" (dict "env" $config.env)) }}
+{{- $componentName := include "onecore.componentName" (dict "root" $ "name" $name) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $componentName }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+spec:
+  replicas: {{ $config.replicas | default 1 }}
+  selector:
+    matchLabels:
+{{ include "onecore.selectorLabels" (dict "root" $ "name" $name) | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ include "onecore.selectorLabels" (dict "root" $ "name" $name) | indent 8 }}
+    spec:
+      {{- if $.Values.global.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ $.Values.global.imagePullSecret }}
+      {{- end }}
+      containers:
+        - name: app
+          image: {{ $config.image }}
+          imagePullPolicy: {{ $config.imagePullPolicy | default "IfNotPresent" }}
+          {{- if $config.env }}
+          env:
+            - name: PORT
+              value: {{ $port | quote }}
+          {{- range $key, $value := $config.env }}
+          {{- if ne $key "PORT" }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- if $config.secrets }}
+            {{- range $secret := $config.secrets }}
+            - name: {{ $secret.envName | default (upper (replace "-" "_" $secret.name)) | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $componentName }}-secrets
+                  key: {{ $secret.name }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ $port }}
+              protocol: TCP
+          {{- if $config.resources }}
+          resources:
+            {{- toYaml $config.resources | nindent 12 }}
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/hpa.yaml
+++ b/onecore-chart/templates/hpa.yaml
@@ -1,0 +1,48 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+# Horizontal Pod Autoscaler
+{{- range $name, $config := $.Values.components }}
+{{- if kindIs "map" $config }}
+{{- if $config.enabled }}
+{{- if $config.autoscaling }}
+{{- if $config.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "onecore.componentName" (dict "root" $ "name" $name) }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "onecore.componentName" (dict "root" $ "name" $name) }}
+  minReplicas: {{ $config.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ $config.autoscaling.maxReplicas | default 10 }}
+  metrics:
+    {{- if $config.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $config.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $config.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $config.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/ingress.yaml
+++ b/onecore-chart/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- if $.Values.ingress.enabled }}
+{{- range $name, $config := $.Values.components }}
+{{- if and (kindIs "map" $config) ($config.enabled) ($config.ingress) }}
+{{- if $config.ingress.enabled }}
+{{- $componentName := include "onecore.componentName" (dict "root" $ "name" $name) }}
+{{- $host := $config.ingress.host | default (printf "%s.%s" $name $.Values.global.hostname) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $componentName }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: {{ $.Values.ingress.className | default "traefik" | quote }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.certManagerClusterIssuer | default "letsencrypt" | quote }}
+spec:
+  ingressClassName: {{ $.Values.ingress.className | default "traefik" }}
+  rules:
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $componentName }}
+                port:
+                  number: 80
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/middlewares.yaml
+++ b/onecore-chart/templates/middlewares.yaml
@@ -1,0 +1,62 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+# Traefik Middlewares
+{{- if $.Values.ingress.enabled }}
+{{- if $.Values.ingress.middlewares }}
+{{- $middlewares := $.Values.ingress.middlewares }}
+
+{{- if $middlewares.cors }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: cors
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+spec:
+  headers:
+    accessControlAllowOriginList:
+      - "*"
+    accessControlAllowMethods:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - OPTIONS
+    accessControlAllowHeaders:
+      - "*"
+{{- end }}
+
+{{- if $middlewares.basicAuth }}
+{{- if $middlewares.basicAuth.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: basic-auth
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+spec:
+  basicAuth:
+    secret: {{ $middlewares.basicAuth.secretName | default "basic-auth" }}
+{{- end }}
+{{- end }}
+
+{{- if $middlewares.stripPrefix }}
+{{- if $middlewares.stripPrefix.enabled }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: strip-prefix
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+spec:
+  stripPrefix:
+    prefixes:
+{{- toYaml $middlewares.stripPrefix.prefixes | nindent 6 }}
+{{- end }}
+{{- end }}
+
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/secrets.yaml
+++ b/onecore-chart/templates/secrets.yaml
@@ -1,0 +1,29 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- range $name, $config := $.Values.components }}
+{{- if kindIs "map" $config }}
+{{- if $config.enabled }}
+{{- if $config.secrets }}
+{{- $componentName := include "onecore.componentName" (dict "root" $ "name" $name) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $componentName }}-secrets
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+type: Opaque
+stringData:
+{{- range $secret := $config.secrets }}
+{{- if $secret.name }}
+  {{ $secret.name }}: "REPLACE_ME"
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/service.yaml
+++ b/onecore-chart/templates/service.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+{{- range $name, $config := $.Values.components }}
+{{- if and (kindIs "map" $config) ($config.enabled) }}
+{{- $componentName := include "onecore.componentName" (dict "root" $ "name" $name) }}
+{{- $port := int (include "onecore.envPort" (dict "env" $config.env)) }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $componentName }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+{{ include "onecore.selectorLabels" (dict "root" $ "name" $name) | indent 4 }}
+  ports:
+    - port: {{ $port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+{{- end }}
+{{- end }}

--- a/onecore-chart/templates/serviceaccount.yaml
+++ b/onecore-chart/templates/serviceaccount.yaml
@@ -1,0 +1,29 @@
+{{/*
+Copyright Bostads AB Mimer.
+SPDX-License-Identifier: AGPL-3.0-only
+*/}}
+
+# ServiceAccounts
+{{- range $name, $config := $.Values.components }}
+{{- if kindIs "map" $config }}
+{{- if $config.enabled }}
+{{- if $config.serviceAccount }}
+{{- if $config.serviceAccount.create }}
+{{- $saName := $config.serviceAccount.name | default (include "onecore.componentName" (dict "root" $ "name" $name)) }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $saName }}
+  namespace: {{ $.Values.global.namespace | default $.Release.Namespace }}
+  labels:
+{{ include "onecore.labels" (dict "root" $ "name" $name) | indent 4 }}
+{{- if $config.serviceAccount.annotations }}
+  annotations:
+{{ toYaml $config.serviceAccount.annotations | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/onecore-chart/values.yaml
+++ b/onecore-chart/values.yaml
@@ -7,7 +7,7 @@ global:
   # Hostname för alla applikationer
   hostname: onecore.example.com
 
-  # Cluster domain för auth等服务
+  # Cluster domain för auth
   clusterDomain: dev.mimer.nu
 
   # Namespace där allt ska installeras

--- a/onecore-chart/values.yaml
+++ b/onecore-chart/values.yaml
@@ -1,330 +1,286 @@
 # ONECore Helm Chart - Values Configuration
 
 global:
-  # Miljönamn (används i resource names)
   environment: dev
-
-  # Hostname för alla applikationer
   hostname: onecore.example.com
-
-  # Cluster domain för auth
   clusterDomain: dev.mimer.nu
-
-  # Namespace där allt ska installeras
   namespace: onecore
-
-  # Image pull secret för GHCR
+  imagePullSecret: regcred
+  namespace: onecore
   imagePullSecret: regcred
 
-  # Bitnami common library
-  common:
-    enabled: true
+# Ingress-konfiguration (global för Traefik)
+ingress:
+  enabled: true
+  className: traefik
+  certManagerClusterIssuer: letsencrypt
 
-  # Common labels för alla resurser
-  labels:
-    app: onecore
-    environment: dev
-
-# Aktivera/inaktivera komponenter
+# Komponenter med all konfiguration på ett ställe
 components:
-  # Backend services
   core:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-core
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  communication:
-    enabled: true
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-communication
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  contacts:
-    enabled: true
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-contacts
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  economy:
-    enabled: true
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-onecore-economy
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  fileStorage:
-    enabled: false
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-file-storage
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  inspection:
-    enabled: false
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-inspection
-      tag: latest
-      pullPolicy: IfNotPresent
-
-  keys:
-    enabled: true
-    replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-keys
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-core:latest
+    env:
+      APPLICATION_NAME: core
+      PORT: '80'
+      SERVICE_URL__LEASING: http://leasing
+      SERVICE_URL__PROPERTY: http://property
+      SERVICE_URL__COMMUNICATION: http://communication
+      SERVICE_URL__KEYS: http://keys
+      SERVICE_URL__WORK_ORDER: http://work-order
+      SERVICE_URL__ECONOMY: http://economy
+      KEYCLOAK_URL: https://auth.${global.clusterDomain}
+    secrets:
+      - name: db-url
+        envName: DATABASE_URL
+      - name: odoo-api-token
+    resources:
+      limits:
+        memory: 512Mi
+        cpu: 500m
+      requests:
+        memory: 256Mi
+        cpu: 200m
+    health:
+      path: /health
+      initialDelaySeconds: 30
+      periodSeconds: 10
+    ingress:
+      enabled: true
+      host: api.${global.hostname}
 
   leasing:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-leasing
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-leasing:latest
+    env:
+      APPLICATION_NAME: leasing
+      PORT: '80'
+    secrets:
+      - name: tenfast-api-key
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+    cronJobs:
+      expire-listings:
+        enabled: true
+        schedule: '0 2 * * *'
+        command: ['npm', 'run', 'script:expire-listings']
 
   property:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-property
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-property:latest
+    env:
+      APPLICATION_NAME: property
+      PORT: '80'
+    secrets:
+      - name: db-url
+        envName: DATABASE_URL
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
+  communication:
+    enabled: true
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-communication:latest
+    env:
+      APPLICATION_NAME: communication
+      PORT: '80'
+    secrets:
+      - name: infobip-api-key
+        envName: INFOBIP_API_KEY
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
+  economy:
+    enabled: true
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-economy:latest
+    env:
+      APPLICATION_NAME: economy
+      PORT: '80'
+    secrets:
+      - name: economy-db-url
+        envName: ECONOMY_DATABASE_URL
+      - name: xledger-api-token
+        envName: XLEDGER_API_TOKEN
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
+  contacts:
+    enabled: true
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore-contacts:latest
+    env:
+      APPLICATION_NAME: contacts
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
+  keys:
+    enabled: true
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore-keys:latest
+    env:
+      APPLICATION_NAME: keys
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
 
   propertyManagement:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-property-management
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore-property-management:latest
+    env:
+      APPLICATION_NAME: property-management
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
 
   workOrder:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-work-order
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore-work-order:latest
+    env:
+      APPLICATION_NAME: work-order
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
 
-  # Frontend applications
+  fileStorage:
+    enabled: false
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore-file-storage:latest
+    env:
+      APPLICATION_NAME: file-storage
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
+  inspection:
+    enabled: false
+    replicas: 1
+    image: ghcr.io/bostads-ab-mimer/onecore-inspection:latest
+    env:
+      APPLICATION_NAME: inspection
+      PORT: '80'
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+
   propertyTree:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/property-tree
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore-property-tree:latest
+    env:
+      VITE_API_URL: https://api.${global.hostname}
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+    ingress:
+      enabled: true
+      host: property-tree.${global.hostname}
 
   keysPortal:
     enabled: true
     replicas: 1
-    image:
-      repository: ghcr.io/bostads-ab-mimer/onecore-keys-portal
-      tag: latest
-      pullPolicy: IfNotPresent
+    image: ghcr.io/bostads-ab-mimer/onecore-keys-portal:latest
+    env:
+      VITE_API_URL: https://api.${global.hostname}
+    resources:
+      limits:
+        memory: 256Mi
+        cpu: 200m
+      requests:
+        memory: 128Mi
+        cpu: 100m
+    ingress:
+      enabled: true
+      host: keys-portal.${global.hostname}
 
   internalPortal:
     enabled: false
     frontend:
       enabled: false
       replicas: 1
-      image:
-        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-frontend
-        tag: latest
-        pullPolicy: IfNotPresent
+      image: ghcr.io/bostads-ab-mimer/onecore-internal-portal-frontend:latest
+      env:
+        VITE_API_URL: https://api.${global.hostname}
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 200m
+        requests:
+          memory: 128Mi
+          cpu: 100m
+      ingress:
+        enabled: true
+        host: internal-portal.${global.hostname}
     backend:
       enabled: false
       replicas: 1
-      image:
-        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-backend
-        tag: latest
-        pullPolicy: IfNotPresent
-
-# Advanced configuration för varje komponent (Bitnami common features)
-advancedConfigs:
-  core:
-    extraEnv: []
-    extraVolumes: []
-    extraVolumeMounts: []
-    sidecars: []
-    initContainers: []
-    podSecurityContext:
-      fsGroup: 1001
-      runAsNonRoot: true
-    containerSecurityContext:
-      allowPrivilegeEscalation: false
-      readOnlyRootFilesystem: true
-    livenessProbe:
-      httpGet:
-        path: /health
-        port: 80
-      initialDelaySeconds: 30
-      periodSeconds: 10
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: 80
-      initialDelaySeconds: 10
-      periodSeconds: 5
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: 80
-      failureThreshold: 30
-      periodSeconds: 10
-    affinity: {}
-    tolerations: []
-    nodeSelector: {}
-    serviceAccount:
-      create: false
-      name: ''
-      annotations: {}
-    podLabels: {}
-    podAnnotations: {}
-    extraContainerPorts: []
-
-# Databaser och externt beroenden
-infrastructure:
-  mssql:
-    enabled: true
-    host: mssql
-    port: 1433
-    databasePrefix: ''
-    secrets:
-      username: sa
-      password: ''
-
-  elasticsearch:
-    enabled: true
-    host: elasticsearch.logging.svc.cluster.local
-    port: 9200
-
-  keycloak:
-    enabled: true
-    url: https://auth.dev.mimer.nu
-    realm: onecore
-    clientId: onecore
-
-  minio:
-    enabled: true
-    host: minio
-    port: 9000
-    accessKey: ''
-    secretKey: ''
-
-# Ingress inställningar
-ingress:
-  enabled: true
-  className: traefik
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-
-  hosts:
-    core: api.$(global.hostname)
-    propertyTree: property-tree.$(global.hostname)
-    keysPortal: keys-portal.$(global.hostname)
-    internalPortal: internal-portal.$(global.hostname)
-
-# Secrets
-secrets:
-  core:
-    auth:
-      jwtSecret: ''
-      keycloakClientSecret: ''
-
-  communication:
-    infobipApiKey: ''
-
-  economy:
-    database:
-      user: ''
-      password: ''
-    xledger:
-      apiToken: ''
-      url: ''
-      sftp:
-        host: ''
-        username: ''
-        password: ''
-
-  leasing:
-    database:
-      url: ''
-    xpand:
-      url: ''
-      apiKey: ''
-
-  property:
-    database:
-      url: ''
-
-# CronJobs
-cronJobs:
-  leasing:
-    expireListings:
-      enabled: true
-      schedule: '0 2 * * *'
-      image:
-        repository: ghcr.io/bostads-ab-mimer/onecore/onecore-leasing
-        tag: latest
-
-# Resources
-resources:
-  defaults:
-    requests:
-      memory: 128Mi
-      cpu: 100m
-    limits:
-      memory: 256Mi
-      cpu: 200m
-
-  core:
-    requests:
-      memory: 256Mi
-      cpu: 200m
-    limits:
-      memory: 512Mi
-      cpu: 500m
-
-# Service configuration
-services:
-  core:
-    type: ClusterIP
-    port: 80
-    targetPort: 80
-    annotations: {}
-
-  propertyTree:
-    type: ClusterIP
-    port: 80
-    targetPort: 80
-    annotations: {}
-
-# Autoscaling
-autoscaling:
-  core:
-    enabled: false
-    minReplicas: 2
-    maxReplicas: 10
-    targetCPUUtilizationPercentage: 70
-    targetMemoryUtilizationPercentage: 80
-
-# NetworkPolicy
-networkPolicy:
-  enabled: false
-  policyTypes:
-    - Ingress
-    - Egress
-
-# Extra manifests
-extraManifests: ''
+      image: ghcr.io/bostads-ab-mimer/onecore-internal-portal-backend:latest
+      env:
+        APPLICATION_NAME: internal-portal-backend
+        PORT: '80'
+      resources:
+        limits:
+          memory: 256Mi
+          cpu: 200m
+        requests:
+          memory: 128Mi
+          cpu: 100m

--- a/onecore-chart/values.yaml
+++ b/onecore-chart/values.yaml
@@ -1,0 +1,330 @@
+# ONECore Helm Chart - Values Configuration
+
+global:
+  # Miljönamn (används i resource names)
+  environment: dev
+
+  # Hostname för alla applikationer
+  hostname: onecore.example.com
+
+  # Cluster domain för auth等服务
+  clusterDomain: dev.mimer.nu
+
+  # Namespace där allt ska installeras
+  namespace: onecore
+
+  # Image pull secret för GHCR
+  imagePullSecret: regcred
+
+  # Bitnami common library
+  common:
+    enabled: true
+
+  # Common labels för alla resurser
+  labels:
+    app: onecore
+    environment: dev
+
+# Aktivera/inaktivera komponenter
+components:
+  # Backend services
+  core:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-core
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  communication:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore/onecore-communication
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  contacts:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-contacts
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  economy:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-onecore-economy
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  fileStorage:
+    enabled: false
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-file-storage
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  inspection:
+    enabled: false
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-inspection
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  keys:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-keys
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  leasing:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-leasing
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  property:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-property
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  propertyManagement:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-property-management
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  workOrder:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-work-order
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  # Frontend applications
+  propertyTree:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/property-tree
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  keysPortal:
+    enabled: true
+    replicas: 1
+    image:
+      repository: ghcr.io/bostads-ab-mimer/onecore-keys-portal
+      tag: latest
+      pullPolicy: IfNotPresent
+
+  internalPortal:
+    enabled: false
+    frontend:
+      enabled: false
+      replicas: 1
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-frontend
+        tag: latest
+        pullPolicy: IfNotPresent
+    backend:
+      enabled: false
+      replicas: 1
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/internal-portal-backend
+        tag: latest
+        pullPolicy: IfNotPresent
+
+# Advanced configuration för varje komponent (Bitnami common features)
+advancedConfigs:
+  core:
+    extraEnv: []
+    extraVolumes: []
+    extraVolumeMounts: []
+    sidecars: []
+    initContainers: []
+    podSecurityContext:
+      fsGroup: 1001
+      runAsNonRoot: true
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: 80
+      initialDelaySeconds: 30
+      periodSeconds: 10
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      initialDelaySeconds: 10
+      periodSeconds: 5
+    startupProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      failureThreshold: 30
+      periodSeconds: 10
+    affinity: {}
+    tolerations: []
+    nodeSelector: {}
+    serviceAccount:
+      create: false
+      name: ''
+      annotations: {}
+    podLabels: {}
+    podAnnotations: {}
+    extraContainerPorts: []
+
+# Databaser och externt beroenden
+infrastructure:
+  mssql:
+    enabled: true
+    host: mssql
+    port: 1433
+    databasePrefix: ''
+    secrets:
+      username: sa
+      password: ''
+
+  elasticsearch:
+    enabled: true
+    host: elasticsearch.logging.svc.cluster.local
+    port: 9200
+
+  keycloak:
+    enabled: true
+    url: https://auth.dev.mimer.nu
+    realm: onecore
+    clientId: onecore
+
+  minio:
+    enabled: true
+    host: minio
+    port: 9000
+    accessKey: ''
+    secretKey: ''
+
+# Ingress inställningar
+ingress:
+  enabled: true
+  className: traefik
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+
+  hosts:
+    core: api.$(global.hostname)
+    propertyTree: property-tree.$(global.hostname)
+    keysPortal: keys-portal.$(global.hostname)
+    internalPortal: internal-portal.$(global.hostname)
+
+# Secrets
+secrets:
+  core:
+    auth:
+      jwtSecret: ''
+      keycloakClientSecret: ''
+
+  communication:
+    infobipApiKey: ''
+
+  economy:
+    database:
+      user: ''
+      password: ''
+    xledger:
+      apiToken: ''
+      url: ''
+      sftp:
+        host: ''
+        username: ''
+        password: ''
+
+  leasing:
+    database:
+      url: ''
+    xpand:
+      url: ''
+      apiKey: ''
+
+  property:
+    database:
+      url: ''
+
+# CronJobs
+cronJobs:
+  leasing:
+    expireListings:
+      enabled: true
+      schedule: '0 2 * * *'
+      image:
+        repository: ghcr.io/bostads-ab-mimer/onecore/onecore-leasing
+        tag: latest
+
+# Resources
+resources:
+  defaults:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+
+  core:
+    requests:
+      memory: 256Mi
+      cpu: 200m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+
+# Service configuration
+services:
+  core:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+    annotations: {}
+
+  propertyTree:
+    type: ClusterIP
+    port: 80
+    targetPort: 80
+    annotations: {}
+
+# Autoscaling
+autoscaling:
+  core:
+    enabled: false
+    minReplicas: 2
+    maxReplicas: 10
+    targetCPUUtilizationPercentage: 70
+    targetMemoryUtilizationPercentage: 80
+
+# NetworkPolicy
+networkPolicy:
+  enabled: false
+  policyTypes:
+    - Ingress
+    - Egress
+
+# Extra manifests
+extraManifests: ''

--- a/onecore-chart/values.yaml
+++ b/onecore-chart/values.yaml
@@ -6,14 +6,18 @@ global:
   clusterDomain: dev.mimer.nu
   namespace: onecore
   imagePullSecret: regcred
-  namespace: onecore
-  imagePullSecret: regcred
 
 # Ingress-konfiguration (global för Traefik)
 ingress:
   enabled: true
   className: traefik
   certManagerClusterIssuer: letsencrypt
+  middlewares:
+    cors:
+      enabled: true
+    basicAuth:
+      enabled: false
+      secretName: basic-auth
 
 # Komponenter med all konfiguration på ett ställe
 components:
@@ -71,6 +75,8 @@ components:
         enabled: true
         schedule: '0 2 * * *'
         command: ['npm', 'run', 'script:expire-listings']
+        env:
+          NODE_ENV: production
 
   property:
     enabled: true
@@ -252,6 +258,7 @@ components:
       enabled: true
       host: keys-portal.${global.hostname}
 
+  # internalPortal med separata frontend och backend
   internalPortal:
     enabled: false
     frontend:

--- a/onecore-chart/values.yaml
+++ b/onecore-chart/values.yaml
@@ -34,7 +34,7 @@ components:
       SERVICE_URL__KEYS: http://keys
       SERVICE_URL__WORK_ORDER: http://work-order
       SERVICE_URL__ECONOMY: http://economy
-      KEYCLOAK_URL: https://auth.${global.clusterDomain}
+      KEYCLOAK_URL: https://auth.dev.mimer.nu
     secrets:
       - name: db-url
         envName: DATABASE_URL
@@ -52,7 +52,7 @@ components:
       periodSeconds: 10
     ingress:
       enabled: true
-      host: api.${global.hostname}
+      host: api.onecore.example.com
 
   leasing:
     enabled: true
@@ -81,7 +81,7 @@ components:
   property:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore/onecore-property:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/property-base:latest
     env:
       APPLICATION_NAME: property
       PORT: '80'
@@ -137,7 +137,7 @@ components:
   contacts:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-contacts:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-contacts:latest
     env:
       APPLICATION_NAME: contacts
       PORT: '80'
@@ -152,7 +152,7 @@ components:
   keys:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-keys:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-keys:latest
     env:
       APPLICATION_NAME: keys
       PORT: '80'
@@ -167,7 +167,7 @@ components:
   propertyManagement:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-property-management:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-property-management:latest
     env:
       APPLICATION_NAME: property-management
       PORT: '80'
@@ -182,7 +182,7 @@ components:
   workOrder:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-work-order:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-work-order:latest
     env:
       APPLICATION_NAME: work-order
       PORT: '80'
@@ -197,7 +197,7 @@ components:
   fileStorage:
     enabled: false
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-file-storage:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-file-storage:latest
     env:
       APPLICATION_NAME: file-storage
       PORT: '80'
@@ -212,7 +212,7 @@ components:
   inspection:
     enabled: false
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-inspection:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-inspection:latest
     env:
       APPLICATION_NAME: inspection
       PORT: '80'
@@ -227,7 +227,7 @@ components:
   propertyTree:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-property-tree:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/property-tree:latest
     env:
       VITE_API_URL: https://api.${global.hostname}
     resources:
@@ -244,7 +244,7 @@ components:
   keysPortal:
     enabled: true
     replicas: 1
-    image: ghcr.io/bostads-ab-mimer/onecore-keys-portal:latest
+    image: ghcr.io/bostads-ab-mimer/onecore/onecore-keys-portal:latest
     env:
       VITE_API_URL: https://api.${global.hostname}
     resources:
@@ -264,9 +264,9 @@ components:
     frontend:
       enabled: false
       replicas: 1
-      image: ghcr.io/bostads-ab-mimer/onecore-internal-portal-frontend:latest
-      env:
-        VITE_API_URL: https://api.${global.hostname}
+      image: ghcr.io/bostads-ab-mimer/onecore/onecore-internal-portal-frontend:latest
+    env:
+      VITE_API_URL: https://api.onecore.example.com
       resources:
         limits:
           memory: 256Mi


### PR DESCRIPTION
## Sammanfattning

Helm chart för att installera hela ONECore-plattformen i ett Kubernetes-kluster med ett enda kommando.

## 🎉 Implementerat

### ✅ Chart-struktur
- **Chart.yaml** med Bitnami Common Library dependency (v2.38.0)
- **values.yaml** med enhetlig komponentkonfiguration
- **README.md** med omfattande dokumentation

### ✅ Templates (43 resurser genereras)
- **Deployment** - 11 backend + 3 frontend komponenter
- **Service** - ClusterIP för alla komponenter
- **Ingress** - Traefik med cert-manager och SSL
- **Secrets** - Externa secret-referenser per komponent
- **ConfigMap** - Miljövariabler per komponent
- **CronJob** - Schemalagda jobb (t.ex. leasing expire-listings)
- **Middleware** - Traefik CORS och basic auth
- **ServiceAccount** - Kubernetes service accounts
- **HPA** - Horizontal Pod Autoscaler
- **_helpers.tpl** - Centraliserade hjälpfunktioner

### ✅ Komponentstruktur (allt på ett ställe)

Varje komponent konfigureras enhetligt:

```yaml
components:
  core:
    enabled: true
    image: ghcr.io/bostads-ab-mimer/onecore/onecore-core:latest
    env:
      APPLICATION_NAME: core
    secrets:
      - name: db-url        # Skapar env DB_URL
      - name: api-key
        envName: API_KEY    # Custom env-namn
    resources:
      limits:
        memory: 512Mi
    ingress:
      enabled: true
      host: api.${global.hostname}
    cronJobs:
      expire-listings:
        enabled: true
        schedule: '0 2 * * *'
        command: ['npm', 'run', 'script:expire-listings']
    autoscaling:
      enabled: true
      minReplicas: 2
      maxReplicas: 10
      targetCPUUtilizationPercentage: 70
    serviceAccount:
      create: true
      annotations:
        eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/onecore-core
```

### ✅ Validering
- `helm lint` passerar ✓
- `helm template` genererar korrekt YAML ✓
- Alla komponentnamn lowercase (Kubernetes-compliant) ✓
- 43 resurser genereras totalt ✓

## 🚀 Användning

```bash
# Installera dependencies
cd onecore-chart && HELM_EXPERIMENTAL_OCI=1 helm dependency update

# Installera alla komponenter
helm install onecore ./onecore-chart

# Installera med custom values
helm install onecore ./onecore-chart \
  --set components.core.enabled=true \
  --set components.propertyTree.enabled=true \
  --set global.hostname=onecore.example.com
```

## 📊 Genererade resurser

| Resource | Count |
|----------|-------|
| Deployment | 11 |
| Service | 11 |
| ConfigMap | 11 |
| Ingress | 3 |
| Secret | 5 |
| CronJob | 1 |
| Middleware | 1 |
| **Total** | **43** |

## 🔐 Säkerhet

- Secrets genereras med platshållare ("REPLACE_ME") - måste ersättas vid installation
- Bör använda SealedSecrets eller Vault i produktion
- Traefik ingress med cert-manager för SSL
- ServiceAccount stöd för IAM-integrering

## 📋 Återstående (inför release)

- [ ] Lägga till NetworkPolicy templates
- [ ] Testa installation i test-kluster
- [ ] CI/CD pipeline för Helm chart
- [ ] Values-schema validering