### PR TITLE
MIM-1677 Sammanställning: Remarks summary component

### DIFF
--- a/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
@@ -31,6 +31,7 @@ import { Button } from '@/shared/ui/Button'
 
 import { useInspectionForm } from '../hooks/useInspectionForm'
 import { InspectionInfoSection } from './InspectionInfoSection'
+import { InspectionSummary } from './InspectionSummary'
 import { RoomInspectionEditor } from './RoomInspectionEditor'
 type Inspection = components['schemas']['InternalInspection']
 type InspectionRoom = components['schemas']['InspectionRoom']
@@ -217,9 +218,7 @@ export function InspectionForm({
             <ChevronLeft />
             Tillbaka till rum
           </Button>
-          <div className="p-8 border rounded-lg text-center text-muted-foreground">
-            Sammanställning kommer här
-          </div>
+          <InspectionSummary inspectionData={inspectionData} rooms={rooms} />
           <div
             className="mt-4 p-4 border rounded-lg space-y-3"
             role="radiogroup"

--- a/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
@@ -2,6 +2,7 @@ import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
 
 import { Badge } from '@/shared/ui/Badge'
+import { Input } from '@/shared/ui/Input'
 import {
   Table,
   TableBody,
@@ -38,8 +39,6 @@ function getRoomRemarks(
   })
 }
 
-const EMPTY_CELL = '—'
-
 export function InspectionSummary({
   inspectionData,
   rooms,
@@ -57,12 +56,14 @@ export function InspectionSummary({
     0
   )
 
+  const remarksLabel = totalRemarks === 1 ? 'anmärkning' : 'anmärkningar'
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <header className="border rounded-lg p-4 space-y-1 bg-card">
         <h2 className="text-xl font-semibold">Sammanställning</h2>
         <p className="text-sm text-muted-foreground">
-          {totalRemarks} anmärkningar i {roomSections.length} rum
+          {totalRemarks} {remarksLabel} i {roomSections.length} rum
         </p>
       </header>
 
@@ -78,55 +79,47 @@ export function InspectionSummary({
           className="border rounded-lg p-4 space-y-3 bg-card"
         >
           <h3 className="text-base font-semibold">{room.name}</h3>
-          <div className="border rounded-lg overflow-hidden">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Komponent</TableHead>
-                  <TableHead>Åtgärd</TableHead>
-                  <TableHead>Noteringar</TableHead>
-                  <TableHead>Foton</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {remarks.map((component) => {
-                  const condition = roomData?.conditions[component.key]
-                  const conditionConfig = getConditionConfig(condition)
-                  const actions = roomData?.actions[component.key] ?? []
-                  const note = roomData?.componentNotes[component.key] ?? ''
-                  const photoCount =
-                    roomData?.componentPhotos[component.key]?.length ?? 0
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Komponent</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="w-40">Kostnad (kr)</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {remarks.map((component) => {
+                const condition = roomData?.conditions[component.key]
+                const conditionConfig = getConditionConfig(condition)
 
-                  return (
-                    <TableRow key={component.key}>
-                      <TableCell>
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">
-                            {getComponentLabel(component.key)}
-                          </span>
-                          {conditionConfig && (
-                            <Badge
-                              variant={conditionConfig.badgeVariant}
-                              className={conditionConfig.badgeClassName}
-                            >
-                              {conditionConfig.label}
-                            </Badge>
-                          )}
-                        </div>
-                      </TableCell>
-                      <TableCell>
-                        {actions.length > 0 ? actions.join(', ') : EMPTY_CELL}
-                      </TableCell>
-                      <TableCell>{note || EMPTY_CELL}</TableCell>
-                      <TableCell>
-                        {photoCount > 0 ? `${photoCount} foton` : EMPTY_CELL}
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
-              </TableBody>
-            </Table>
-          </div>
+                return (
+                  <TableRow key={component.key}>
+                    <TableCell className="font-medium">
+                      {getComponentLabel(component.key)}
+                    </TableCell>
+                    <TableCell>
+                      {conditionConfig && (
+                        <Badge
+                          variant={conditionConfig.badgeVariant}
+                          className={conditionConfig.badgeClassName}
+                        >
+                          {conditionConfig.label}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        min={0}
+                        defaultValue={0}
+                        aria-label={`Kostnad för ${getComponentLabel(component.key)}`}
+                      />
+                    </TableCell>
+                  </TableRow>
+                )
+              })}
+            </TableBody>
+          </Table>
         </section>
       ))}
     </div>

--- a/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
@@ -1,0 +1,134 @@
+import type { components } from '@/services/api/core/generated/api-types'
+import type { Room } from '@/services/types'
+
+import { Badge } from '@/shared/ui/Badge'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/shared/ui/Table'
+
+import { CONDITION_TYPE, getConditionConfig } from '../constants/conditions'
+import {
+  ROOM_COMPONENTS,
+  getComponentLabel,
+  type ComponentDefinition,
+} from '../constants/components'
+
+type InspectionRoom = components['schemas']['InspectionRoom']
+
+interface InspectionSummaryProps {
+  inspectionData: Record<string, InspectionRoom>
+  rooms: Room[]
+}
+
+function getRoomRemarks(
+  roomData: InspectionRoom | undefined
+): ComponentDefinition[] {
+  if (!roomData) return []
+  return ROOM_COMPONENTS.filter((component) => {
+    const condition = roomData.conditions[component.key]
+    return (
+      condition === CONDITION_TYPE.ACCEPTABLE ||
+      condition === CONDITION_TYPE.DAMAGED
+    )
+  })
+}
+
+const EMPTY_CELL = '—'
+
+export function InspectionSummary({
+  inspectionData,
+  rooms,
+}: InspectionSummaryProps) {
+  const roomSections = rooms
+    .map((room) => ({
+      room,
+      roomData: inspectionData[room.id],
+      remarks: getRoomRemarks(inspectionData[room.id]),
+    }))
+    .filter((section) => section.remarks.length > 0)
+
+  const totalRemarks = roomSections.reduce(
+    (sum, section) => sum + section.remarks.length,
+    0
+  )
+
+  return (
+    <div className="space-y-6">
+      <header className="border rounded-lg p-4 space-y-1 bg-card">
+        <h2 className="text-xl font-semibold">Sammanställning</h2>
+        <p className="text-sm text-muted-foreground">
+          {totalRemarks} anmärkningar i {roomSections.length} rum
+        </p>
+      </header>
+
+      {roomSections.length === 0 && (
+        <div className="p-8 border rounded-lg text-center text-muted-foreground">
+          Inga anmärkningar registrerade. Alla komponenter är i gott skick.
+        </div>
+      )}
+
+      {roomSections.map(({ room, roomData, remarks }) => (
+        <section
+          key={room.id}
+          className="border rounded-lg p-4 space-y-3 bg-card"
+        >
+          <h3 className="text-base font-semibold">{room.name}</h3>
+          <div className="border rounded-lg overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Komponent</TableHead>
+                  <TableHead>Åtgärd</TableHead>
+                  <TableHead>Noteringar</TableHead>
+                  <TableHead>Foton</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {remarks.map((component) => {
+                  const condition = roomData?.conditions[component.key]
+                  const conditionConfig = getConditionConfig(condition)
+                  const actions = roomData?.actions[component.key] ?? []
+                  const note = roomData?.componentNotes[component.key] ?? ''
+                  const photoCount =
+                    roomData?.componentPhotos[component.key]?.length ?? 0
+
+                  return (
+                    <TableRow key={component.key}>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">
+                            {getComponentLabel(component.key)}
+                          </span>
+                          {conditionConfig && (
+                            <Badge
+                              variant={conditionConfig.badgeVariant}
+                              className={conditionConfig.badgeClassName}
+                            >
+                              {conditionConfig.label}
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        {actions.length > 0 ? actions.join(', ') : EMPTY_CELL}
+                      </TableCell>
+                      <TableCell>{note || EMPTY_CELL}</TableCell>
+                      <TableCell>
+                        {photoCount > 0 ? `${photoCount} foton` : EMPTY_CELL}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements MIM-1677 — replaces the `Sammanställning` placeholder (MIM-1675) with a real `InspectionSummary` component: header with live `X anmärkning(ar) i Y rum` count, per-room tables of non-good components with columns `Komponent | Status | Kostnad (kr)`, and the empty state copy from the card.

Kostnad is a stubbed uncontrolled `<Input type="number">` — **MIM-1678** adds the data model, `useInspectionForm` handler, and persistence, and swaps `defaultValue={0}` for a controlled `value`.

## Branch chain

Based on **MIM-1675 (#507)** — review and merge that first.

## Test plan

- [x] Remarks across 2+ rooms → header count + per-room tables accurate; only non-good components shown
- [x] All God → empty state
- [x] Singular/plural: `1 anmärkning` vs `N anmärkningar`
- [x] `Tillbaka till rum` preserves conditions (Kostnad resets — expected stub)
- [ ] `Slutför besiktning` payload unchanged