### PR TITLE
mim-1703: Fix url linking to odoo

### DIFF
--- a/apps/property-tree/src/features/maintenance-units/ui/MaintenanceUnitsTabContent.tsx
+++ b/apps/property-tree/src/features/maintenance-units/ui/MaintenanceUnitsTabContent.tsx
@@ -1,10 +1,9 @@
 import { Link } from 'react-router-dom'
 import { ChevronRight, FilePlus, Wrench } from 'lucide-react'
 
-import { linkToOdooCreateMaintenanceRequestForContext } from '@/shared/lib/odooUtils'
-
 import type { MaintenanceUnit } from '@/services/types'
 
+import { linkToOdooCreateMaintenanceRequestForContext } from '@/shared/lib/odooUtils'
 import { paths } from '@/shared/routes'
 import { ContextType } from '@/shared/types/ui'
 import {

--- a/apps/property-tree/src/features/work-orders/ui/WorkOrdersTabContent.tsx
+++ b/apps/property-tree/src/features/work-orders/ui/WorkOrdersTabContent.tsx
@@ -4,7 +4,6 @@ import {
   linkToOdooCreateMaintenanceRequestForContext,
   type WorkOrderMetadata,
 } from '@/shared/lib/odooUtils'
-
 import { ContextType } from '@/shared/types/ui'
 import { Button } from '@/shared/ui/Button'
 import { TabLayout } from '@/shared/ui/layout/TabLayout'

--- a/apps/property-tree/src/features/work-orders/ui/WorkOrdersTable.tsx
+++ b/apps/property-tree/src/features/work-orders/ui/WorkOrdersTable.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 
-import { linkToWorkOrderInOdoo } from '@/shared/lib/odooUtils'
-
 import { WorkOrder } from '@/services/api/core'
 
+import { linkToWorkOrderInOdoo } from '@/shared/lib/odooUtils'
 import { Badge } from '@/shared/ui/Badge'
 import { Button } from '@/shared/ui/Button'
 import { ResponsiveTable } from '@/shared/ui/ResponsiveTable'

--- a/apps/property-tree/src/shared/lib/odooUtils.ts
+++ b/apps/property-tree/src/shared/lib/odooUtils.ts
@@ -7,7 +7,7 @@ interface OdooLinkableWorkOrder {
 }
 
 const ODOO_URL = resolve('VITE_ODOO_URL', '')
-const CREATE_MAINTENANCE_REQUEST_URL = `${ODOO_URL}/web#action=onecore_maintenance_extension.action_maintenance_request_create`
+const CREATE_MAINTENANCE_REQUEST_FROM_URL = `${ODOO_URL}/odoo/maintenance_create_from_url`
 const WINDOW_OPEN_TARGET = '_blank'
 const WINDOW_OPEN_FEATURES = 'noopener,noreferrer'
 
@@ -23,22 +23,6 @@ export const linkToWorkOrderInOdoo = (order: OdooLinkableWorkOrder) => {
   window.open(
     ODOO_URL +
       `/web#id=${workOrderId}&model=maintenance.request&view_type=form`,
-    WINDOW_OPEN_TARGET,
-    WINDOW_OPEN_FEATURES
-  )
-}
-
-export const linkToOdooCreateMaintenanceRequestForContactCode = (
-  contactCode: string
-) => {
-  const context = {
-    default_search_type: 'contactCode',
-    default_search_by_number: contactCode,
-  }
-
-  // Append "context" parameter to the URL to prefill the contact code and set the search type
-  window.open(
-    `${CREATE_MAINTENANCE_REQUEST_URL}&context=${encodeURIComponent(JSON.stringify(context))}`,
     WINDOW_OPEN_TARGET,
     WINDOW_OPEN_FEATURES
   )
@@ -163,19 +147,11 @@ export const linkToOdooCreateMaintenanceRequestForContext = (
 
   if (context) {
     window.open(
-      `${CREATE_MAINTENANCE_REQUEST_URL}&context=${encodeURIComponent(
+      `${CREATE_MAINTENANCE_REQUEST_FROM_URL}?context=${encodeURIComponent(
         JSON.stringify(context)
       )}`,
       WINDOW_OPEN_TARGET,
       WINDOW_OPEN_FEATURES
     )
   }
-}
-
-export const linkToOdooCreateMaintenanceRequest = () => {
-  window.open(
-    CREATE_MAINTENANCE_REQUEST_URL,
-    WINDOW_OPEN_TARGET,
-    WINDOW_OPEN_FEATURES
-  )
 }


### PR DESCRIPTION
Needed to restructure how we call odoo because of odoo 19 upgrade. Context needs to be passed differently.

Requires this change in odoo-onecore to be merged first:
https://github.com/Bostads-AB-Mimer/onecore-odoo/pull/241

How to test:

1. Go to the work order tab for building, residence, staircase etc. and press "skapa ärende" button. 
2. Check if you are redirected to odoo with the correct information pre-filled in the form.. Utrymme should be set as well as the search value for example:
<img width="827" height="143" alt="Screenshot 2026-04-20 at 15 09 19" src="https://github.com/user-attachments/assets/629971df-7764-45b0-b2cb-35acabbb178d" />
