### PR TITLE
Fix bug in debt collection invoice row aggregation

### DIFF
--- a/services/economy/src/services/debt-collection-service/service.ts
+++ b/services/economy/src/services/debt-collection-service/service.ts
@@ -404,8 +404,8 @@ export const aggregateRows = (rows: RentInvoiceRow[]): RentInvoiceRow[] => {
       }
 
       groups.push(currentGroup)
-    } else if (row.printGroup === null) {
-      // No printgroup, do not group
+    } else {
+      // No printgroup or printgroup without header row, do not group
       groups.push([row])
       i++
     }

--- a/services/economy/test/services/debt-collection-service/service.test.ts
+++ b/services/economy/test/services/debt-collection-service/service.test.ts
@@ -173,25 +173,31 @@ describe('Debt Collection Service', () => {
         // Second group with printGroup 'A'
         createMockRentInvoiceRow({ printGroup: 'A', amount: 100 }),
         createMockRentInvoiceRow({ printGroup: 'A', amount: 200 }),
+        // Row with other printGroup (ungrouped)
+        createMockRentInvoiceRow({ printGroup: 'B', amount: 400 }),
         // Row with null printGroup (ungrouped)
-        createMockRentInvoiceRow({ printGroup: null, amount: 300 }),
+        createMockRentInvoiceRow({ printGroup: null, amount: 500 }),
       ]
 
       const aggregated = aggregateRows(rows)
 
-      expect(aggregated).toHaveLength(3)
+      expect(aggregated).toHaveLength(4)
 
       // First group should sum amount + reduction
-      expect(aggregated[0].amount).toBe(1100) // 1000 + 0 + 100
+      expect(aggregated[0].amount).toBe(1100)
       expect(aggregated[0].printGroup).toBe('N')
 
       // Second group
-      expect(aggregated[1].amount).toBe(300) // 100 + 200
+      expect(aggregated[1].amount).toBe(300)
       expect(aggregated[1].printGroup).toBe('A')
 
       // Ungrouped row
-      expect(aggregated[2].amount).toBe(300)
-      expect(aggregated[2].printGroup).toBe(null)
+      expect(aggregated[2].amount).toBe(400)
+      expect(aggregated[2].printGroup).toBe('B')
+
+      // Ungrouped row
+      expect(aggregated[3].amount).toBe(500)
+      expect(aggregated[3].printGroup).toBe(null)
     })
 
     it('should handle partially paid invoices correctly', async () => {


### PR DESCRIPTION
Det kom in en faktura som hade en fakturarad som hade en printgroup men ingen tillhörande "rubrikrad", vilket fick en while-loop att fastna, trots min kommentar om att "We should rewrite this when we have time".