### PR TITLE
mim-1690: use only context menu when InspectionMoreMenu is used in mobile

### DIFF
--- a/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
@@ -248,7 +248,7 @@ export function InspectionForm({
       {/* Footer buttons */}
 
       <div className="flex gap-3 justify-between pt-4 border-t">
-        <InspectionMoreMenu rentalId={rentalId} />
+        <InspectionMoreMenu rentalId={rentalId} variant="buttons" />
         <div className="flex gap-3">
           <Button variant="outline" onClick={onCancel}>
             Avbryt

--- a/apps/property-tree/src/features/inspections/ui/InspectionMoreMenu.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionMoreMenu.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { MoreHorizontal } from 'lucide-react'
+import { FileImage, MoreHorizontal, Plus } from 'lucide-react'
 
 import { Button } from '@/shared/ui/Button'
 import {
@@ -22,11 +22,16 @@ import { Label } from '@/shared/ui/Label'
 interface InspectionMoreMenuProps {
   rentalId?: string
   onAddRoom?: (name: string) => void
+  // `menu` renders a single icon trigger with a dropdown — used on mobile
+  // where the bottom bar is tight. `buttons` renders each action as its own
+  // labeled button, used on desktop where there is room for captions.
+  variant?: 'menu' | 'buttons'
 }
 
 export function InspectionMoreMenu({
   rentalId,
   onAddRoom,
+  variant = 'menu',
 }: InspectionMoreMenuProps) {
   const [showFloorplan, setShowFloorplan] = useState(false)
   const [showAddRoom, setShowAddRoom] = useState(false)
@@ -42,30 +47,45 @@ export function InspectionMoreMenu({
 
   return (
     <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="outline" size="icon">
-            <MoreHorizontal className="h-4 w-4" />
-            <span className="sr-only">Fler alternativ</span>
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent side="top" align="start">
-          <DropdownMenuItem
-            onSelect={() => setShowFloorplan(true)}
-            className="py-3 text-base"
-          >
+      {variant === 'buttons' ? (
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setShowFloorplan(true)}>
+            <FileImage className="h-4 w-4" />
             Se planritning
-          </DropdownMenuItem>
+          </Button>
           {onAddRoom && (
+            <Button variant="outline" onClick={() => setShowAddRoom(true)}>
+              <Plus className="h-4 w-4" />
+              Lägg till rum/utrymme
+            </Button>
+          )}
+        </div>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="icon">
+              <MoreHorizontal className="h-4 w-4" />
+              <span className="sr-only">Fler alternativ</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="top" align="start">
             <DropdownMenuItem
-              onSelect={() => setShowAddRoom(true)}
+              onSelect={() => setShowFloorplan(true)}
               className="py-3 text-base"
             >
-              Lägg till rum/utrymme
+              Se planritning
             </DropdownMenuItem>
-          )}
-        </DropdownMenuContent>
-      </DropdownMenu>
+            {onAddRoom && (
+              <DropdownMenuItem
+                onSelect={() => setShowAddRoom(true)}
+                className="py-3 text-base"
+              >
+                Lägg till rum/utrymme
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       {/* Floorplan Dialog */}
       <Dialog open={showFloorplan} onOpenChange={setShowFloorplan}>

--- a/apps/property-tree/src/shared/ui/Dialog.tsx
+++ b/apps/property-tree/src/shared/ui/Dialog.tsx
@@ -29,14 +29,26 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    // Override for the internal DialogOverlay className. Needed when rendering
+    // a Dialog from inside a higher-z container (e.g. a mobile Sheet) so the
+    // dim backdrop can be bumped above it.
+    overlayClassName?: string
+  }
 >(
   (
-    { className, children, onInteractOutside, onPointerDownOutside, ...props },
+    {
+      className,
+      overlayClassName,
+      children,
+      onInteractOutside,
+      onPointerDownOutside,
+      ...props
+    },
     ref
   ) => (
     <DialogPortal>
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         ref={ref}
         onInteractOutside={(e) => {

--- a/apps/property-tree/src/shared/ui/Dialog.tsx
+++ b/apps/property-tree/src/shared/ui/Dialog.tsx
@@ -29,26 +29,14 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
-    // Override for the internal DialogOverlay className. Needed when rendering
-    // a Dialog from inside a higher-z container (e.g. a mobile Sheet) so the
-    // dim backdrop can be bumped above it.
-    overlayClassName?: string
-  }
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(
   (
-    {
-      className,
-      overlayClassName,
-      children,
-      onInteractOutside,
-      onPointerDownOutside,
-      ...props
-    },
+    { className, children, onInteractOutside, onPointerDownOutside, ...props },
     ref
   ) => (
     <DialogPortal>
-      <DialogOverlay className={overlayClassName} />
+      <DialogOverlay />
       <DialogPrimitive.Content
         ref={ref}
         onInteractOutside={(e) => {


### PR DESCRIPTION
Otherwise use a regular button row..

Changes to work in https://github.com/Bostads-AB-Mimer/onecore/pull/513 :)