### PR TITLE
Feature/mim 1683 spara besiktningsdata per komponent i besiktningsflode

### DIFF
--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -3,9 +3,8 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/auth/generatehash": {
+  '/auth/generatehash': {
     /**
      * Generates a salt and hashes the given password using that salt.
      * @description Generates a salt and hashes the given password using that salt. Pass cleartext password as query parameter.
@@ -14,18 +13,18 @@ export interface paths {
       parameters: {
         query: {
           /** @description The cleartext password that should be hashed */
-          password: string;
-        };
-      };
+          password: string
+        }
+      }
       responses: {
         /** @description Hashed password and salt */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/generatetoken": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/generatetoken': {
     /**
      * Generates a JWT token
      * @description Validates username and password from request body and returns a JWT token.
@@ -33,41 +32,41 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/x-www-form-urlencoded": {
-            username?: string;
-            password?: string;
-          };
-        };
-      };
+          'application/x-www-form-urlencoded': {
+            username?: string
+            password?: string
+          }
+        }
+      }
       responses: {
         /** @description A valid JWT token */
         200: {
           content: {
-            "application/json": {
-              token?: string;
-            };
-          };
-        };
+            'application/json': {
+              token?: string
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
-              errorMessage?: string;
-            };
-          };
-        };
+            'application/json': {
+              errorMessage?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/auth/login": {
+            'application/json': {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/auth/login': {
     /**
      * Redirects to Keycloak login
      * @description Redirects the user to the Keycloak login page
@@ -76,12 +75,12 @@ export interface paths {
       responses: {
         /** @description Redirect to Keycloak login */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/callback": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/callback': {
     /**
      * OAuth callback endpoint
      * @description Handles the OAuth callback from Keycloak
@@ -89,21 +88,21 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            code?: string;
-            redirectUri?: string;
-          };
-        };
-      };
+          'application/json': {
+            code?: string
+            redirectUri?: string
+          }
+        }
+      }
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/logout": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/logout': {
     /**
      * Logout endpoint
      * @description Clears authentication cookies and redirects to Keycloak logout
@@ -112,12 +111,12 @@ export interface paths {
       responses: {
         /** @description Redirect to login page */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/profile": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/profile': {
     /**
      * Get user profile
      * @description Returns the authenticated user's profile information
@@ -126,16 +125,16 @@ export interface paths {
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/refresh": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/refresh': {
     /**
      * Refresh access token
      * @description Uses refresh_token cookie to get new access_token
@@ -144,16 +143,16 @@ export interface paths {
       responses: {
         /** @description Token refreshed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid or expired refresh token */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/roles/{roleName}/users": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/roles/{roleName}/users': {
     /**
      * Get users by realm role (via group membership)
      * @description Returns all users that belong to groups assigned the given Keycloak realm role. Users are deduplicated across groups.
@@ -162,46 +161,44 @@ export interface paths {
       parameters: {
         path: {
           /** @description The name of the Keycloak realm role */
-          roleName: string;
-        };
-      };
+          roleName: string
+        }
+      }
       responses: {
         /** @description List of users with the given role */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeycloakUser"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeycloakUser'][]
+            }
+          }
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Forbidden — insufficient permissions to query role members */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Role not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Keycloak unreachable */
         502: {
-          content: never;
-        };
-      };
-    };
-  };
-  "openapi": {
-  };
-  "security": {
-  };
-  "/sendBulkSms": {
+          content: never
+        }
+      }
+    }
+  }
+  openapi: {}
+  security: {}
+  '/sendBulkSms': {
     /**
      * Send SMS to multiple contacts
      * @description Send SMS messages to multiple phone numbers
@@ -209,35 +206,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of phone numbers */
-            phoneNumbers: string[];
+            phoneNumbers: string[]
             /** @description SMS message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description SMS sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkSmsResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkSmsResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/sendBulkEmail": {
+          content: never
+        }
+      }
+    }
+  }
+  '/sendBulkEmail': {
     /**
      * Send email to multiple contacts
      * @description Send email messages to multiple email addresses
@@ -245,37 +242,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of email addresses */
-            emails: string[];
+            emails: string[]
             /** @description Email subject */
-            subject: string;
+            subject: string
             /** @description Email message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description Email sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkEmailResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkEmailResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearTickets": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearTickets': {
     /**
      * Get Linear tickets with mimer-visible label
      * @description Fetch Linear issues that have the mimer-visible label
@@ -284,24 +281,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of tickets to fetch */
-          first?: number;
+          first?: number
           /** @description Cursor for pagination */
-          after?: string;
-        };
-      };
+          after?: string
+        }
+      }
       responses: {
         /** @description Linear tickets fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/createLinearErrand": {
+          content: never
+        }
+      }
+    }
+  }
+  '/createLinearErrand': {
     /**
      * Create a new Linear errand
      * @description Create a new issue in Linear with specified team, project, and labels
@@ -309,33 +306,33 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Errand title */
-            title: string;
+            title: string
             /** @description Errand description */
-            description: string;
+            description: string
             /** @description Label ID for category (Bug, Improvement, etc.) */
-            categoryLabelId: string;
-          };
-        };
-      };
+            categoryLabelId: string
+          }
+        }
+      }
       responses: {
         /** @description Linear errand created successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearLabels": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearLabels': {
     /**
      * Get Linear category labels
      * @description Fetch available category labels (Bug, Improvement, new feature)
@@ -344,16 +341,16 @@ export interface paths {
       responses: {
         /** @description Linear labels fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/health": {
+          content: never
+        }
+      }
+    }
+  }
+  '/health': {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -363,35 +360,35 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /**
                * @description Name of the system.
                * @example core
                */
-              name?: string;
+              name?: string
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string;
-              subsystems?: ({
-                  /** @description Name of the subsystem. */
-                  name?: string;
-                  /**
-                   * @description Status of the subsystem.
-                   * @enum {string}
-                   */
-                  status?: "active" | "impaired" | "failure" | "unknown";
-                  /** @description Additional details about the subsystem status. */
-                  details?: string;
-                })[];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/search": {
+              status?: string
+              subsystems?: {
+                /** @description Name of the subsystem. */
+                name?: string
+                /**
+                 * @description Status of the subsystem.
+                 * @enum {string}
+                 */
+                status?: 'active' | 'impaired' | 'failure' | 'unknown'
+                /** @description Additional details about the subsystem status. */
+                details?: string
+              }[]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/search': {
     /**
      * Search and filter leases
      * @description Search leases with comprehensive filtering options including text search, object type, status, date ranges, and property hierarchy filters.
@@ -400,64 +397,70 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking)) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
+          buildingManager?: string[]
           /** @description Page number */
-          page?: number;
+          page?: number
           /** @description Items per page */
-          limit?: number;
+          limit?: number
           /** @description Include Upphört (ended) contracts. Excluded by default for performance. */
-          includeEnded?: boolean;
+          includeEnded?: boolean
           /** @description Sort field */
-          sortBy?: "leaseStartDate" | "lastDebitDate" | "leaseId" | "address" | "objectType" | "rentalObjectCode";
+          sortBy?:
+            | 'leaseStartDate'
+            | 'lastDebitDate'
+            | 'leaseId'
+            | 'address'
+            | 'objectType'
+            | 'rentalObjectCode'
           /** @description Sort direction */
-          sortOrder?: "asc" | "desc";
-        };
-      };
+          sortOrder?: 'asc' | 'desc'
+        }
+      }
       responses: {
         /** @description Successfully retrieved lease search results with pagination */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["LeaseSearchResult"][];
-              _meta?: components["schemas"]["PaginationMeta"];
-              _links?: components["schemas"]["PaginationLinks"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['LeaseSearchResult'][]
+              _meta?: components['schemas']['PaginationMeta']
+              _links?: components['schemas']['PaginationLinks'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/building-managers": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/building-managers': {
     /**
      * Get all building managers
      * @description Returns a list of all building managers (Kvartersvärd) with their code, name and district.
@@ -467,23 +470,23 @@ export interface paths {
         /** @description List of building managers */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  name?: string;
-                  district?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                name?: string
+                district?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/parking-space-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/parking-space-types': {
     /**
      * Get all parking space types
      * @description Returns a list of all parking space types (P-platstyper).
@@ -493,22 +496,22 @@ export interface paths {
         /** @description List of parking space types */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/export": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/export': {
     /**
      * Export leases to Excel
      * @description Export lease search results to Excel file. Uses same filters as /leases/search but without pagination.
@@ -517,44 +520,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/from-lease-search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/from-lease-search': {
     /**
      * Get contacts matching lease search filters
      * @description Retrieves contact information for tenants matching the given lease search filters.
@@ -563,48 +566,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ContactInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ContactInfo'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/by-rental-property-id/{rentalPropertyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get leases with related entities for a specific rental property id
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified rental property id.
@@ -613,38 +616,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
+          includeTerminatedLeases?: boolean
           /** @description Whether to include contact information in the response */
-          includeContacts?: boolean;
+          includeContacts?: boolean
           /** @description Whether to include rent information in the response */
-          includeRentInfo?: boolean;
-        };
+          includeRentInfo?: boolean
+        }
         path: {
           /** @description Rental roperty id of the building/residence to fetch leases for. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-pnr/{pnr}': {
     /**
      * Get leases with related entities for a specific Personal Number (PNR)
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
@@ -653,28 +656,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Personal Number (PNR) of the individual to fetch leases for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-contact-code/{contactCode}': {
     /**
      * Get leases with related entities for a specific contact code
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified contact code.
@@ -683,28 +686,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Contact code of the individual to fetch leases for. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/consumer-reports/by-pnr/{pnr}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/consumer-reports/by-pnr/{pnr}': {
     /**
      * Get consumer report for a specific Personal Number (PNR)
      * @description Retrieves credit information and consumer report for the specified Personal Number (PNR).
@@ -713,20 +716,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch credit information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with credit information and consumer report */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/by-pnr/{pnr}': {
     /**
      * Get contact information for a specific Personal Number (PNR)
      * @description Retrieves contact information associated with the specified Personal Number (PNR).
@@ -735,20 +738,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch contact information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/offers": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/offers': {
     /**
      * Get offers for a contact
      * @description Retrieves all offers associated with a specific contact based on the provided contact code.
@@ -757,28 +760,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique code identifying the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with a list of offers for the contact. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description The contact was not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve offers. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/comments": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/comments': {
     /**
      * Get comments for a contact
      * @description Retrieves all comments/notes for a contact from Xpand
@@ -787,57 +790,57 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by comment type. If omitted, returns all comment types. */
-          commentType?: "Standard" | "Sökande";
-        };
+          commentType?: 'Standard' | 'Sökande'
+        }
         path: {
           /**
            * @description The unique code identifying the contact.
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved comments */
         200: {
           content: {
-            "application/json": {
-              content?: ({
-                  contactKey?: string;
-                  contactCode?: string;
-                  commentKey?: string;
-                  id?: number;
-                  commentType?: string | null;
-                  /** @description Array of individual notes parsed from comment text */
-                  notes?: ({
-                      /**
-                       * Format: date
-                       * @description Date in YYYY-MM-DD format
-                       */
-                      date?: string | null;
-                      /** @description Time in HH:MM format */
-                      time?: string | null;
-                      /** @description Author initials (6 letters) or "Notering utan signatur" */
-                      author?: string;
-                      /** @description Note content (plain text) */
-                      text?: string;
-                    })[];
-                  priority?: number | null;
-                  kind?: number | null;
-                })[];
-            };
-          };
-        };
+            'application/json': {
+              content?: {
+                contactKey?: string
+                contactCode?: string
+                commentKey?: string
+                id?: number
+                commentType?: string | null
+                /** @description Array of individual notes parsed from comment text */
+                notes?: {
+                  /**
+                   * Format: date
+                   * @description Date in YYYY-MM-DD format
+                   */
+                  date?: string | null
+                  /** @description Time in HH:MM format */
+                  time?: string | null
+                  /** @description Author initials (6 letters) or "Notering utan signatur" */
+                  author?: string
+                  /** @description Note content (plain text) */
+                  text?: string
+                }[]
+                priority?: number | null
+                kind?: number | null
+              }[]
+            }
+          }
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Create or append to contact comment
      * @description Creates a new comment if none exists for the contact, or appends to existing comment in Xpand
@@ -849,56 +852,56 @@ export interface paths {
            * @description The unique code identifying the contact
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /**
              * @description Plain text content of the note
              * @example Customer contacted regarding lease renewal
              */
-            content: string;
+            content: string
             /**
              * @description Author name or code (1-50 characters)
              * @example DAVLIN
              */
-            author: string;
+            author: string
             /**
              * @description Type of comment. Defaults to 'Standard' if not specified.
              * @default Standard
              * @enum {string}
              */
-            commentType?: "Standard" | "Sökande";
-          };
-        };
-      };
+            commentType?: 'Standard' | 'Sökande'
+          }
+        }
+      }
       responses: {
         /** @description Comment updated successfully (appended to existing comment) */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Comment created successfully (new comment) */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body (validation failed) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/applicants/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/applicants/{contactCode}': {
     /**
      * Get a specific offer for an applicant
      * @description Retrieve details of a specific offer associated with an applicant using contact code and offer ID.
@@ -907,30 +910,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the offer. */
-          offerId: string;
+          offerId: string
           /** @description The unique code identifying the applicant. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Details of the specified offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Offer not found for the specified contact code and offer ID. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}': {
     /**
      * Get offers for a specific listing
      * @description Get all offers for a listing.
@@ -939,24 +942,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description A list of offers. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}/active": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}/active': {
     /**
      * Gets active offer for a specific listing
      * @description Get an offer for a listing.
@@ -965,24 +968,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description The active offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/search': {
     /**
      * Search contacts by name, PNR, contact code, or email
      * @description Search contacts by contact code, personal registration number, name, or email. Supports searching by full name or partial name (e.g., "john smith" or "smith"). Multiple search terms are matched with AND logic. Email search is triggered when query contains "@".
@@ -991,30 +994,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description Search query - can be contact code, personal registration number, name, or email (if query contains "@"). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successful response with search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Contact'][]
+            }
+          }
+        }
         /** @description Bad request. The query parameter 'q' must be a string. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve contacts. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/for-identity-check": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/for-identity-check': {
     /**
      * Get contacts for deceased/protected identity check
      * @description Returns paginated list of person contacts eligible for deceased/protected identity verification. Note - Results are validated using the personnummer package, so the actual count may be fewer than the requested limit if invalid personnummer are filtered out.
@@ -1023,38 +1026,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved contacts for identity check. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["IdentityCheckContact"][];
+            'application/json': {
+              content?: components['schemas']['IdentityCheckContact'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}': {
     /**
      * Get contact by contact code
      * @description Retrieves a contact based on the provided contact code.
@@ -1063,22 +1066,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/tenants/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Contact']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/tenants/by-contact-code/{contactCode}': {
     /**
      * Get tenant by contact code
      * @description Retrieves a tenant based on the provided contact code.
@@ -1087,31 +1090,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant information. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The tenant data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve Tenant information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/by-phone-number/{pnr}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/by-phone-number/{pnr}': {
     /**
      * Get contact by phone number
      * @description Retrieves a contact based on the provided phone number.
@@ -1120,20 +1123,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The phone number used to identify the contact. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/{id}': {
     /**
      * Get lease by ID
      * @description Retrieves lease details along with related entities based on the provided ID.
@@ -1142,22 +1145,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the lease to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested lease and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/accept": {
+            'application/json': {
+              content?: components['schemas']['Lease']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/accept': {
     /**
      * Accept an offer
      * @description Accepts an offer for the contact of the contactCode provided
@@ -1166,22 +1169,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to accept */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer accepted successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to accept the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/deny": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/deny': {
     /**
      * Deny an offer
      * @description Denies an offer
@@ -1190,22 +1193,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to deny */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer denied successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to deny the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/expire": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/expire': {
     /**
      * Expire an offer
      * @description Expires an offer
@@ -1214,22 +1217,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to expire */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer expired successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to expire the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/applicants": {
+          content: never
+        }
+      }
+    }
+  }
+  '/applicants': {
     /**
      * Get applicants by contact code
      * @description Retrieves applicants based on the contact code.
@@ -1238,20 +1241,20 @@ export interface paths {
       parameters: {
         query: {
           /** @description The contact code used to fetch applicants. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}': {
     /**
      * Validate property rental rules for applicant
      * @description Validate property rental rules for an applicant based on contact code and listing ID.
@@ -1260,61 +1263,61 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand rental object code of the property. */
-          rentalObjectCode: number;
-        };
-      };
+          rentalObjectCode: number
+        }
+      }
       responses: {
         /** @description No property rental rules apply to this property. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
+              applicationType?: string
               /** @example No property rental rules applies to this property. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Rental object code is not a parking space. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental object code entity is not a parking space. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the property based on property rental rules. */
         403: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description Listing, property info, or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating property rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating property rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}': {
     /**
      * Validate residential area rental rules for applicant
      * @description Validate residential area rental rules for an applicant based on contact code and district code.
@@ -1323,52 +1326,52 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand district code of the residential area to validate against. */
-          districtCode: string;
-        };
-      };
+          districtCode: string
+        }
+      }
       responses: {
         /** @description Either no residential area rental rules apply or applicant is eligible to apply for parking space. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
-              reason?: string;
-            };
-          };
-        };
+              applicationType?: string
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the listing based on residential area rental rules. */
         403: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant does not have any current or upcoming housing contracts in the residential area. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Listing or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating residential area rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating residential area rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants-with-listings/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants-with-listings/by-contact-code/{contactCode}': {
     /**
      * Get applicants with listings by contact code
      * @description Retrieves applicants along with their listings based on the contact code.
@@ -1377,20 +1380,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch applicants and their associated listings. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants with their listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{contactCode}/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{contactCode}/{listingId}': {
     /**
      * Get applicant by contact code and listing ID
      * @description Retrieves an applicant by their contact code and listing ID.
@@ -1399,22 +1402,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The ID of the listing associated with the applicant. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the applicant. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-manager": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-manager': {
     /**
      * Withdraw applicant by manager
      * @description Withdraws an applicant by the manager using the applicant ID.
@@ -1423,32 +1426,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
-        };
-      };
+          applicantId: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by manager. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by manager. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-user/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-user/{contactCode}': {
     /**
      * Withdraw applicant by user
      * @description Withdraws an applicant by the user identified by contact code and applicant ID.
@@ -1457,34 +1460,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
+          applicantId: string
           /** @description The contact code of the user initiating the withdrawal. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by user. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by user. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile': {
     /**
      * Gets an application profile by contact code
      * @description Retrieve application profile information by contact code.
@@ -1493,31 +1496,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/admin": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/admin': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1526,41 +1529,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/client": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/client': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1569,41 +1572,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/{rentalObjectCode}/verify-application": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/{rentalObjectCode}/verify-application': {
     /**
      * Validate max num residents.
      * @description Checks if application is allowed based on current number of residents.
@@ -1612,32 +1615,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
+          contactCode: string
           /** @description The rental object code associated with the rental property. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Application allowed. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Application not allowed. */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings': {
     /**
      * Get listings
      * @description Retrieves a list of listings.
@@ -1646,28 +1649,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The listing category, either PARKING_SPACE, APARTMENT or STORAGE. */
-          listingCategory?: string;
+          listingCategory?: string
           /** @description true for published listings, false for unpublished listings. */
-          published?: boolean;
+          published?: boolean
           /** @description The rental rule for the listings, either SCORED or NON_SCORED. */
-          rentalRule?: string;
+          rentalRule?: string
           /** @description A contact code to filter out listings that are not valid to rent for the contact. */
-          validToRentForContactCode?: string;
+          validToRentForContactCode?: string
           /** @description A Rental Object Code to filter the listings. */
-          rentalObjectCode?: string;
-        };
-      };
+          rentalObjectCode?: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested list of listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}': {
     /**
      * Delete a Listing by ID
      * @description Deletes a listing by it's ID.
@@ -1676,31 +1679,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description Successfully deleted listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Conflict. */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/status": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/status': {
     /**
      * Update a listings status by ID
      * @description Updates a listing status by it's ID.
@@ -1709,36 +1712,36 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/offers": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/offers': {
     /**
      * Create an offer for a listing
      * @description Creates an offer for the specified listing.
@@ -1747,22 +1750,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to create an offer for. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Offer creation successful. */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/applicants/details": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/applicants/details': {
     /**
      * Get listing by ID with detailed applicants
      * @description Retrieves a listing by ID along with detailed information about its applicants.
@@ -1771,20 +1774,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to fetch along with detailed applicant information. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the listing with detailed applicant information. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{id}': {
     /**
      * Get listing by ID
      * @description Retrieves details of a listing based on the provided ID.
@@ -1793,20 +1796,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested listing details. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings-with-applicants": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings-with-applicants': {
     /**
      * Get listings with applicants
      * @description Retrieves a list of listings along with their associated applicants.
@@ -1815,24 +1818,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filters listings by one of the above types. Must be one of the specified values. */
-          type?: "published" | "ready-for-offer" | "offered" | "historical";
-        };
-      };
+          type?: 'published' | 'ready-for-offer' | 'offered' | 'historical'
+        }
+      }
       responses: {
         /** @description Successful response with listings and their applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>[];
-          };
-        };
+            'application/json': Record<string, never>[]
+          }
+        }
         /** @description Internal server error. Failed to retrieve listings with applicants. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/batch": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/batch': {
     /**
      * Create multiple listings
      * @description Create multiple listings in a single request.
@@ -1840,48 +1843,54 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            listings: ({
-                rentalObjectCode: string;
-                /** Format: date-time */
-                publishedFrom: string;
-                /** Format: date-time */
-                publishedTo: string;
-                /** @enum {string} */
-                status: "ACTIVE" | "INACTIVE" | "CLOSED" | "ASSIGNED" | "EXPIRED" | "NO_APPLICANTS";
-                /** @enum {string} */
-                rentalRule: "SCORED" | "NON_SCORED";
-                /** @enum {string} */
-                listingCategory: "PARKING_SPACE" | "APARTMENT" | "STORAGE";
-              })[];
-          };
-        };
-      };
+          'application/json': {
+            listings: {
+              rentalObjectCode: string
+              /** Format: date-time */
+              publishedFrom: string
+              /** Format: date-time */
+              publishedTo: string
+              /** @enum {string} */
+              status:
+                | 'ACTIVE'
+                | 'INACTIVE'
+                | 'CLOSED'
+                | 'ASSIGNED'
+                | 'EXPIRED'
+                | 'NO_APPLICANTS'
+              /** @enum {string} */
+              rentalRule: 'SCORED' | 'NON_SCORED'
+              /** @enum {string} */
+              listingCategory: 'PARKING_SPACE' | 'APARTMENT' | 'STORAGE'
+            }[]
+          }
+        }
+      }
       responses: {
         /** @description All listings created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Partial success. Some listings created, some failed. */
         207: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request. Invalid input data. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create listings. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/vacant-parkingspaces": {
+          content: never
+        }
+      }
+    }
+  }
+  '/vacant-parkingspaces': {
     /**
      * Get all vacant parking spaces
      * @description Retrieves a list of all vacant parking spaces.
@@ -1891,39 +1900,39 @@ export interface paths {
         /** @description A list of vacant parking spaces. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve vacant parking spaces. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-objects/by-code/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-objects/by-code/{rentalObjectCode}': {
     /**
      * Get a rental object by code
      * @description Fetches a rental object by Rental Object Code.
@@ -1932,46 +1941,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the rental object to fetch. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rental object. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to fetch rental object. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listing-text-content/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listing-text-content/{rentalObjectCode}': {
     /**
      * Get listing text content by rental object code
      * @description Fetch the listing text content for a specific rental object.
@@ -1980,28 +1989,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to fetch text content for. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update listing text content
      * @description Update existing listing text content.
@@ -2010,37 +2019,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to update. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete listing text content
      * @description Delete listing text content.
@@ -2049,26 +2058,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to delete. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listing-text-content": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listing-text-content': {
     /**
      * Create listing text content
      * @description Create new listing text content for a rental object.
@@ -2076,34 +2085,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content already exists for rental object code */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/floorplan": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/floorplan': {
     /**
      * Get floor plan for a rental property
      * @description Returns the floor plan image for the specified rental property.
@@ -2112,100 +2121,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved floor plan image */
         200: {
           content: {
-            "image/jpeg": string;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options": {
+            'image/jpeg': string
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options': {
     /** Get room types with material options by rental property ID */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch room types for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with room types and their material options */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options/{materialOptionId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options/{materialOptionId}': {
     /** Get material option by ID for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material options from */
-          id: string;
+          id: string
           /** @description ID of the material option to fetch */
-          materialOptionId: string;
-        };
-      };
+          materialOptionId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material option */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{apartmentId}/contracts/{contractId}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{apartmentId}/contracts/{contractId}/material-choices': {
     /** Get material choices for a specific apartment and contract */
     get: {
       parameters: {
         path: {
           /** @description ID of the apartment to fetch material choices for */
-          apartmentId: string;
+          apartmentId: string
           /** @description ID of the contract to fetch material choices for */
-          contractId: string;
-        };
-      };
+          contractId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/rooms-with-material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/rooms-with-material-choices': {
     /** Get rooms with material choices for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch rooms with material choices for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested rooms and their material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-choices': {
     /**
      * Get material choices for a specific rental property
      * @description Retrieve material choices associated with a rental property identified by {id}.
@@ -2214,18 +2223,18 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
     /**
      * Save material choices for a rental property
      * @description Saves material choices for a specific rental property.
@@ -2234,25 +2243,25 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to save material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Material choices successfully saved */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/material-choice-statuses": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/material-choice-statuses': {
     /**
      * Get material choice statuses for rental properties
      * @description Retrieves statuses of material choices associated with rental properties. Optionally includes rental property details if specified in query parameter.
@@ -2261,20 +2270,20 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional parameter to include rental property details in response. */
-          includeRentalProperties?: "true";
-        };
-      };
+          includeRentalProperties?: 'true'
+        }
+      }
       responses: {
         /** @description Successful response with material choice statuses */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}': {
     /**
      * Get rental property by ID
      * @description Retrieves details of a rental property based on the provided ID.
@@ -2283,22 +2292,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with rental property details */
         200: {
           content: {
-            "application/json": {
-              data?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/leases": {
+            'application/json': {
+              data?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/leases': {
     /**
      * Create lease for an external parking space
      * @description Creates a new lease for the specified external parking space.
@@ -2307,38 +2316,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the lease is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Lease successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space id is missing. It needs to be passed in the url. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/note-of-interests": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/note-of-interests': {
     /**
      * Create a note of interest for an internal parking space
      * @description Creates a new note of interest for the specified internal parking space.
@@ -2347,38 +2356,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the note of interest is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Note of interest successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Contact code is missing. It needs to be passed in the body (contactCode) */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/by-rental-object-code/{rentalObjectCode}": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/by-rental-object-code/{rentalObjectCode}': {
     /**
      * Get rental property information from Xpand
      * @description Retrieves detailed information about a rental property from Xpand based on the provided rental object code.
@@ -2387,32 +2396,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental object code used to identify the specific rental property in Xpand. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental property information */
         200: {
           content: {
-            "application/json": components["schemas"]["RentalPropertyResponse"];
-          };
-        };
+            'application/json': components['schemas']['RentalPropertyResponse']
+          }
+        }
         /** @description Rental property not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}': {
     /**
      * Get maintenance units for a rental property
      * @description Retrieves maintenance units for a specific rental property, optionally filtered by type.
@@ -2421,22 +2430,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch maintenance units for. */
-          rentalPropertyId: string;
+          rentalPropertyId: string
           /** @description Optional type filter for maintenance units. */
-          type: string;
-        };
-      };
+          type: string
+        }
+      }
       responses: {
         /** @description Successful response with maintenance units */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-contact-code/{contactCode}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-contact-code/{contactCode}': {
     /**
      * Get maintenance units by contact code.
      * @description Returns all maintenance units belonging to a contact code.
@@ -2445,33 +2454,33 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code for which to retrieve maintenance units. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  ok?: boolean;
-                  data?: components["schemas"]["MaintenanceUnit"][];
-                }[];
-            };
-          };
-        };
+                ok?: boolean
+                data?: components['schemas']['MaintenanceUnit'][]
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/work-orders/data/{identifier}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/data/{identifier}': {
     /**
      * Get work order data by different identifiers
      * @description Retrieves work order data along with associated leases based on the provided identifier type.
@@ -2480,50 +2489,55 @@ export interface paths {
       parameters: {
         query: {
           /** @description The type of the identifier used to fetch work order data. */
-          handler: "rentalObjectId" | "leaseId" | "pnr" | "phoneNumber" | "contactCode";
-        };
+          handler:
+            | 'rentalObjectId'
+            | 'leaseId'
+            | 'pnr'
+            | 'phoneNumber'
+            | 'contactCode'
+        }
         path: {
           /** @description The identifier value for fetching work order data. */
-          identifier: string;
-        };
-      };
+          identifier: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order data. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalPropertyId?: string;
-                  leases?: {
-                      leaseId?: string;
-                      rentalPropertyId?: string;
-                    }[];
-                }[];
-            };
-          };
-        };
+                rentalPropertyId?: string
+                leases?: {
+                  leaseId?: string
+                  rentalPropertyId?: string
+                }[]
+              }[]
+            }
+          }
+        }
         /** @description Invalid handler */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid handler */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -2532,34 +2546,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id
      * @description Retrieves work orders based on the provided rental property id.
@@ -2568,34 +2582,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -2604,34 +2618,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -2640,34 +2654,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2676,34 +2690,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -2712,42 +2726,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id from xpand
      * @description Retrieves work orders based on the provided rental property id.
@@ -2756,34 +2770,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders based on the provided property id.
@@ -2792,34 +2806,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders based on the provided building id.
@@ -2828,34 +2842,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2864,42 +2878,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/{code}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/{code}': {
     /**
      * Get work order details by rental property id from xpand
      * @description Retrieves work order details.
@@ -2908,40 +2922,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["XpandWorkOrder"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['XpandWorkOrder']
+            }
+          }
+        }
         /** @description Work order not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders': {
     /**
      * Create a new work order
      * @description Creates a new work order.
@@ -2949,64 +2963,64 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The contact code of the tenant. */
-            ContactCode?: string;
+            ContactCode?: string
             /** @description The rental property ID. */
-            RentalObjectCode?: string;
+            RentalObjectCode?: string
             Rows?: {
-                /** @description The location code of the work order. */
-                LocationCode?: string;
-              }[];
+              /** @description The location code of the work order. */
+              LocationCode?: string
+            }[]
             /** @description Access options for the work order. */
-            AccessOptions?: Record<string, never>;
+            AccessOptions?: Record<string, never>
             /** @description Pet information for the work order. */
-            Pet?: Record<string, never>;
-            Images?: string[];
-          };
-        };
-      };
+            Pet?: Record<string, never>
+            Images?: string[]
+          }
+        }
+      }
       responses: {
         /** @description Successfully created the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order created */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example ContactCode is missing */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Not found. Rental property or active lease not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental property not found */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to create the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to create a new work order */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/update": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/update': {
     /**
      * Update a work order with a message
      * @description Adds a message to the specified work order.
@@ -3015,49 +3029,49 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be updated. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The message to be added to the work order. */
-            message?: string;
-          };
-        };
-      };
+            message?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully added the message to the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message added to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message is missing from the request body */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to add the message to the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to add message to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/close": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/close': {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -3066,32 +3080,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       responses: {
         /** @description Successfully closed the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order with ID {workOrderId} updated successfully */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to close the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-sms": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-sms': {
     /**
      * Send SMS for a work order
      * @description Sends an SMS message to the specified phone number for a work order.
@@ -3099,46 +3113,46 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The phone number to send the SMS to. */
-            phoneNumber?: string;
+            phoneNumber?: string
             /** @description The message to be sent via SMS. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the SMS. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Sms sent to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: phoneNumber and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the SMS. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Unexpected error sending sms to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-email": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-email': {
     /**
      * Send email for a work order
      * @description Sends an email to the specified recipient for a work order.
@@ -3146,48 +3160,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The email address of the recipient. */
-            to?: string;
+            to?: string
             /** @description The subject of the email. */
-            subject?: string;
+            subject?: string
             /** @description The message to be sent in the email. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the email. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Email sent to {to} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: to, subject, and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the email. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to send email to {to}, status: {statusCode} */
-              text?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/by-room/{roomId}": {
+              text?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/by-room/{roomId}': {
     /**
      * Get components by room ID
      * @description Returns all components currently installed in a specific space via their installation records.
@@ -3197,40 +3211,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the room */
-          roomId: string;
-        };
-      };
+          roomId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the components list */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component'][]
+            }
+          }
+        }
         /** @description Room not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Room not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories': {
     /**
      * Get all component categories
      * @description Top-level groupings for building components (e.g., Ventilation, VVS, Vitvaror, Tak). Use categoryId to filter component types.
@@ -3238,21 +3252,21 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?: number;
-          limit?: number;
-        };
-      };
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component categories */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component category
      * @description Creates a new top-level category for organizing component types.
@@ -3260,22 +3274,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories/{id}': {
     /**
      * Get component category by ID
      * @description Returns a single category with its name and metadata.
@@ -3283,24 +3297,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
         /** @description Component category not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component category
      * @description Updates category name or metadata.
@@ -3308,25 +3322,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component category
      * @description Removes a category. Will fail if category has associated types.
@@ -3334,18 +3348,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-types': {
     /**
      * Get all component types
      * @description Specific kinds of components within a category (e.g., Diskmaskin, Värmepump, Takbeläggning). Filter by categoryId to get types for a specific category.
@@ -3354,22 +3368,22 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter types by category ID */
-          categoryId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          categoryId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component types */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component type
      * @description Creates a new type within a category. Requires categoryId.
@@ -3377,22 +3391,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-types/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-types/{id}': {
     /**
      * Get component type by ID
      * @description Returns a single type with its category relationship.
@@ -3400,24 +3414,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
         /** @description Component type not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component type
      * @description Updates type name or category assignment.
@@ -3425,25 +3439,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component type
      * @description Removes a type. Will fail if type has associated subtypes.
@@ -3451,18 +3465,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-subtypes": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-subtypes': {
     /**
      * Get all component subtypes
      * @description Variants of a type with lifecycle data including depreciation price, technical/economic lifespan, and replacement interval. Filter by typeId or subtypeName.
@@ -3471,30 +3485,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter subtypes by type ID */
-          typeId?: string;
+          typeId?: string
           /** @description Search subtypes by name (case-insensitive) */
-          subtypeName?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          subtypeName?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component subtypes */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"][];
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component subtype
      * @description Creates a subtype with lifecycle parameters. Requires typeId.
@@ -3502,22 +3516,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-subtypes/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-subtypes/{id}': {
     /**
      * Get component subtype by ID
      * @description Returns subtype with full lifecycle and cost planning data.
@@ -3525,24 +3539,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component subtype
      * @description Updates subtype specifications or lifecycle data.
@@ -3550,29 +3564,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component subtype
      * @description Removes a subtype. Will fail if subtype has associated models.
@@ -3580,22 +3594,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models': {
     /**
      * Get all component models
      * @description Specific manufacturer products with pricing, warranty, specifications, and dimensions. Filter by subtypeId, manufacturer, or modelName.
@@ -3604,32 +3618,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter models by component type ID */
-          componentTypeId?: string;
+          componentTypeId?: string
           /** @description Filter models by subtype ID */
-          subtypeId?: string;
+          subtypeId?: string
           /** @description Filter models by manufacturer name */
-          manufacturer?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          manufacturer?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component models */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"][];
+            'application/json': {
+              content?: components['schemas']['ComponentModel'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component model
      * @description Creates a manufacturer product entry. Requires subtypeId.
@@ -3637,49 +3651,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/documents/component-models/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/documents/component-models/{id}': {
     /** Get all documents for a component model */
     get: {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}': {
     /**
      * Get component model by ID
      * @description Returns full model details including specs and current pricing.
@@ -3687,24 +3701,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component model
      * @description Updates model pricing, specs, or warranty info.
@@ -3712,29 +3726,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component model
      * @description Removes a model. Will fail if model has associated components.
@@ -3742,22 +3756,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components': {
     /**
      * Get all components
      * @description Physical units with serial numbers and status. Filter by modelId, status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED), or serialNumber.
@@ -3765,31 +3779,31 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          modelId?: string;
-          status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+          modelId?: string
+          status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
           /** @description Search by serial number (case-insensitive partial match) */
-          serialNumber?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          serialNumber?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of components */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
+            'application/json': {
+              content?: components['schemas']['Component'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component
      * @description Registers a new physical unit. Requires modelId and serialNumber.
@@ -3797,22 +3811,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/{id}": {
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/{id}': {
     /**
      * Get component by ID
      * @description Returns full component details including purchase info, warranty dates, and current status.
@@ -3820,24 +3834,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component
      * @description Updates component status, warranty dates, or other attributes.
@@ -3846,29 +3860,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component
      * @description Removes a component record. Automatically deletes associated installation records.
@@ -3876,22 +3890,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-installations": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-installations': {
     /**
      * Get all component installations
      * @description Placement records linking components to property locations (spaceId). A component can be moved between locations over time. Filter by componentId, spaceId, or buildingPartId.
@@ -3899,30 +3913,30 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          componentId?: string;
-          spaceId?: string;
-          buildingPartId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          componentId?: string
+          spaceId?: string
+          buildingPartId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component installations */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"][];
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component installation
      * @description Records a component being installed at a location. Requires componentId and spaceId.
@@ -3930,22 +3944,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-installations/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-installations/{id}': {
     /**
      * Get component installation by ID
      * @description Returns installation record with dates, location, order number, and cost.
@@ -3953,24 +3967,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component installation
      * @description Updates installation details or records deinstallation date.
@@ -3979,29 +3993,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component installation ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component installation
      * @description Removes an installation record.
@@ -4009,22 +4023,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/{id}/upload': {
     /**
      * Upload a file to a component
      * @description Attach photos or documents to a specific component (e.g., installation photos, receipts).
@@ -4033,92 +4047,92 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
+            contentType: string
             /** @description Optional caption for the file */
-            caption?: string;
-          };
-        };
-      };
+            caption?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/component-instances/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/component-instances/{id}': {
     /** Get all documents for a component */
     get: {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/{id}': {
     /** Delete a document by ID */
     delete: {
       parameters: {
         path: {
           /** @description Document ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Document deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Document not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}/upload': {
     /**
      * Upload a document to a component model
      * @description Attach product documentation, manuals, or spec sheets to a model for reference.
@@ -4127,38 +4141,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
-          };
-        };
-      };
+            contentType: string
+          }
+        }
+      }
       responses: {
         /** @description Document uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/analyze-image": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/analyze-image': {
     /**
      * Analyze component image(s) using AI
      * @description Upload photos to identify component type, model, or condition using AI image analysis. Can accept a typeplate/label image, product photo, or both for improved accuracy.
@@ -4166,30 +4180,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["AnalyzeComponentImageRequest"];
-        };
-      };
+          'application/json': components['schemas']['AnalyzeComponentImageRequest']
+        }
+      }
       responses: {
         /** @description Component analysis successful */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["AIComponentAnalysis"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['AIComponentAnalysis']
+            }
+          }
+        }
         /** @description Invalid request (e.g., image too large, missing required fields) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description AI analysis failed */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/processes/add-component": {
+          content: never
+        }
+      }
+    }
+  }
+  '/processes/add-component': {
     /**
      * Add a component with model, instance, and installation
      * @description Unified process to add a component. This handles:
@@ -4205,99 +4219,99 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Model name (used to find existing model or create new one) */
-            modelName: string;
+            modelName: string
             /**
              * Format: uuid
              * @description Subtype ID (must exist)
              */
-            componentSubtypeId: string;
+            componentSubtypeId: string
             /** @description Required if model doesn't exist */
-            manufacturer?: string;
+            manufacturer?: string
             /** @description Required if model doesn't exist */
-            currentPrice?: number;
+            currentPrice?: number
             /** @description Required if model doesn't exist */
-            currentInstallPrice?: number;
+            currentInstallPrice?: number
             /** @description Required if model doesn't exist */
-            modelWarrantyMonths?: number;
-            technicalSpecification?: string;
-            dimensions?: string;
-            coclassCode?: string;
-            serialNumber: string;
-            specifications?: string;
-            additionalInformation?: string;
+            modelWarrantyMonths?: number
+            technicalSpecification?: string
+            dimensions?: string
+            coclassCode?: string
+            serialNumber: string
+            specifications?: string
+            additionalInformation?: string
             /**
              * Format: date-time
              * @description ISO-8601 DateTime format (e.g., 2026-01-01T00:00:00.000Z)
              */
-            warrantyStartDate?: string;
-            componentWarrantyMonths: number;
-            priceAtPurchase: number;
-            depreciationPriceAtPurchase: number;
-            economicLifespan: number;
+            warrantyStartDate?: string
+            componentWarrantyMonths: number
+            priceAtPurchase: number
+            depreciationPriceAtPurchase: number
+            economicLifespan: number
             /** @default 1 */
-            quantity?: number;
+            quantity?: number
             /** @description NCS color code */
-            ncsCode?: string;
+            ncsCode?: string
             /**
              * @default ACTIVE
              * @enum {string}
              */
-            status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+            status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
             /**
              * @description Physical condition of the component (optional)
              * @enum {string|null}
              */
-            condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+            condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
             /** @description Where to install the component */
-            spaceId: string;
+            spaceId: string
             /** @enum {string} */
-            spaceType: "OBJECT" | "PropertyObject";
-            installationDate: string;
-            orderNumber?: string;
-            installationCost: number;
-          };
-        };
-      };
+            spaceType: 'OBJECT' | 'PropertyObject'
+            installationDate: string
+            orderNumber?: string
+            installationCost: number
+          }
+        }
+      }
       responses: {
         /** @description Component added successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                modelCreated?: boolean;
+                modelCreated?: boolean
                 model?: {
-                  id?: string;
-                  modelName?: string;
-                  manufacturer?: string;
-                };
+                  id?: string
+                  modelName?: string
+                  manufacturer?: string
+                }
                 component?: {
-                  id?: string;
-                  serialNumber?: string;
-                  status?: string;
-                };
+                  id?: string
+                  serialNumber?: string
+                  status?: string
+                }
                 installation?: {
-                  id?: string;
-                  spaceId?: string;
-                  installationDate?: string;
-                };
-              };
-            };
-          };
-        };
+                  id?: string
+                  spaceId?: string
+                  installationDate?: string
+                }
+              }
+            }
+          }
+        }
         /** @description Validation error or missing required model fields */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings': {
     /**
      * Get all buildings for a specific property
      * @description Retrieves all buildings associated with a given property code.
@@ -4308,30 +4322,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the property. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the buildings. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings/{id}': {
     /**
      * Get detailed information about a specific building
      * @description Retrieves comprehensive information about a building using its unique building id.
@@ -4342,40 +4356,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique id of the building */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-building-code/{buildingCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-building-code/{buildingCode}': {
     /**
      * Get building by building code
      * @description Retrieves building data by building code
@@ -4384,40 +4398,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-property-code/{propertyCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-property-code/{propertyCode}': {
     /**
      * Get buildings by property code
      * @description Retrieves buildings by property code
@@ -4426,31 +4440,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property to fetch buildings for */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved buildings */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies': {
     /**
      * Get all companies
      * @description Retrieves companies from property base
@@ -4460,24 +4474,24 @@ export interface paths {
         /** @description Successfully retrieved companies */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Company"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Company'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies/{organizationNumber}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies/{organizationNumber}': {
     /**
      * Get detailed information about a specific company
      * @description Retrieves comprehensive information about a company using its organization number.
@@ -4486,40 +4500,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The organization number of the company. */
-          organizationNumber: string;
-        };
-      };
+          organizationNumber: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved company information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CompanyDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['CompanyDetails']
+            }
+          }
+        }
         /** @description Company not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Company not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences': {
     /**
      * Get residences by building code and (optional) staircase code
      * @description Retrieves residences by building code and (optional) staircase code
@@ -4528,41 +4542,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch residences from */
-          buildingCode: string;
+          buildingCode: string
           /** @description Code for the staircase to fetch residences from */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Residence"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Residence'][]
+            }
+          }
+        }
         /** @description Missing building code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties': {
     /**
      * Get properties by company code and (optional) tract
      * @description Retrieves properties by company code and (optional) tract
@@ -4571,41 +4585,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the company that owns the properties. */
-          companyCode: string;
+          companyCode: string
           /** @description Optional filter to get properties in a specific tract. */
-          tract?: string;
-        };
-      };
+          tract?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved properties */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Missing company code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties/search": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties/search': {
     /**
      * Search properties
      * @description Retrieves a list of all real estate properties by name.
@@ -4614,30 +4628,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The search query. */
-          q?: string;
-        };
-      };
+          q?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved list of properties. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/properties/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/properties/{propertyCode}': {
     /**
      * Get property by property code
      * @description Retrieves property by property code
@@ -4646,40 +4660,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved property */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property']
+            }
+          }
+        }
         /** @description Property not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Property not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/by-rental-id/{rentalId}': {
     /**
      * Get residence data by residence rental id
      * @description Retrieves residence data by residence rental id
@@ -4688,40 +4702,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id for the residence to fetch */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residence. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceDetails']
+            }
+          }
+        }
         /** @description Residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Residence not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve residence data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/by-rental-id/{rentalId}': {
     /**
      * Get rental blocks by rental ID
      * @description Retrieves rental blocks by rental ID
@@ -4730,44 +4744,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
-        };
+          active?: boolean
+        }
         path: {
           /** @description Rental id to fetch rental blocks for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlock"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['RentalBlock'][]
+            }
+          }
+        }
         /** @description Rental ID not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental ID not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve rental blocks. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/export": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/export': {
     /**
      * Export rental blocks to Excel
      * @description Generates and downloads an Excel file with all rental blocks matching the filters
@@ -4776,36 +4790,36 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term */
-          q?: string;
+          q?: string
           /** @description Filter by category (supports multiple values) */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter by start date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter by end date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-        };
-      };
+          active?: boolean
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/search': {
     /**
      * Search rental blocks with server-side filtering
      * @description Search and filter rental blocks. Searches by rentalId and address.
@@ -4814,55 +4828,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term (searches rentalId, address) */
-          q?: string;
+          q?: string
           /** @description Comma-separated fields to search (default rentalId,address,propertyName,blockReason) */
-          fields?: string;
+          fields?: string
           /** @description Filter by category (Bostad, Bilplats, Lokal, Förråd) - supports multiple values */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property code/name (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter blocks starting on or after this date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter blocks ending on or before this date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-          page?: number;
-          limit?: number;
-        };
-      };
+          active?: boolean
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully searched rental blocks */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/all": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/all': {
     /**
      * Get all rental blocks (paginated)
      * @description Retrieves all rental blocks for residences across the system with pagination support
@@ -4871,46 +4885,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
+          active?: boolean
           /** @description Page number (1-indexed) */
-          page?: number;
+          page?: number
           /** @description Number of items per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved all rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/block-reasons": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/block-reasons': {
     /**
      * Get all block reasons
      * @description Returns all available block reasons for rental blocks. Used for filtering dropdowns.
@@ -4920,22 +4934,22 @@ export interface paths {
         /** @description Successfully retrieved block reasons */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  id?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                id?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/search': {
     /**
      * Search residences
      * @description Searches for residences by rental object id.
@@ -4944,30 +4958,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental object id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/summary/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/summary/by-building-code/{buildingCode}': {
     /**
      * Get residences by building code, optionally filtered by staircase code.
      * @description Returns all residences belonging to a specific building, optionally filtered by staircase code.
@@ -4976,34 +4990,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
+          staircaseCode?: string
+        }
         path: {
           /** @description The building code of the building. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the residences. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSummary"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSummary'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/staircases": {
+          content: never
+        }
+      }
+    }
+  }
+  '/staircases': {
     /**
      * Get staircases for a building
      * @description Retrieves staircases for a building
@@ -5012,42 +5026,42 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch staircases for */
-          buildingCode: string;
+          buildingCode: string
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved staircases. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Staircase"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Staircase'][]
+            }
+          }
+        }
         /** @description Missing buildingCode */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Missing buildingCode */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rooms": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rooms': {
     /**
      * Get rooms by rental id.
      * @description Returns all rooms belonging to a residence.
@@ -5056,32 +5070,32 @@ export interface paths {
       parameters: {
         query: {
           /** @description The rental id of the residence. */
-          rentalId: string;
+          rentalId: string
           /** @description The code of the room (optional). */
-          roomCode?: string;
-        };
-      };
+          roomCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rooms/by-facility-id/{facilityId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rooms/by-facility-id/{facilityId}': {
     /**
      * Get rooms by facility id.
      * @description Returns all rooms belonging to a facility.
@@ -5090,26 +5104,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The id of the facility. */
-          facilityId: string;
-        };
-      };
+          facilityId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/by-rental-id/{rentalId}': {
     /**
      * Get parking space data by rentalId
      * @description Retrieves parking space data by rentalId
@@ -5118,40 +5132,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id to fetch parking space for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking space. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpace"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpace']
+            }
+          }
+        }
         /** @description Parking space not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve parking space data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-id/{rentalId}': {
     /**
      * Get maintenance units by rental id.
      * @description Returns all maintenance units belonging to a rental property.
@@ -5160,30 +5174,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property for which to retrieve maintenance units. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-building-code/{buildingCode}': {
     /**
      * Get maintenance units by building code.
      * @description Returns all maintenance units belonging to a building.
@@ -5192,30 +5206,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve maintenance units. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-rental-id/{rentalId}': {
     /**
      * Get facility by rental id.
      * @description Returns facility.
@@ -5224,30 +5238,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental id of the facility. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facility. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilityDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilityDetails']
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-property-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-property-code/{code}': {
     /**
      * Get maintenance units by property code.
      * @description Returns all maintenance units belonging to a property.
@@ -5256,30 +5270,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve maintenance units. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-code/{code}': {
     /**
      * Get a maintenance unit by its code
      * @description Returns a single maintenance unit by its unique code.
@@ -5288,30 +5302,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the maintenance unit to retrieve. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance unit. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit']
+            }
+          }
+        }
         /** @description Maintenance unit not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/search': {
     /**
      * Search maintenance units
      * @description Searches for maintenance units by code.
@@ -5320,30 +5334,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (maintenance unit code). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved maintenance units matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-property-code/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-property-code/{propertyCode}': {
     /**
      * Get facilities by property code.
      * @description Returns all facilities belonging to a property.
@@ -5352,30 +5366,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve facilities. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-building-code/{buildingCode}': {
     /**
      * Get facilities by building code.
      * @description Returns all facilities belonging to a building.
@@ -5384,30 +5398,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve facilities. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/search': {
     /**
      * Search facilities
      * @description Searches for facilities by rental id.
@@ -5416,30 +5430,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved facilities matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilitySearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilitySearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/search': {
     /**
      * Search parking spaces
      * @description Searches for parking spaces by rental id.
@@ -5448,30 +5462,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking spaces matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpaceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpaceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/search': {
     /**
      * Omni-search for different entities
      * @description Search for properties, buildings, residences, parking spaces, and maintenance units.
@@ -5487,30 +5501,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query string */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description A list of search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SearchResult'][]
+            }
+          }
+        }
         /** @description Bad request - invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/inspections": {
+          content: never
+        }
+      }
+    }
+  }
+  '/inspections': {
     /**
      * Retrieve inspections from all sources
      * @description Retrieves inspections from both the local database and Xpand, merged with a source indicator per item.
@@ -5519,58 +5533,58 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections from all sources. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["InspectionWithSource"][];
+            'application/json': {
+              content?: components['schemas']['InspectionWithSource'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new inspection
      * @description Creates a new inspection in the local inspection database
@@ -5578,40 +5592,40 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateInspectionRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateInspectionRequest']
+        }
+      }
       responses: {
         /** @description Inspection created successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["DetailedInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['DetailedInspection']
+              }
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/residence/{residenceId}": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from all sources
      * @description Retrieves inspections associated with a specific residence ID from both the local database and Xpand.
@@ -5620,37 +5634,37 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["InspectionWithSource"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['InspectionWithSource'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand': {
     /**
      * Retrieve inspections from Xpand
      * @description Retrieves inspections from Xpand with pagination and status filtering support.
@@ -5659,60 +5673,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Inspection"][];
+            'application/json': {
+              content?: components['schemas']['Inspection'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/residence/{residenceId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from Xpand
      * @description Retrieves inspections associated with a specific residence ID from Xpand.
@@ -5721,46 +5735,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["Inspection"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['Inspection'][]
+              }
+            }
+          }
+        }
         /** @description No inspections found for the specified residence ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}': {
     /**
      * Retrieve an inspection by ID from Xpand
      * @description Retrieves a specific inspection by its ID from Xpand.
@@ -5769,40 +5783,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["DetailedInspection"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['DetailedInspection']
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve the inspection. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}/pdf": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}/pdf': {
     /**
      * Generate PDF protocol for an inspection
      * @description Generates and returns a PDF protocol for a specific inspection by its ID.
@@ -5811,47 +5825,47 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean;
-        };
+          includeCosts?: boolean
+        }
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string;
-              };
-            };
-          };
-        };
+                pdfBase64?: string
+              }
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to generate PDF. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/tenant-contacts": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/tenant-contacts': {
     /**
      * Get tenant contacts for inspection protocol modal
      * @description Retrieves contact information for new and previous tenants to display in confirmation modal before sending protocol
@@ -5860,40 +5874,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant contacts */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["TenantContactsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['TenantContactsResponse']
+            }
+          }
+        }
         /** @description Inspection or residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/send-protocol": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/send-protocol': {
     /**
      * Send inspection protocol to tenant
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous)
@@ -5902,90 +5916,90 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SendProtocolRequest"];
-        };
-      };
+          'application/json': components['schemas']['SendProtocolRequest']
+        }
+      }
       responses: {
         /** @description Protocol sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SendProtocolResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SendProtocolResponse']
+            }
+          }
+        }
         /** @description Invalid request or no contract found */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid request body */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}': {
     /** Get internal inspection by ID including draft room data */
     get: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Internal inspection with draft room data */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["InternalInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['InternalInspection']
+              }
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Update internal inspection
      * @description Updates an internal inspection. Supports updating status (with valid transitions Registrerad → Påbörjad → Genomförd) and/or inspector. At least one field must be provided.
@@ -5994,270 +6008,270 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to update */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateInspectionStatusRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateInspectionStatusRequest']
+        }
+      }
       responses: {
         /** @description Inspection updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["DetailedInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['DetailedInspection']
+              }
+            }
+          }
+        }
         /** @description Invalid request body or invalid status transition */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/draft": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/draft': {
     /** Save inspection draft data (rooms and inspector name) */
     patch: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SaveInspectionDraftRequest"];
-        };
-      };
+          'application/json': components['schemas']['SaveInspectionDraftRequest']
+        }
+      }
       responses: {
         /** @description Draft saved successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/files": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/files': {
     /** List files with optional prefix */
     get: {
       parameters: {
         query?: {
-          prefix?: string;
-        };
-      };
+          prefix?: string
+        }
+      }
       responses: {
         /** @description List of files with metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListFilesResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListFilesResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/upload': {
     /** Upload a file */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["FileUploadRequest"];
-        };
-      };
+          'application/json': components['schemas']['FileUploadRequest']
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUploadResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUploadResponse']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/url": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/url': {
     /** Get presigned URL for file download */
     get: {
       parameters: {
         query?: {
           /** @description URL expiry time in seconds */
-          expirySeconds?: number;
-        };
+          expirySeconds?: number
+        }
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description Presigned URL generated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUrlResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUrlResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/metadata": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/metadata': {
     /** Get file metadata */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileMetadata"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileMetadata']
+            }
+          }
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}': {
     /** Delete a file */
     delete: {
       parameters: {
         path: {
           /** @description Name of the file to delete */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/exists": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/exists': {
     /** Check if file exists */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File existence status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileExistsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileExistsResponse']
+            }
+          }
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/dax/card-owners": {
+          content: never
+        }
+      }
+    }
+  }
+  '/dax/card-owners': {
     /**
      * Search card owners from DAX
      * @description Search for card owners in the DAX access control system
@@ -6266,44 +6280,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by name (rental object ID / object code) */
-          nameFilter?: string;
+          nameFilter?: string
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
+          expand?: string
           /** @description Filter by ID */
-          idfilter?: string;
+          idfilter?: string
           /** @description Filter by attribute */
-          attributeFilter?: string;
+          attributeFilter?: string
           /** @description Select specific attributes to return */
-          selectedAttributes?: string;
+          selectedAttributes?: string
           /** @description Filter by folder */
-          folderFilter?: string;
+          folderFilter?: string
           /** @description Filter by organisation */
-          organisationFilter?: string;
+          organisationFilter?: string
           /** @description Pagination offset */
-          offset?: number;
+          offset?: number
           /** @description Maximum number of results */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Card owners retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwners?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              cardOwners?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Failed to fetch card owners */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/card-owners/{cardOwnerId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/card-owners/{cardOwnerId}': {
     /**
      * Get a specific card owner from DAX
      * @description Retrieve a card owner by ID from the DAX access control system
@@ -6312,38 +6326,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card owner ID */
-          cardOwnerId: string;
-        };
-      };
+          cardOwnerId: string
+        }
+      }
       responses: {
         /** @description Card owner retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwner?: components["schemas"]["CardOwner"];
-            };
-          };
-        };
+            'application/json': {
+              cardOwner?: components['schemas']['CardOwner']
+            }
+          }
+        }
         /** @description Card owner not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card owner */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/cards/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/cards/{cardId}': {
     /**
      * Get a specific card from DAX
      * @description Retrieve a card by ID from the DAX access control system
@@ -6352,38 +6366,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "codes") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card ID */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              card?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              card?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-bundles": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-bundles': {
     /**
      * List key bundles with pagination
      * @description Fetches a paginated list of all key bundles ordered by name.
@@ -6392,28 +6406,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description A paginated list of key bundles. */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key bundle
      * @description Create a new key bundle record.
@@ -6421,30 +6435,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while creating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/search': {
     /**
      * Search key bundles with pagination
      * @description Search key bundles with flexible filtering and pagination.
@@ -6453,35 +6467,35 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. */
-          fields?: string;
-        };
-      };
+          fields?: string
+        }
+      }
       responses: {
         /** @description Paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Invalid search parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-key/{keyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-key/{keyId}': {
     /**
      * Get all bundles containing a specific key
      * @description Returns all bundle records containing the specified key ID
@@ -6490,26 +6504,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to search for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of bundles containing this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}': {
     /**
      * Get key bundle by ID
      * @description Fetch a specific key bundle by its ID.
@@ -6518,28 +6532,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key bundle object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while fetching the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a key bundle
      * @description Delete a key bundle by ID.
@@ -6548,24 +6562,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key bundle deleted successfully. */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while deleting the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a key bundle
      * @description Partially update an existing key bundle.
@@ -6574,39 +6588,39 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while updating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}/keys-with-loan-status": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}/keys-with-loan-status': {
     /**
      * Get keys in bundle with maintenance loan status
      * @description Fetches all keys in a key bundle along with their active maintenance loan information
@@ -6615,30 +6629,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key bundle ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Bundle information and keys with loan status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundleDetailsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundleDetailsResponse']
+            }
+          }
+        }
         /** @description Key bundle not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-contact/{contactCode}/with-loaned-keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-contact/{contactCode}/with-loaned-keys': {
     /**
      * Get key bundles with keys loaned to a contact
      * @description Fetches all key bundles that have keys currently loaned to a specific contact.
@@ -6647,28 +6661,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code (F-number) to find bundles for */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description A list of bundles with loaned keys info. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BundleWithLoanedKeysInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BundleWithLoanedKeysInfo'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events': {
     /**
      * Get all key events
      * @description Returns all key events ordered by creation date.
@@ -6678,19 +6692,19 @@ export interface paths {
         /** @description List of key events. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a key event
      * @description Create a new key event record. Will fail with 409 if any of the keys have an incomplete event (status not COMPLETED).
@@ -6698,43 +6712,43 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Conflict - one or more keys have incomplete events. */
         409: {
           content: {
-            "application/json": {
-              reason?: string;
-              conflictingKeys?: string[];
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+              conflictingKeys?: string[]
+            }
+          }
+        }
         /** @description An error occurred while creating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/by-key/{keyId}': {
     /**
      * Get all key events for a specific key
      * @description Returns all key events associated with a specific key ID. Optionally limit results to get only the latest event(s).
@@ -6743,32 +6757,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional limit on number of results (e.g., 1 for latest event only). */
-          limit?: number;
-        };
+          limit?: number
+        }
         path: {
           /** @description The key ID to filter events by. */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description List of key events for the key. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/{id}': {
     /**
      * Get key event by ID
      * @description Fetch a specific key event by its ID.
@@ -6777,32 +6791,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key event object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key event
      * @description Update an existing key event.
@@ -6811,45 +6825,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans': {
     /**
      * List all key loans
      * @description Fetches a list of all key loans ordered by creation date.
@@ -6859,19 +6873,19 @@ export interface paths {
         /** @description A list of key loans. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key loans. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key loan
      * @description Create a new key loan record.
@@ -6879,34 +6893,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description An error occurred while creating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/search': {
     /**
      * Search key loans
      * @description Search key loans with flexible filtering.
@@ -6919,58 +6933,58 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to contact and contact2. */
-          fields?: string;
+          fields?: string
           /** @description Search by key name or rental object code (requires JOIN with keys table) */
-          keyNameOrObjectCode?: string;
+          keyNameOrObjectCode?: string
           /** @description Minimum number of keys in loan */
-          minKeys?: number;
+          minKeys?: number
           /** @description Maximum number of keys in loan */
-          maxKeys?: number;
+          maxKeys?: number
           /** @description Filter by pickedUpAt null status (true = NOT NULL, false = NULL) */
-          hasPickedUp?: boolean;
+          hasPickedUp?: boolean
           /** @description Filter by returnedAt null status (true = NOT NULL, false = NULL) */
-          hasReturned?: boolean;
-          id?: string;
-          keys?: string;
-          contact?: string;
-          contact2?: string;
-          loanType?: "TENANT" | "MAINTENANCE";
+          hasReturned?: boolean
+          id?: string
+          keys?: string
+          contact?: string
+          contact2?: string
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          returnedAt?: string;
-          availableToNextTenantFrom?: string;
+          returnedAt?: string
+          availableToNextTenantFrom?: string
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          pickedUpAt?: string;
-          createdAt?: string;
-          updatedAt?: string;
-        };
-      };
+          pickedUpAt?: string
+          createdAt?: string
+          updatedAt?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-key/{keyId}': {
     /**
      * Get all loans for a specific key
      * @description Returns all loan records for the specified key ID, ordered by creation date DESC
@@ -6979,28 +6993,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to fetch loans for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-card/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-card/{cardId}': {
     /**
      * Get all loans for a specific card
      * @description Returns all loan records for the specified card ID, ordered by creation date DESC
@@ -7009,23 +7023,23 @@ export interface paths {
       parameters: {
         path: {
           /** @description The card ID to fetch loans for */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this card */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
-        500: components["responses"]["InternalServerError"];
-      };
-    };
-  };
-  "/key-loans/by-rental-object/{rentalObjectCode}": {
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
+        500: components['responses']['InternalServerError']
+      }
+    }
+  }
+  '/key-loans/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key loans by rental object code
      * @description Returns all key loans for a specific rental object with keys and optional receipts
@@ -7034,43 +7048,43 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by contact code */
-          contact?: string;
+          contact?: string
           /** @description Filter by second contact code */
-          contact2?: string;
+          contact2?: string
           /** @description Include receipts in the response */
-          includeReceipts?: boolean;
+          includeReceipts?: boolean
           /**
            * @description Filter by return status:
            * - true: Only returned loans (returnedAt IS NOT NULL)
            * - false: Only active loans (returnedAt IS NULL)
            * - omitted: All loans (no filter)
            */
-          returned?: boolean;
-        };
+          returned?: boolean
+        }
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description A list of key loans with details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-contact/{contact}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-contact/{contact}/with-keys': {
     /**
      * Get key loans by contact with keys
      * @description Returns all key loans for a specific contact with full key details, optionally filtered by loan type and return status
@@ -7079,34 +7093,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
-        };
+          returned?: boolean
+        }
         path: {
           /** @description The contact identifier to search for */
-          contact: string;
-        };
-      };
+          contact: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-bundle/{bundleId}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-bundle/{bundleId}/with-keys': {
     /**
      * Get key loans by bundle with keys
      * @description Returns all key loans for a specific bundle with full key details, optionally filtered by loan type and return status
@@ -7115,34 +7129,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
-        };
+          returned?: boolean
+        }
         path: {
           /** @description The bundle ID to search for */
-          bundleId: string;
-        };
-      };
+          bundleId: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/{id}': {
     /**
      * Get key loan by ID
      * @description Fetch a specific key loan by its ID.
@@ -7155,42 +7169,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description When true, includes keysArray with keySystem data attached to each key. */
-          includeKeySystem?: boolean;
+          includeKeySystem?: boolean
           /** @description When true, includes keyCardsArray with card data from DAX. Auto-implies key fetching. */
-          includeCards?: boolean;
+          includeCards?: boolean
           /** @description When true, includes loan history attached to each key in keysArray. */
-          includeLoans?: boolean;
+          includeLoans?: boolean
           /** @description When true, includes event history attached to each key in keysArray. */
-          includeEvents?: boolean;
-        };
+          includeEvents?: boolean
+        }
         path: {
           /** @description The unique ID of the key loan to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key loan object. Returns KeyLoanWithDetails if includeKeySystem or includeCards is true. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"] | components["schemas"]["KeyLoanWithDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?:
+                | components['schemas']['KeyLoan']
+                | components['schemas']['KeyLoanWithDetails']
+            }
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key loan
      * @description Delete an existing key loan by ID.
@@ -7199,28 +7215,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key loan deleted successfully. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while deleting the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key loan
      * @description Partially update an existing key loan.
@@ -7229,45 +7245,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/{id}': {
     /**
      * Get key note by ID
      * @description Retrieve a specific key note by its ID
@@ -7276,32 +7292,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key note
      * @description Update the description of an existing key note
@@ -7310,45 +7326,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key note by rental object code
      * @description Retrieve the key note for a specific rental object
@@ -7357,34 +7373,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes': {
     /**
      * Create a new key note
      * @description Create a new key note for a rental object
@@ -7392,34 +7408,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems': {
     /**
      * List all key systems with pagination
      * @description Retrieve a paginated list of all key systems
@@ -7428,28 +7444,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated key systems */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key system
      * @description Create a new key system
@@ -7457,34 +7473,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/search': {
     /**
      * Search key systems
      * @description Search key systems with flexible filtering.
@@ -7501,54 +7517,54 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Search query for OR search across fields specified in 'fields' parameter */
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search (e.g., "systemCode,manufacturer"). Defaults to systemCode. */
-          fields?: string;
-          id?: string;
-          systemCode?: string;
-          name?: string;
-          manufacturer?: string;
-          managingSupplier?: string;
-          type?: string;
-          propertyIds?: string;
-          installationDate?: string;
-          isActive?: string;
-          notes?: string;
-          createdAt?: string;
-          updatedAt?: string;
-          createdBy?: string;
-          updatedBy?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          systemCode?: string
+          name?: string
+          manufacturer?: string
+          managingSupplier?: string
+          type?: string
+          propertyIds?: string
+          installationDate?: string
+          isActive?: string
+          notes?: string
+          createdAt?: string
+          updatedAt?: string
+          createdBy?: string
+          updatedBy?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Bad request. Invalid parameters or field names */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}': {
     /**
      * Get key system by ID
      * @description Retrieve a specific key system by its ID
@@ -7557,32 +7573,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key system */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key system
      * @description Delete a key system by ID
@@ -7591,28 +7607,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key system deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key system
      * @description Partially update a key system
@@ -7621,139 +7637,139 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/upload-schema": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/upload-schema': {
     /** Upload a schema file for a key system */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-            fileName?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+            fileName?: string
+          }
+        }
+      }
       responses: {
         /** @description Schema file uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/download-schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/download-schema': {
     /** Get presigned download URL for a key system schema file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": components["schemas"]["SchemaDownloadUrlResponse"];
-          };
-        };
+            'application/json': components['schemas']['SchemaDownloadUrlResponse']
+          }
+        }
         /** @description Key system or schema file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/schema': {
     /** Delete the schema file for a key system */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Schema deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/keys': {
     /**
      * List keys with pagination
      * @description Returns paginated keys ordered by createdAt (desc).
@@ -7762,60 +7778,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Paginated list of keys */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a key */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/search': {
     /**
      * Search keys
      * @description Search keys with flexible filtering.
@@ -7828,48 +7844,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to keyName. */
-          fields?: string;
-          id?: string;
-          keyName?: string;
-          keySequenceNumber?: string;
-          flexNumber?: string;
-          rentalObjectCode?: string;
-          keyType?: string;
-          keySystemId?: string;
-          createdAt?: string;
-          updatedAt?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          keyName?: string
+          keySequenceNumber?: string
+          flexNumber?: string
+          rentalObjectCode?: string
+          keyType?: string
+          keySystemId?: string
+          createdAt?: string
+          updatedAt?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/by-rental-object/{rentalObjectCode}': {
     /**
      * Get all keys by rental object code
      * @description Returns all keys associated with a specific rental object code without pagination
@@ -7878,182 +7894,182 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to filter keys by */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved keys */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/cards/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/cards/by-rental-object/{rentalObjectCode}': {
     /** Get cards by rental object code */
     get: {
       parameters: {
         query?: {
-          includeLoans?: boolean;
-        };
+          includeLoans?: boolean
+        }
         path: {
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Cards for the rental object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CardDetails"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/cards/{cardId}": {
+            'application/json': {
+              content?: components['schemas']['CardDetails'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/cards/{cardId}': {
     /** Get card by ID */
     get: {
       parameters: {
         path: {
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/{id}': {
     /** Get key by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Delete a key */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Deleted */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Update a key (partial) */
     patch: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyRequest']
+        }
+      }
       responses: {
         /** @description Updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update': {
     /**
      * Bulk update keys
      * @description Update multiple keys with the same values. Maximum 100 keys per request.
@@ -8061,35 +8077,35 @@ export interface paths {
     patch: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateKeysRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateKeysRequest']
+        }
+      }
       responses: {
         /** @description Keys updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update-flex": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update-flex': {
     /**
      * Bulk update flex number for all keys on a rental object
      * @description Update the flex number for all keys associated with a specific rental object code. Flex numbers range from 1-3.
@@ -8097,35 +8113,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateFlexRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateFlexRequest']
+        }
+      }
       responses: {
         /** @description Flex numbers updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-delete": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-delete': {
     /**
      * Bulk delete keys
      * @description Delete multiple keys by their IDs. Maximum 100 keys per request.
@@ -8133,37 +8149,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            keyIds: string[];
-          };
-        };
-      };
+          'application/json': {
+            keyIds: string[]
+          }
+        }
+      }
       responses: {
         /** @description Keys deleted successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys deleted */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs': {
     /**
      * List logs with pagination
      * @description Returns paginated logs (most recent per objectId) ordered by eventTime (desc).
@@ -8172,60 +8188,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Paginated list of logs */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a log */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateLogRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateLogRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Invalid or missing fields */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/search': {
     /**
      * Search logs with pagination
      * @description Search logs with flexible filtering and pagination.
@@ -8238,46 +8254,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to objectId. */
-          fields?: string;
-          id?: string;
-          userName?: string;
-          eventType?: string;
-          eventTime?: string;
-          objectType?: string;
-          objectId?: string;
-          description?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          userName?: string
+          eventType?: string
+          eventTime?: string
+          objectType?: string
+          objectId?: string
+          description?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/object/{objectId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/object/{objectId}': {
     /**
      * Get all logs for a specific objectId
      * @description Returns all log entries for a given objectId, ordered by most recent first
@@ -8285,60 +8301,60 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          objectId: string;
-        };
-      };
+          objectId: string
+        }
+      }
       responses: {
         /** @description List of logs for the objectId */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/{id}': {
     /** Get log by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Log found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/rental-object/{rentalObjectCode}': {
     /**
      * Get all logs for a specific rental object
      * @description Returns all log entries for a given rental object code by JOINing across multiple tables.
@@ -8355,40 +8371,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The rental object code (e.g., "705-011-03-0102") */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the rental object */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/contact/{contactId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/contact/{contactId}': {
     /**
      * Get all logs for a specific contact
      * @description Returns all log entries for a given contact code by JOINing across keyLoans and receipts.
@@ -8405,40 +8421,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The contact code (e.g., "P079586", "F123456") */
-          contactId: string;
-        };
-      };
+          contactId: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the contact */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts': {
     /**
      * Create a receipt
      * @description Create a new receipt record for a key loan
@@ -8446,34 +8462,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/{id}': {
     /**
      * Get a receipt by ID
      * @description Retrieve a specific receipt by its ID
@@ -8482,32 +8498,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The receipt ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved receipt */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a receipt
      * @description Delete a receipt by ID (and associated file from MinIO)
@@ -8516,28 +8532,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Receipt deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a receipt
      * @description Update a receipt (e.g., set fileId after upload)
@@ -8546,144 +8562,144 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Receipt updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/by-key-loan/{keyLoanId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/by-key-loan/{keyLoanId}': {
     /** Get receipts by key loan ID */
     get: {
       parameters: {
         path: {
-          keyLoanId: string;
-        };
-      };
+          keyLoanId: string
+        }
+      }
       responses: {
         /** @description Receipts for the key loan */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/upload': {
     /** Upload a file for a receipt */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/download": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/download': {
     /** Get presigned download URL for a receipt file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                url?: string;
-                expiresIn?: number;
-                fileId?: string;
-              };
-            };
-          };
-        };
+                url?: string
+                expiresIn?: number
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Receipt or file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/signatures/send": {
+          content: never
+        }
+      }
+    }
+  }
+  '/signatures/send': {
     /**
      * Send a document for digital signature via SimpleSign
      * @description Send a PDF document to SimpleSign for digital signature
@@ -8691,49 +8707,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @enum {string} */
-            resourceType: "receipt";
+            resourceType: 'receipt'
             /** Format: uuid */
-            resourceId: string;
+            resourceId: string
             /** Format: email */
-            recipientEmail: string;
-            recipientName?: string;
-            pdfBase64: string;
-          };
-        };
-      };
+            recipientEmail: string
+            recipientName?: string
+            pdfBase64: string
+          }
+        }
+      }
       responses: {
         /** @description Signature request sent successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Resource not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/{id}': {
     /**
      * Get a signature by ID
      * @description Retrieve a specific signature by its ID
@@ -8741,34 +8757,34 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Signature details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Signature not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/resource/{resourceType}/{resourceId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/resource/{resourceType}/{resourceId}': {
     /**
      * Get all signatures for a resource
      * @description Retrieve all signatures associated with a specific resource
@@ -8776,29 +8792,29 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          resourceType: "receipt";
-          resourceId: string;
-        };
-      };
+          resourceType: 'receipt'
+          resourceId: string
+        }
+      }
       responses: {
         /** @description List of signatures */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/webhooks/simplesign": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/webhooks/simplesign': {
     /**
      * Webhook endpoint for SimpleSign status updates
      * @description Receives webhook notifications from SimpleSign when document status changes (e.g., signed, declined)
@@ -8806,26 +8822,26 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SimpleSignWebhookPayload"];
-        };
-      };
+          'application/json': components['schemas']['SimpleSignWebhookPayload']
+        }
+      }
       responses: {
         /** @description Webhook processed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Signature not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/v1/contacts": {
+          content: never
+        }
+      }
+    }
+  }
+  '/v1/contacts': {
     /**
      * List and filter(search) for contact information
      * @description Filtering can be done by wildcard search
@@ -8834,4296 +8850,4511 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Wildcard search string */
-          q?: string[];
+          q?: string[]
           /** @description Filter on contact type */
-          type?: "individual" | "organisation";
+          type?: 'individual' | 'organisation'
           /** @description Page number for paginated results (1-based) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              content: components["schemas"]["ContactV1"][];
+            'application/json': {
+              content: components['schemas']['ContactV1'][]
               _meta: {
-                totalRecords: number;
-                page: number;
-                limit: number;
-                count: number;
-              };
-              _links: ({
-                  href: string;
-                  /** @enum {string} */
-                  rel: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords: number
+                page: number
+                limit: number
+                count: number
+              }
+              _links: {
+                href: string
+                /** @enum {string} */
+                rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
         /** @description Internal Server Error */
         500: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}': {
     /** Get a single contact by canonical id (contact code) */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}/trustee": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}/trustee': {
     /** Get the trustee of a contact */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-phone-number/{phoneNumber}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-phone-number/{phoneNumber}': {
     /** List contacts by phone number */
     get: {
       parameters: {
         path: {
           /** @description Phone Number */
-          phoneNumber: string;
-        };
-      };
+          phoneNumber: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-email-address/{emailAddress}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-email-address/{emailAddress}': {
     /** List contacts by email address */
     get: {
       parameters: {
         path: {
           /** @description Email Address */
-          emailAddress: string;
-        };
-      };
+          emailAddress: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-national-id/{nid}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-national-id/{nid}': {
     /** List contacts by national id (Personnummer / Org.nr) */
     get: {
       parameters: {
         path: {
           /** @description National ID */
-          nid: string;
-        };
-      };
+          nid: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
     Lease: {
-      leaseId: string;
-      leaseNumber: string;
+      leaseId: string
+      leaseNumber: string
       /** Format: date-time */
-      leaseStartDate: string;
+      leaseStartDate: string
       /** Format: date-time */
-      leaseEndDate?: string;
+      leaseEndDate?: string
       /** @enum {string} */
-      status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-      tenantContactIds?: string[];
-      rentalPropertyId: string;
+      status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+      tenantContactIds?: string[]
+      rentalPropertyId: string
       rentalProperty?: {
-        rentalPropertyId: string;
-        apartmentNumber: number;
-        size: number;
-        type: string;
+        rentalPropertyId: string
+        apartmentNumber: number
+        size: number
+        type: string
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        rentalPropertyType: string;
-        additionsIncludedInRent: string;
-        otherInfo?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        rentalPropertyType: string
+        additionsIncludedInRent: string
+        otherInfo?: string
         roomTypes?: {
-            roomTypeId: string;
-            name: string;
-          }[];
+          roomTypeId: string
+          name: string
+        }[]
         /** Format: date-time */
-        lastUpdated?: string;
-      };
-      type: string;
+        lastUpdated?: string
+      }
+      type: string
       rentInfo?: {
         currentRent: {
-          rentId?: string;
-          leaseId?: string;
-          currentRent: number;
-          vat: number;
-          additionalChargeDescription?: string;
-          additionalChargeAmount?: number;
+          rentId?: string
+          leaseId?: string
+          currentRent: number
+          vat: number
+          additionalChargeDescription?: string
+          additionalChargeAmount?: number
           /** Format: date-time */
-          rentStartDate?: string;
+          rentStartDate?: string
           /** Format: date-time */
-          rentEndDate?: string;
-        };
-      };
+          rentEndDate?: string
+        }
+      }
       address?: {
-        street?: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      };
-      noticeGivenBy?: string;
+        street?: string
+        number: string
+        postalCode: string
+        city: string
+      }
+      noticeGivenBy?: string
       /** Format: date-time */
-      noticeDate?: string;
-      noticeTimeTenant?: string | number;
+      noticeDate?: string
+      noticeTimeTenant?: string | number
       /** Format: date-time */
-      preferredMoveOutDate?: string;
+      preferredMoveOutDate?: string
       /** Format: date-time */
-      terminationDate?: string;
+      terminationDate?: string
       /** Format: date-time */
-      contractDate?: string;
+      contractDate?: string
       /** Format: date-time */
-      lastDebitDate?: string;
+      lastDebitDate?: string
       /** Format: date-time */
-      approvalDate?: string;
+      approvalDate?: string
       residentialArea?: {
-        code: string;
-        caption: string;
-      };
+        code: string
+        caption: string
+      }
       tenants?: {
-          contactCode: string;
-          contactKey: string;
-          leaseIds?: string[];
-          firstName: string;
-          lastName: string;
-          fullName: string;
-          nationalRegistrationNumber: string;
+        contactCode: string
+        contactKey: string
+        leaseIds?: string[]
+        firstName: string
+        lastName: string
+        fullName: string
+        nationalRegistrationNumber: string
+        /** Format: date-time */
+        birthDate: string
+        address?: {
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        phoneNumbers?: {
+          phoneNumber: string
+          type: string
+          isMainNumber: boolean
+        }[]
+        emailAddress?: string
+        isTenant: boolean
+        parkingSpaceWaitingList?: {
           /** Format: date-time */
-          birthDate: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          phoneNumbers?: {
-              phoneNumber: string;
-              type: string;
-              isMainNumber: boolean;
-            }[];
-          emailAddress?: string;
-          isTenant: boolean;
-          parkingSpaceWaitingList?: {
-            /** Format: date-time */
-            queueTime: string;
-            queuePoints: number;
-            type: number;
-          };
-          specialAttention?: boolean;
-          leaseContactType?: string;
-        }[];
-    };
+          queueTime: string
+          queuePoints: number
+          type: number
+        }
+        specialAttention?: boolean
+        leaseContactType?: string
+      }[]
+    }
     IdentityCheckContact: {
-      contactCode: string;
-      nationalRegistrationNumber: string;
-    };
+      contactCode: string
+      nationalRegistrationNumber: string
+    }
     LeaseSearchResult: {
-      leaseId: string;
-      objectTypeCode: string;
-      leaseType: string;
-      contacts: ({
-          name: string;
-          contactCode: string;
-          email: string | null;
-          phone: string | null;
-        })[];
-      address: string | null;
+      leaseId: string
+      objectTypeCode: string
+      leaseType: string
+      contacts: {
+        name: string
+        contactCode: string
+        email: string | null
+        phone: string | null
+      }[]
+      address: string | null
       /** Format: date-time */
-      startDate: string | null;
+      startDate: string | null
       /** Format: date-time */
-      lastDebitDate: string | null;
+      lastDebitDate: string | null
       /** @enum {number} */
-      status: 0 | 1 | 2 | 3;
-      rentalObjectCode: string | null;
-      property?: string | null;
-      buildingCode?: string | null;
-      area?: string | null;
-      buildingManager?: string | null;
-      districtName?: string | null;
-      parkingSpaceType?: string | null;
-    };
+      status: 0 | 1 | 2 | 3
+      rentalObjectCode: string | null
+      property?: string | null
+      buildingCode?: string | null
+      area?: string | null
+      buildingManager?: string | null
+      districtName?: string | null
+      parkingSpaceType?: string | null
+    }
     ContactInfo: {
-      name: string;
-      contactCode: string;
-      email: string | null;
-      phone: string | null;
-    };
+      name: string
+      contactCode: string
+      email: string | null
+      phone: string | null
+    }
     PaginationMeta: {
-      totalRecords: number;
-      page: number;
-      limit: number;
-      count: number;
-    };
+      totalRecords: number
+      page: number
+      limit: number
+      count: number
+    }
     PaginationLinks: {
-      href: string;
+      href: string
       /** @enum {string} */
-      rel: "self" | "first" | "last" | "prev" | "next";
-    };
+      rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+    }
     Contact: {
-      contactCode: string;
-      contactKey: string;
-      leaseIds?: string[];
-      firstName: string | null;
-      lastName: string | null;
-      fullName: string | null;
-      nationalRegistrationNumber: string;
+      contactCode: string
+      contactKey: string
+      leaseIds?: string[]
+      firstName: string | null
+      lastName: string | null
+      fullName: string | null
+      nationalRegistrationNumber: string
       /** Format: date-time */
-      birthDate: string | null;
+      birthDate: string | null
       address: {
-        street: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      } | null;
+        street: string
+        number: string
+        postalCode: string
+        city: string
+      } | null
       phoneNumbers: {
-          phoneNumber: string;
-          type: string;
-          isMainNumber: boolean;
-        }[];
-      emailAddress: string | null;
-      isTenant: boolean;
-      specialAttention?: boolean;
-    };
+        phoneNumber: string
+        type: string
+        isMainNumber: boolean
+      }[]
+      emailAddress: string | null
+      isTenant: boolean
+      specialAttention?: boolean
+    }
     ListingTextContent: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
+      id: string
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     CreateListingTextContentRequest: {
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     UpdateListingTextContentRequest: {
-      contentBlocks?: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      contentBlocks?: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     WorkOrder: {
-      accessCaption: string;
-      caption: string;
-      code: string;
-      contactCode: string;
-      description: string;
-      detailsCaption: string;
-      externalResource: boolean;
-      id: string;
+      accessCaption: string
+      caption: string
+      code: string
+      contactCode: string
+      description: string
+      detailsCaption: string
+      externalResource: boolean
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string;
+      lastChanged: string
+      priority: string
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-      hiddenFromMyPages?: boolean;
-      workOrderRows: ({
-          description: string | null;
-          locationCode: string | null;
-          equipmentCode: string | null;
-        })[];
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+      hiddenFromMyPages?: boolean
+      workOrderRows: {
+        description: string | null
+        locationCode: string | null
+        equipmentCode: string | null
+      }[]
       messages?: {
-          id: number;
-          body: string;
-          messageType: string;
-          author: string;
-          /** Format: date-time */
-          createDate: string;
-        }[];
-      url?: string;
-    };
+        id: number
+        body: string
+        messageType: string
+        author: string
+        /** Format: date-time */
+        createDate: string
+      }[]
+      url?: string
+    }
     XpandWorkOrder: {
-      accessCaption: string;
-      caption: string | null;
-      code: string;
-      contactCode: string | null;
-      id: string;
+      accessCaption: string
+      caption: string | null
+      code: string
+      contactCode: string | null
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string | null;
+      lastChanged: string
+      priority: string | null
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-    };
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+    }
     Building: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       buildingType: {
-        id: string | null;
-        code: string | null;
-        name: string | null;
-      };
+        id: string | null
+        code: string | null
+        name: string | null
+      }
       construction: {
-        constructionYear: number | null;
-        renovationYear: number | null;
-        valueYear: number | null;
-      };
+        constructionYear: number | null
+        renovationYear: number | null
+        valueYear: number | null
+      }
       features: {
-        heating?: string | null;
-        fireRating?: string | null;
-      };
+        heating?: string | null
+        fireRating?: string | null
+      }
       insurance: {
-        class: string | null;
-        value: number | null;
-      };
-      quantityValues?: ({
-          id: string;
-          value: number;
-          name: string;
-          unitId: string | null;
-        })[];
-      deleted: boolean;
-      property?: ({
-        name: string | null;
-        code: string;
-        id: string;
-      }) | null;
-    };
+        class: string | null
+        value: number | null
+      }
+      quantityValues?: {
+        id: string
+        value: number
+        name: string
+        unitId: string | null
+      }[]
+      deleted: boolean
+      property?: {
+        name: string | null
+        code: string
+        id: string
+      } | null
+    }
     Company: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+    }
     CompanyDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-      phone: string | null;
-      fax: string | null;
-      vatNumber?: string | null;
-      internalExternal: number;
-      fTax: number;
-      cooperativeHousingAssociation: number;
-      differentiatedAdditionalCapital: number;
-      rentAdministered: number;
-      blocked: number;
-      rentDaysPerMonth: number;
-      economicPlanApproved: number;
-      vatObligationPercent: number;
-      vatRegistered: number;
-      energyOptimization: number;
-      ownedCompany: number;
-      interestInvoice: number;
-      errorReportAdministration: number;
-      mediaBilling: number;
-      ownResponsibilityForInternalMaintenance: number;
-      subletPercentage: number;
-      subletFeeAmount: number;
-      disableQuantitiesBelowCompany: number;
-      timestamp: string;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+      phone: string | null
+      fax: string | null
+      vatNumber?: string | null
+      internalExternal: number
+      fTax: number
+      cooperativeHousingAssociation: number
+      differentiatedAdditionalCapital: number
+      rentAdministered: number
+      blocked: number
+      rentDaysPerMonth: number
+      economicPlanApproved: number
+      vatObligationPercent: number
+      vatRegistered: number
+      energyOptimization: number
+      ownedCompany: number
+      interestInvoice: number
+      errorReportAdministration: number
+      mediaBilling: number
+      ownResponsibilityForInternalMaintenance: number
+      subletPercentage: number
+      subletFeeAmount: number
+      disableQuantitiesBelowCompany: number
+      timestamp: string
+    }
     Property: {
-      id: string;
-      propertyObjectId: string;
-      marketAreaId: string | null;
-      districtId: string | null;
-      propertyDesignationId: string | null;
-      valueAreaId: string | null;
-      code: string;
-      designation: string;
-      municipality: string;
-      tract: string;
-      block: string;
-      sector: string | null;
-      propertyIndexNumber: string | null;
-      congregation: string | null;
-      builtStatus: number;
-      separateAssessmentUnit: number;
-      consolidationNumber: string | null;
-      ownershipType: string;
-      registrationDate: string | null;
-      acquisitionDate: string | null;
-      isLeasehold: number;
-      leaseholdTerminationDate: string | null;
-      area: string | null;
-      purpose: string | null;
-      buildingType: string | null;
-      propertyTaxNumber: string | null;
-      mainPartAssessedValue: number;
-      includeInAssessedValue: number;
-      grading: number;
-      deleteMark: number;
+      id: string
+      propertyObjectId: string
+      marketAreaId: string | null
+      districtId: string | null
+      propertyDesignationId: string | null
+      valueAreaId: string | null
+      code: string
+      designation: string
+      municipality: string
+      tract: string
+      block: string
+      sector: string | null
+      propertyIndexNumber: string | null
+      congregation: string | null
+      builtStatus: number
+      separateAssessmentUnit: number
+      consolidationNumber: string | null
+      ownershipType: string
+      registrationDate: string | null
+      acquisitionDate: string | null
+      isLeasehold: number
+      leaseholdTerminationDate: string | null
+      area: string | null
+      purpose: string | null
+      buildingType: string | null
+      propertyTaxNumber: string | null
+      mainPartAssessedValue: number
+      includeInAssessedValue: number
+      grading: number
+      deleteMark: number
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string;
-      timestamp: string;
-    };
+      toDate: string
+      timestamp: string
+    }
     Residence: {
-      id: string;
-      code: string;
-      name: string;
-      deleted: boolean;
+      id: string
+      code: string
+      name: string
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
-    };
+        toDate: string
+      }
+    }
     ResidenceDetails: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       /** @enum {string|null} */
-      status: "VACANT" | "LEASED" | null;
-      entrance: string | null;
-      location: string | null;
-      floor: string | null;
-      partNo: number | null;
-      part: string | null;
-      deleted: boolean;
+      status: 'VACANT' | 'LEASED' | null
+      entrance: string | null
+      location: string | null
+      floor: string | null
+      partNo: number | null
+      part: string | null
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
+        toDate: string
+      }
       accessibility: {
-        wheelchairAccessible: boolean;
-        elevator: boolean;
-        residenceAdapted: boolean;
-      };
+        wheelchairAccessible: boolean
+        elevator: boolean
+        residenceAdapted: boolean
+      }
       features: {
-        hygieneFacility: string | null;
+        hygieneFacility: string | null
         balcony1?: {
-          location: string;
-          type: string;
-        };
+          location: string
+          type: string
+        }
         balcony2?: {
-          location: string;
-          type: string;
-        };
-        patioLocation: string | null;
-        sauna: boolean;
-        extraToilet: boolean;
-        sharedKitchen: boolean;
-        petAllergyFree: boolean;
+          location: string
+          type: string
+        }
+        patioLocation: string | null
+        sauna: boolean
+        extraToilet: boolean
+        sharedKitchen: boolean
+        petAllergyFree: boolean
         /** @description Is the apartment checked for electric allergy intolerance? */
-        electricAllergyIntolerance: boolean;
-        smokeFree: boolean;
-        asbestos: boolean;
-      };
+        electricAllergyIntolerance: boolean
+        smokeFree: boolean
+        asbestos: boolean
+      }
       type: {
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-      };
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+      }
       residenceType: {
-        residenceTypeId: string;
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-        systemStandard: number;
-        checklistId: string | null;
-        componentTypeActionId: string | null;
-        statisticsGroupSCBId: string | null;
-        statisticsGroup2Id: string | null;
-        statisticsGroup3Id: string | null;
-        statisticsGroup4Id: string | null;
-        timestamp: string;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        residenceTypeId: string
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+        systemStandard: number
+        checklistId: string | null
+        componentTypeActionId: string | null
+        statisticsGroupSCBId: string | null
+        statisticsGroup2Id: string | null
+        statisticsGroup3Id: string | null
+        statisticsGroup4Id: string | null
+        timestamp: string
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       propertyObject: {
         energy: {
-          energyClass: number;
+          energyClass: number
           /** Format: date-time */
-          energyRegistered?: string;
+          energyRegistered?: string
           /** Format: date-time */
-          energyReceived?: string;
-          energyIndex?: number;
-        };
-        rentalId: string | null;
-        rentalInformation: ({
+          energyReceived?: string
+          energyIndex?: number
+        }
+        rentalId: string | null
+        rentalInformation: {
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
-        rentalBlocks: ({
-            id: string;
-            blockReasonId: string | null;
-            blockReason: string | null;
-            /** Format: date-time */
-            fromDate: string;
-            /** Format: date-time */
-            toDate: string | null;
-            amount: number | null;
-          })[];
-      };
+            code: string
+            name: string | null
+          }
+        } | null
+        rentalBlocks: {
+          id: string
+          blockReasonId: string | null
+          blockReason: string | null
+          /** Format: date-time */
+          fromDate: string
+          /** Format: date-time */
+          toDate: string | null
+          amount: number | null
+        }[]
+      }
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      staircase: ({
-        id: string;
-        code: string;
-        name: string | null;
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      staircase: {
+        id: string
+        code: string
+        name: string | null
         features: {
-          floorPlan: string | null;
-          accessibleByElevator: boolean;
-        };
+          floorPlan: string | null
+          accessibleByElevator: boolean
+        }
         dates: {
           /** Format: date-time */
-          from: string;
+          from: string
           /** Format: date-time */
-          to: string;
-        };
+          to: string
+        }
         property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
+          propertyId: string | null
+          propertyName: string | null
+          propertyCode: string | null
+        }
         building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
-        deleted: boolean;
-        timestamp: string;
-      }) | null;
-      areaSize: number | null;
-      malarEnergiFacilityId: string | null;
-    };
+          buildingId: string | null
+          buildingName: string | null
+          buildingCode: string | null
+        }
+        deleted: boolean
+        timestamp: string
+      } | null
+      areaSize: number | null
+      malarEnergiFacilityId: string | null
+    }
     ResidenceSummary: {
-      id: string;
-      code: string;
-      name: string | null;
-      deleted: boolean;
-      rentalId: string;
-      buildingCode: string;
-      buildingName: string;
-      staircaseCode: string;
-      staircaseName: string;
-      elevator: number | null;
-      floor: string;
-      hygieneFacility: string | null;
-      wheelchairAccessible: number;
+      id: string
+      code: string
+      name: string | null
+      deleted: boolean
+      rentalId: string
+      buildingCode: string
+      buildingName: string
+      staircaseCode: string
+      staircaseName: string
+      elevator: number | null
+      floor: string
+      hygieneFacility: string | null
+      wheelchairAccessible: number
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string | null;
+        fromDate: string | null
         /** Format: date-time */
-        toDate: string | null;
-      };
+        toDate: string | null
+      }
       residenceType: {
-        code: string;
-        name: string;
-        roomCount: number;
-        kitchen: number;
-      };
-      quantityValues: ({
-          value: number;
-          quantityTypeId: string;
-          quantityType: {
-            name: string;
-            unitId: string | null;
-          };
-        })[];
-    };
+        code: string
+        name: string
+        roomCount: number
+        kitchen: number
+      }
+      quantityValues: {
+        value: number
+        quantityTypeId: string
+        quantityType: {
+          name: string
+          unitId: string | null
+        }
+      }[]
+    }
     Staircase: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       features: {
-        floorPlan: string | null;
-        accessibleByElevator: boolean;
-      };
+        floorPlan: string | null
+        accessibleByElevator: boolean
+      }
       dates: {
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
-      };
+        to: string
+      }
       property?: {
-        propertyId: string | null;
-        propertyName: string | null;
-        propertyCode: string | null;
-      };
+        propertyId: string | null
+        propertyName: string | null
+        propertyCode: string | null
+      }
       building?: {
-        buildingId: string | null;
-        buildingName: string | null;
-        buildingCode: string | null;
-      };
-      deleted: boolean;
-      timestamp: string;
-    };
+        buildingId: string | null
+        buildingName: string | null
+        buildingCode: string | null
+      }
+      deleted: boolean
+      timestamp: string
+    }
     Room: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
       usage: {
-        shared: boolean;
-        allowPeriodicWorks: boolean;
-        spaceType: number;
-      };
+        shared: boolean
+        allowPeriodicWorks: boolean
+        spaceType: number
+      }
       features: {
-        hasToilet: boolean;
-        isHeated: boolean;
-        hasThermostatValve: boolean;
-        orientation: number;
-      };
+        hasToilet: boolean
+        isHeated: boolean
+        hasThermostatValve: boolean
+        orientation: number
+      }
       dates: {
         /** Format: date-time */
-        installation: string | null;
+        installation: string | null
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
+        to: string
         /** Format: date-time */
-        availableFrom: string | null;
+        availableFrom: string | null
         /** Format: date-time */
-        availableTo: string | null;
-      };
-      sortingOrder: number;
-      deleted: boolean;
-      timestamp: string;
-      roomType: ({
-        id: string;
-        code: string;
-        name: string | null;
-        use: number;
-        optionAllowed: number;
-        isSystemStandard: number;
-        allowSmallRoomsInValuation: number;
-        timestamp: string;
-      }) | null;
-      area?: number;
-    };
+        availableTo: string | null
+      }
+      sortingOrder: number
+      deleted: boolean
+      timestamp: string
+      roomType: {
+        id: string
+        code: string
+        name: string | null
+        use: number
+        optionAllowed: number
+        isSystemStandard: number
+        allowSmallRoomsInValuation: number
+        timestamp: string
+      } | null
+      area?: number
+    }
     ParkingSpace: {
-      rentalId: string;
-      companyCode: string;
-      companyName: string;
-      managementUnitCode: string;
-      managementUnitName: string;
-      propertyCode: string;
-      propertyName: string;
-      buildingCode: string | null;
-      buildingName: string | null;
+      rentalId: string
+      companyCode: string
+      companyName: string
+      managementUnitCode: string
+      managementUnitName: string
+      propertyCode: string
+      propertyName: string
+      buildingCode: string | null
+      buildingName: string | null
       parkingSpace: {
-        propertyObjectId: string;
-        code: string;
-        name: string;
-        parkingNumber: string;
+        propertyObjectId: string
+        code: string
+        name: string
+        parkingNumber: string
         parkingSpaceType: {
-          code: string;
-          name: string;
-        };
-      };
+          code: string
+          name: string
+        }
+      }
       address: {
-        streetAddress: string | null;
-        streetAddress2: string | null;
-        postalCode: string | null;
-        city: string | null;
-      };
-    };
+        streetAddress: string | null
+        streetAddress2: string | null
+        postalCode: string | null
+        city: string | null
+      }
+    }
     MaintenanceUnit: {
-      id: string;
-      propertyObjectId: string;
-      rentalPropertyId?: string;
-      code: string;
-      caption: string | null;
-      type?: string | null;
-      estateCode: string | null;
-      estate: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      rentalPropertyId?: string
+      code: string
+      caption: string | null
+      type?: string | null
+      estateCode: string | null
+      estate: string | null
+    }
     FacilityDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
-      entrance: string | null;
-      deleted: boolean;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
+      entrance: string | null
+      deleted: boolean
       type: {
-        code: string;
-        name: string | null;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        code: string
+        name: string | null
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      areaSize: number | null;
-    };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      areaSize: number | null
+    }
     RentalBlock: {
-      id: string;
-      blockReasonId: string;
-      blockReason: string;
+      id: string
+      blockReasonId: string
+      blockReason: string
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-    };
+      toDate: string | null
+      amount: number | null
+    }
     RentalBlockWithRentalObject: {
-      id: string;
-      blockReasonId: string | null;
-      blockReason: string | null;
+      id: string
+      blockReasonId: string | null
+      blockReason: string | null
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-      distrikt: string | null;
+      toDate: string | null
+      amount: number | null
+      distrikt: string | null
       rentalObject: {
-        code: string | null;
-        name: string | null;
+        code: string | null
+        name: string | null
         /** @enum {string} */
-        category: "Bostad" | "Bilplats" | "Lokal" | "Förråd" | "Övrigt";
-        address: string | null;
-        rentalId: string | null;
-        residenceId: string | null;
-        yearlyRent: number;
-        type: string | null;
-      };
+        category: 'Bostad' | 'Bilplats' | 'Lokal' | 'Förråd' | 'Övrigt'
+        address: string | null
+        rentalId: string | null
+        residenceId: string | null
+        yearlyRent: number
+        type: string | null
+      }
       building: {
-        code: string | null;
-        name: string | null;
-      };
+        code: string | null
+        name: string | null
+      }
       property: {
-        code: string | null;
-        name: string | null;
-      };
-    };
+        code: string | null
+        name: string | null
+      }
+    }
     FacilitySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a facility result
        * @enum {string}
        */
-      type: "facility";
+      type: 'facility'
       /** @description Name of the facility */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the facility */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the facility */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the facility */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ResidenceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a residence result
        * @enum {string}
        */
-      type: "residence";
+      type: 'residence'
       /** @description Name of the residence */
-      name: string | null;
+      name: string | null
       /** @description Rental object ID of the residence */
-      rentalId: string | null;
+      rentalId: string | null
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the residence */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ParkingSpaceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a parking space result
        * @enum {string}
        */
-      type: "parking-space";
+      type: 'parking-space'
       /** @description Name of the parking space */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the parking space */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the parking space */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     Component: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      modelId: string;
-      serialNumber: string | null;
-      specifications?: string | null;
-      additionalInformation?: string | null;
-      warrantyStartDate: string | null;
-      warrantyMonths: number;
-      priceAtPurchase: number;
-      depreciationPriceAtPurchase: number;
-      ncsCode?: string | null;
+      modelId: string
+      serialNumber: string | null
+      specifications?: string | null
+      additionalInformation?: string | null
+      warrantyStartDate: string | null
+      warrantyMonths: number
+      priceAtPurchase: number
+      depreciationPriceAtPurchase: number
+      ncsCode?: string | null
       /** @enum {string} */
-      status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      quantity: number;
-      economicLifespan: number;
-      createdAt: string;
-      updatedAt: string;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      quantity: number
+      economicLifespan: number
+      createdAt: string
+      updatedAt: string
       model?: {
         /** Format: uuid */
-        id: string;
-        modelName: string;
+        id: string
+        modelName: string
         /** Format: uuid */
-        componentSubtypeId: string;
-        currentPrice: number;
-        currentInstallPrice: number;
-        warrantyMonths: number;
-        manufacturer: string;
-        technicalSpecification: string | null;
-        installationInstructions: string | null;
-        dimensions: string | null;
-        coclassCode: string | null;
-        createdAt: string;
-        updatedAt: string;
+        componentSubtypeId: string
+        currentPrice: number
+        currentInstallPrice: number
+        warrantyMonths: number
+        manufacturer: string
+        technicalSpecification: string | null
+        installationInstructions: string | null
+        dimensions: string | null
+        coclassCode: string | null
+        createdAt: string
+        updatedAt: string
         subtype?: {
           /** Format: uuid */
-          id: string;
-          subTypeName: string;
+          id: string
+          subTypeName: string
           /** Format: uuid */
-          typeId: string;
-          xpandCode: string | null;
-          depreciationPrice: number;
-          technicalLifespan: number;
-          economicLifespan: number;
-          replacementIntervalMonths: number;
+          typeId: string
+          xpandCode: string | null
+          depreciationPrice: number
+          technicalLifespan: number
+          economicLifespan: number
+          replacementIntervalMonths: number
           /** @enum {string} */
-          quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-          createdAt: string;
-          updatedAt: string;
+          quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+          createdAt: string
+          updatedAt: string
           componentType?: {
             /** Format: uuid */
-            id: string;
-            typeName: string;
+            id: string
+            typeName: string
             /** Format: uuid */
-            categoryId: string;
-            description: string | null;
-            createdAt: string;
-            updatedAt: string;
+            categoryId: string
+            description: string | null
+            createdAt: string
+            updatedAt: string
             category?: {
               /** Format: uuid */
-              id: string;
-              categoryName: string;
-              description: string;
-              createdAt: string;
-              updatedAt: string;
-            };
-          };
-        };
-      };
-      componentInstallations?: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          componentId: string;
-          spaceId: string | null;
-          /** @enum {string} */
-          spaceType: "OBJECT" | "PropertyObject";
-          installationDate: string | null;
-          deinstallationDate: string | null;
-          orderNumber?: string | null;
-          cost: number;
-          createdAt: string;
-          updatedAt: string;
-          propertyObject?: ({
-            id: string;
-            propertyStructures?: ({
-                roomId?: string | null;
-                roomCode?: string | null;
-                roomName?: string | null;
-                residenceId?: string | null;
-                residenceCode?: string | null;
-                residenceName?: string | null;
-                rentalId?: string | null;
-                buildingCode?: string | null;
-                buildingName?: string | null;
-                residence?: {
-                  id: string;
-                } | null;
-              })[];
-          }) | null;
-        })[];
-    };
+              id: string
+              categoryName: string
+              description: string
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      componentInstallations?: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        componentId: string
+        spaceId: string | null
+        /** @enum {string} */
+        spaceType: 'OBJECT' | 'PropertyObject'
+        installationDate: string | null
+        deinstallationDate: string | null
+        orderNumber?: string | null
+        cost: number
+        createdAt: string
+        updatedAt: string
+        propertyObject?: {
+          id: string
+          propertyStructures?: {
+            roomId?: string | null
+            roomCode?: string | null
+            roomName?: string | null
+            residenceId?: string | null
+            residenceCode?: string | null
+            residenceName?: string | null
+            rentalId?: string | null
+            buildingCode?: string | null
+            buildingName?: string | null
+            residence?: {
+              id: string
+            } | null
+          }[]
+        } | null
+      }[]
+    }
     ComponentCategory: {
       /** Format: uuid */
-      id: string;
-      categoryName: string;
-      description: string;
-      createdAt: string;
-      updatedAt: string;
-    };
+      id: string
+      categoryName: string
+      description: string
+      createdAt: string
+      updatedAt: string
+    }
     ComponentType: {
       /** Format: uuid */
-      id: string;
-      typeName: string;
+      id: string
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description: string | null;
-      createdAt: string;
-      updatedAt: string;
+      categoryId: string
+      description: string | null
+      createdAt: string
+      updatedAt: string
       category?: {
         /** Format: uuid */
-        id: string;
-        categoryName: string;
-        description: string;
-        createdAt: string;
-        updatedAt: string;
-      };
-    };
+        id: string
+        categoryName: string
+        description: string
+        createdAt: string
+        updatedAt: string
+      }
+    }
     ComponentSubtype: {
       /** Format: uuid */
-      id: string;
-      subTypeName: string;
+      id: string
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode: string | null;
-      depreciationPrice: number;
-      technicalLifespan: number;
-      economicLifespan: number;
-      replacementIntervalMonths: number;
+      typeId: string
+      xpandCode: string | null
+      depreciationPrice: number
+      technicalLifespan: number
+      economicLifespan: number
+      replacementIntervalMonths: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-      createdAt: string;
-      updatedAt: string;
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+      createdAt: string
+      updatedAt: string
       componentType?: {
         /** Format: uuid */
-        id: string;
-        typeName: string;
+        id: string
+        typeName: string
         /** Format: uuid */
-        categoryId: string;
-        description: string | null;
-        createdAt: string;
-        updatedAt: string;
+        categoryId: string
+        description: string | null
+        createdAt: string
+        updatedAt: string
         category?: {
           /** Format: uuid */
-          id: string;
-          categoryName: string;
-          description: string;
-          createdAt: string;
-          updatedAt: string;
-        };
-      };
-    };
+          id: string
+          categoryName: string
+          description: string
+          createdAt: string
+          updatedAt: string
+        }
+      }
+    }
     ComponentModel: {
       /** Format: uuid */
-      id: string;
-      modelName: string;
+      id: string
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
-      currentPrice: number;
-      currentInstallPrice: number;
-      warrantyMonths: number;
-      manufacturer: string;
-      technicalSpecification: string | null;
-      installationInstructions: string | null;
-      dimensions: string | null;
-      coclassCode: string | null;
-      createdAt: string;
-      updatedAt: string;
+      componentSubtypeId: string
+      currentPrice: number
+      currentInstallPrice: number
+      warrantyMonths: number
+      manufacturer: string
+      technicalSpecification: string | null
+      installationInstructions: string | null
+      dimensions: string | null
+      coclassCode: string | null
+      createdAt: string
+      updatedAt: string
       subtype?: {
         /** Format: uuid */
-        id: string;
-        subTypeName: string;
+        id: string
+        subTypeName: string
         /** Format: uuid */
-        typeId: string;
-        xpandCode: string | null;
-        depreciationPrice: number;
-        technicalLifespan: number;
-        economicLifespan: number;
-        replacementIntervalMonths: number;
+        typeId: string
+        xpandCode: string | null
+        depreciationPrice: number
+        technicalLifespan: number
+        economicLifespan: number
+        replacementIntervalMonths: number
         /** @enum {string} */
-        quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-        createdAt: string;
-        updatedAt: string;
+        quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+        createdAt: string
+        updatedAt: string
         componentType?: {
           /** Format: uuid */
-          id: string;
-          typeName: string;
+          id: string
+          typeName: string
           /** Format: uuid */
-          categoryId: string;
-          description: string | null;
-          createdAt: string;
-          updatedAt: string;
+          categoryId: string
+          description: string | null
+          createdAt: string
+          updatedAt: string
           category?: {
             /** Format: uuid */
-            id: string;
-            categoryName: string;
-            description: string;
-            createdAt: string;
-            updatedAt: string;
-          };
-        };
-      };
-    };
+            id: string
+            categoryName: string
+            description: string
+            createdAt: string
+            updatedAt: string
+          }
+        }
+      }
+    }
     ComponentInstallation: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      componentId: string;
-      spaceId: string | null;
+      componentId: string
+      spaceId: string | null
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
-      installationDate: string | null;
-      deinstallationDate: string | null;
-      orderNumber?: string | null;
-      cost: number;
-      createdAt: string;
-      updatedAt: string;
+      spaceType: 'OBJECT' | 'PropertyObject'
+      installationDate: string | null
+      deinstallationDate: string | null
+      orderNumber?: string | null
+      cost: number
+      createdAt: string
+      updatedAt: string
       component?: {
         /** Format: uuid */
-        id: string;
+        id: string
         /** Format: uuid */
-        modelId: string;
-        serialNumber: string | null;
-        specifications?: string | null;
-        additionalInformation?: string | null;
-        warrantyStartDate: string | null;
-        warrantyMonths: number;
-        priceAtPurchase: number;
-        depreciationPriceAtPurchase: number;
-        ncsCode?: string | null;
+        modelId: string
+        serialNumber: string | null
+        specifications?: string | null
+        additionalInformation?: string | null
+        warrantyStartDate: string | null
+        warrantyMonths: number
+        priceAtPurchase: number
+        depreciationPriceAtPurchase: number
+        ncsCode?: string | null
         /** @enum {string} */
-        status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+        status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
         /** @enum {string|null} */
-        condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-        quantity: number;
-        economicLifespan: number;
-        createdAt: string;
-        updatedAt: string;
+        condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+        quantity: number
+        economicLifespan: number
+        createdAt: string
+        updatedAt: string
         model?: {
           /** Format: uuid */
-          id: string;
-          modelName: string;
+          id: string
+          modelName: string
           /** Format: uuid */
-          componentSubtypeId: string;
-          currentPrice: number;
-          currentInstallPrice: number;
-          warrantyMonths: number;
-          manufacturer: string;
-          technicalSpecification: string | null;
-          installationInstructions: string | null;
-          dimensions: string | null;
-          coclassCode: string | null;
-          createdAt: string;
-          updatedAt: string;
+          componentSubtypeId: string
+          currentPrice: number
+          currentInstallPrice: number
+          warrantyMonths: number
+          manufacturer: string
+          technicalSpecification: string | null
+          installationInstructions: string | null
+          dimensions: string | null
+          coclassCode: string | null
+          createdAt: string
+          updatedAt: string
           subtype?: {
             /** Format: uuid */
-            id: string;
-            subTypeName: string;
+            id: string
+            subTypeName: string
             /** Format: uuid */
-            typeId: string;
-            xpandCode: string | null;
-            depreciationPrice: number;
-            technicalLifespan: number;
-            economicLifespan: number;
-            replacementIntervalMonths: number;
+            typeId: string
+            xpandCode: string | null
+            depreciationPrice: number
+            technicalLifespan: number
+            economicLifespan: number
+            replacementIntervalMonths: number
             /** @enum {string} */
-            quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-            createdAt: string;
-            updatedAt: string;
+            quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+            createdAt: string
+            updatedAt: string
             componentType?: {
               /** Format: uuid */
-              id: string;
-              typeName: string;
+              id: string
+              typeName: string
               /** Format: uuid */
-              categoryId: string;
-              description: string | null;
-              createdAt: string;
-              updatedAt: string;
+              categoryId: string
+              description: string | null
+              createdAt: string
+              updatedAt: string
               category?: {
                 /** Format: uuid */
-                id: string;
-                categoryName: string;
-                description: string;
-                createdAt: string;
-                updatedAt: string;
-              };
-            };
-          };
-        };
-        componentInstallations?: ({
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            componentId: string;
-            spaceId: string | null;
-            spaceType: components["schemas"]["ComponentInstallation"]["spaceType"];
-            installationDate: string | null;
-            deinstallationDate: string | null;
-            orderNumber?: string | null;
-            cost: number;
-            createdAt: string;
-            updatedAt: string;
-            propertyObject?: ({
-              id: string;
-              propertyStructures?: ({
-                  roomId?: string | null;
-                  roomCode?: string | null;
-                  roomName?: string | null;
-                  residenceId?: string | null;
-                  residenceCode?: string | null;
-                  residenceName?: string | null;
-                  rentalId?: string | null;
-                  buildingCode?: string | null;
-                  buildingName?: string | null;
-                  residence?: {
-                    id: string;
-                  } | null;
-                })[];
-            }) | null;
-          })[];
-      };
-    };
+                id: string
+                categoryName: string
+                description: string
+                createdAt: string
+                updatedAt: string
+              }
+            }
+          }
+        }
+        componentInstallations?: {
+          /** Format: uuid */
+          id: string
+          /** Format: uuid */
+          componentId: string
+          spaceId: string | null
+          spaceType: components['schemas']['ComponentInstallation']['spaceType']
+          installationDate: string | null
+          deinstallationDate: string | null
+          orderNumber?: string | null
+          cost: number
+          createdAt: string
+          updatedAt: string
+          propertyObject?: {
+            id: string
+            propertyStructures?: {
+              roomId?: string | null
+              roomCode?: string | null
+              roomName?: string | null
+              residenceId?: string | null
+              residenceCode?: string | null
+              residenceName?: string | null
+              rentalId?: string | null
+              buildingCode?: string | null
+              buildingName?: string | null
+              residence?: {
+                id: string
+              } | null
+            }[]
+          } | null
+        }[]
+      }
+    }
     CreateComponentCategoryRequest: {
-      categoryName: string;
-      description: string;
-    };
+      categoryName: string
+      description: string
+    }
     UpdateComponentCategoryRequest: {
-      categoryName?: string;
-      description?: string;
-    };
+      categoryName?: string
+      description?: string
+    }
     CreateComponentTypeRequest: {
-      typeName: string;
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description?: string;
-    };
+      categoryId: string
+      description?: string
+    }
     UpdateComponentTypeRequest: {
-      typeName?: string;
+      typeName?: string
       /** Format: uuid */
-      categoryId?: string;
-      description?: string;
-    };
+      categoryId?: string
+      description?: string
+    }
     CreateComponentSubtypeRequest: {
-      subTypeName: string;
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode?: string;
+      typeId: string
+      xpandCode?: string
       /** @default 0 */
-      depreciationPrice?: number;
+      depreciationPrice?: number
       /** @default 0 */
-      technicalLifespan?: number;
+      technicalLifespan?: number
       /** @default 0 */
-      economicLifespan?: number;
+      economicLifespan?: number
       /** @default 0 */
-      replacementIntervalMonths?: number;
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     UpdateComponentSubtypeRequest: {
-      subTypeName?: string;
+      subTypeName?: string
       /** Format: uuid */
-      typeId?: string;
-      xpandCode?: string;
-      depreciationPrice?: number;
-      technicalLifespan?: number;
-      economicLifespan?: number;
-      replacementIntervalMonths?: number;
+      typeId?: string
+      xpandCode?: string
+      depreciationPrice?: number
+      technicalLifespan?: number
+      economicLifespan?: number
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType?: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType?: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     CreateComponentModelRequest: {
-      modelName: string;
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
+      componentSubtypeId: string
       /** @default 0 */
-      currentPrice?: number;
+      currentPrice?: number
       /** @default 0 */
-      currentInstallPrice?: number;
+      currentInstallPrice?: number
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default */
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     UpdateComponentModelRequest: {
-      modelName?: string;
+      modelName?: string
       /** Format: uuid */
-      componentSubtypeId?: string;
-      currentPrice?: number;
-      currentInstallPrice?: number;
-      warrantyMonths?: number;
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      componentSubtypeId?: string
+      currentPrice?: number
+      currentInstallPrice?: number
+      warrantyMonths?: number
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     CreateComponentRequest: {
       /** Format: uuid */
-      modelId: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
+      warrantyStartDate?: string
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default 0 */
-      priceAtPurchase?: number;
+      priceAtPurchase?: number
       /** @default 0 */
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /**
        * @default ACTIVE
        * @enum {string}
        */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
       /** @default 1 */
-      quantity?: number;
+      quantity?: number
       /** @default 0 */
-      economicLifespan?: number;
-      files?: string;
-    };
+      economicLifespan?: number
+      files?: string
+    }
     UpdateComponentRequest: {
       /** Format: uuid */
-      modelId?: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId?: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
-      warrantyMonths?: number;
-      priceAtPurchase?: number;
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      warrantyStartDate?: string
+      warrantyMonths?: number
+      priceAtPurchase?: number
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /** @enum {string} */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      quantity?: number;
-      economicLifespan?: number;
-      files?: string;
-    };
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      quantity?: number
+      economicLifespan?: number
+      files?: string
+    }
     CreateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId: string;
-      spaceId?: string;
+      componentId: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
+      spaceType: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string | null;
+      installationDate?: string | null
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost: number
+    }
     UpdateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId?: string;
-      spaceId?: string;
+      componentId?: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType?: "OBJECT" | "PropertyObject";
+      spaceType?: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string;
+      installationDate?: string
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost?: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost?: number
+    }
     DocumentWithUrl: {
-      id: string;
-      fileId: string;
-      originalName: string;
-      mimeType: string;
-      size: number;
-      createdAt: string;
-      url: string;
-      uploadedAt?: string;
-      caption?: string;
-    };
+      id: string
+      fileId: string
+      originalName: string
+      mimeType: string
+      size: number
+      createdAt: string
+      url: string
+      uploadedAt?: string
+      caption?: string
+    }
     AnalyzeComponentImageRequest: {
-      image: string;
-      additionalImage?: string;
-    };
+      image: string
+      additionalImage?: string
+    }
     AIComponentAnalysis: {
-      componentType: string | null;
-      componentSubtype: string | null;
-      manufacturer: string | null;
-      model: string | null;
-      serialNumber: string | null;
-      estimatedAge: string | null;
-      condition: string | null;
-      specifications: string | null;
-      dimensions: string | null;
-      warrantyMonths: number | null;
-      ncsCode: string | null;
-      additionalInformation: string | null;
-      confidence: number;
-    };
+      componentType: string | null
+      componentSubtype: string | null
+      manufacturer: string | null
+      model: string | null
+      serialNumber: string | null
+      estimatedAge: string | null
+      condition: string | null
+      specifications: string | null
+      dimensions: string | null
+      warrantyMonths: number | null
+      ncsCode: string | null
+      additionalInformation: string | null
+      confidence: number
+    }
     Key: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeySystem: {
       /** Format: uuid */
-      id: string;
-      systemCode: string;
-      name: string;
-      manufacturer: string;
-      managingSupplier?: string | null;
+      id: string
+      systemCode: string
+      name: string
+      manufacturer: string
+      managingSupplier?: string | null
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+    }
     KeyLoan: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+    }
     KeyDetails: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      keySystem?: components["schemas"]["KeySystem"] | null;
-      loans?: components["schemas"]["KeyLoan"][] | null;
-      events?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
-          /** @enum {string} */
-          status: "ORDERED" | "RECEIVED" | "COMPLETED";
-          /** Format: uuid */
-          workOrderId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[]) | null;
-      activeLoanContact?: string | null;
-    };
+      updatedAt: string
+      keySystem?: components['schemas']['KeySystem'] | null
+      loans?: components['schemas']['KeyLoan'][] | null
+      events?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+            /** @enum {string} */
+            status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+            /** Format: uuid */
+            workOrderId?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+          }[]
+        | null
+      activeLoanContact?: string | null
+    }
     KeyLoanWithDetails: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-      keysArray: ({
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+      keysArray: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: {
-              id: components["schemas"]["KeyLoanWithDetails"]["id"];
-              loanType: components["schemas"]["KeyLoanWithDetails"]["loanType"];
-              contact?: components["schemas"]["KeyLoanWithDetails"]["contact"];
-              contact2?: components["schemas"]["KeyLoanWithDetails"]["contact2"];
-              contactPerson?: components["schemas"]["KeyLoanWithDetails"]["contactPerson"];
-              notes?: components["schemas"]["KeyLoanWithDetails"]["notes"];
-              returnedAt?: components["schemas"]["KeyLoanWithDetails"]["returnedAt"];
-              availableToNextTenantFrom?: components["schemas"]["KeyLoanWithDetails"]["availableToNextTenantFrom"];
-              pickedUpAt?: components["schemas"]["KeyLoanWithDetails"]["pickedUpAt"];
-              createdAt: components["schemas"]["KeyLoanWithDetails"]["createdAt"];
-              updatedAt: components["schemas"]["KeyLoanWithDetails"]["updatedAt"];
-              createdBy?: components["schemas"]["KeyLoanWithDetails"]["createdBy"];
-              updatedBy?: components["schemas"]["KeyLoanWithDetails"]["updatedBy"];
-              keyCount?: components["schemas"]["KeyLoanWithDetails"]["keyCount"];
-              cardCount?: components["schemas"]["KeyLoanWithDetails"]["cardCount"];
-            }[] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?:
+          | {
+              id: components['schemas']['KeyLoanWithDetails']['id']
+              loanType: components['schemas']['KeyLoanWithDetails']['loanType']
+              contact?: components['schemas']['KeyLoanWithDetails']['contact']
+              contact2?: components['schemas']['KeyLoanWithDetails']['contact2']
+              contactPerson?: components['schemas']['KeyLoanWithDetails']['contactPerson']
+              notes?: components['schemas']['KeyLoanWithDetails']['notes']
+              returnedAt?: components['schemas']['KeyLoanWithDetails']['returnedAt']
+              availableToNextTenantFrom?: components['schemas']['KeyLoanWithDetails']['availableToNextTenantFrom']
+              pickedUpAt?: components['schemas']['KeyLoanWithDetails']['pickedUpAt']
+              createdAt: components['schemas']['KeyLoanWithDetails']['createdAt']
+              updatedAt: components['schemas']['KeyLoanWithDetails']['updatedAt']
+              createdBy?: components['schemas']['KeyLoanWithDetails']['createdBy']
+              updatedBy?: components['schemas']['KeyLoanWithDetails']['updatedBy']
+              keyCount?: components['schemas']['KeyLoanWithDetails']['keyCount']
+              cardCount?: components['schemas']['KeyLoanWithDetails']['cardCount']
+            }[]
+          | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-      keyCardsArray: ({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[];
-      receipts: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          keyLoanId: string;
-          /** @enum {string} */
-          receiptType: "LOAN" | "RETURN";
-          /** @enum {string} */
-          type: "DIGITAL" | "PHYSICAL";
-          fileId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+      keyCardsArray: {
+        cardId: string
+        name?: string | null
+        owner?: unknown
+        appearanceCode?: string | null
+        classification?: string | null
+        disabled?: boolean
+        startTime?: string | null
+        stopTime?: string | null
+        createTime: string
+        pinCode?: string | null
+        state?: string | null
+        archivedAt?: string | null
+        codes?: unknown[] | null
+      }[]
+      receipts: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        keyLoanId: string
+        /** @enum {string} */
+        receiptType: 'LOAN' | 'RETURN'
+        /** @enum {string} */
+        type: 'DIGITAL' | 'PHYSICAL'
+        fileId?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+      }[]
+    }
     Log: {
       /** Format: uuid */
-      id: string;
-      userName: string;
+      id: string
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
+      objectId?: string | null
       /** Format: date-time */
-      eventTime: string;
-      description?: string | null;
-      eventTypeLabel?: string;
-      objectTypeLabel?: string;
-    };
+      eventTime: string
+      description?: string | null
+      eventTypeLabel?: string
+      objectTypeLabel?: string
+    }
     KeyNote: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      description: string;
-    };
+      id: string
+      rentalObjectCode: string
+      description: string
+    }
     Receipt: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type: "DIGITAL" | "PHYSICAL";
-      fileId?: string | null;
+      type: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeyEvent: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
+      workOrderId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     Signature: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
-      status: string;
+      recipientEmail: string
+      recipientName?: string | null
+      status: string
       /** Format: date-time */
-      sentAt: string;
+      sentAt: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     CreateKeyRequest: {
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      notes?: string | null
+    }
     UpdateKeyRequest: {
-      keyName?: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName?: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType?: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType?:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      disposed?: boolean;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      disposed?: boolean
+      notes?: string | null
+    }
     BulkUpdateFlexRequest: {
-      rentalObjectCode: string;
-      flexNumber: number;
-    };
+      rentalObjectCode: string
+      flexNumber: number
+    }
     BulkUpdateKeysRequest: {
-      keyIds: string[];
+      keyIds: string[]
       updates: {
-        keyName?: string;
-        flexNumber?: number | null;
+        keyName?: string
+        flexNumber?: number | null
         /** Format: uuid */
-        keySystemId?: string | null;
-        rentalObjectCode?: string;
-        disposed?: boolean;
-        notes?: string | null;
-        clearNotes?: boolean;
-      };
-    };
+        keySystemId?: string | null
+        rentalObjectCode?: string
+        disposed?: boolean
+        notes?: string | null
+        clearNotes?: boolean
+      }
+    }
     CreateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
-      createdBy?: string | null;
-    };
+      availableToNextTenantFrom?: string | null
+      createdBy?: string | null
+    }
     UpdateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType?: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType?: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
-      updatedBy?: string | null;
-    };
+      pickedUpAt?: string | null
+      updatedBy?: string | null
+    }
     CreateKeySystemRequest: {
-      systemCode: string;
-      name: string;
-      manufacturer: string;
+      systemCode: string
+      name: string
+      manufacturer: string
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+    }
     UpdateKeySystemRequest: {
-      systemCode?: string;
-      name?: string;
-      manufacturer?: string;
+      systemCode?: string
+      name?: string
+      manufacturer?: string
       /** @enum {string} */
-      type?: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type?: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
+    }
     CreateLogRequest: {
-      userName: string;
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
-      description?: string | null;
-      autoGenerateDescription?: boolean;
-      entityData?: unknown;
+      objectId?: string | null
+      description?: string | null
+      autoGenerateDescription?: boolean
+      entityData?: unknown
       /** @enum {string} */
-      action?: "Skapad" | "Uppdaterad" | "Kasserad" | "Raderad";
+      action?: 'Skapad' | 'Uppdaterad' | 'Kasserad' | 'Raderad'
       /** Format: date-time */
-      eventTime?: string;
-    };
+      eventTime?: string
+    }
     CreateKeyNoteRequest: {
-      rentalObjectCode: string;
-      description: string;
-    };
+      rentalObjectCode: string
+      description: string
+    }
     UpdateKeyNoteRequest: {
-      rentalObjectCode?: string;
-      description?: string;
-    };
+      rentalObjectCode?: string
+      description?: string
+    }
     KeyBundle: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description?: string | null;
-      keyCount?: number;
-    };
+      id: string
+      name: string
+      description?: string | null
+      keyCount?: number
+    }
     BundleWithLoanedKeysInfo: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description: string | null;
-      loanedKeyCount: number;
-      totalKeyCount: number;
-    };
+      id: string
+      name: string
+      description: string | null
+      loanedKeyCount: number
+      totalKeyCount: number
+    }
     CreateKeyBundleRequest: {
-      name: string;
-      keys: string[];
-      description?: string | null;
-    };
+      name: string
+      keys: string[]
+      description?: string | null
+    }
     UpdateKeyBundleRequest: {
-      name?: string;
-      keys?: string[];
-      description?: string | null;
-    };
+      name?: string
+      keys?: string[]
+      description?: string | null
+    }
     KeyBundleDetailsResponse: {
       bundle: {
         /** Format: uuid */
-        id: string;
-        name: string;
-        description?: string | null;
-        keyCount?: number;
-      };
-      keys: ({
+        id: string
+        name: string
+        description?: string | null
+        keyCount?: number
+      }
+      keys: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: components["schemas"]["KeyLoan"][] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?: components['schemas']['KeyLoan'][] | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+    }
     CreateKeyEventRequest: {
-      keys: string[];
+      keys: string[]
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     UpdateKeyEventRequest: {
-      keys?: string[];
+      keys?: string[]
       /** @enum {string} */
-      type?: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type?: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status?: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status?: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     CreateSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
+      recipientEmail: string
+      recipientName?: string | null
       /** @default sent */
-      status?: string;
-    };
+      status?: string
+    }
     UpdateSignatureRequest: {
-      status?: string;
+      status?: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     SendSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
+      resourceId: string
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string;
-      pdfBase64: string;
-    };
+      recipientEmail: string
+      recipientName?: string
+      pdfBase64: string
+    }
     SimpleSignWebhookPayload: {
-      id: number;
-      status: string;
-      status_updated_at: string;
-    };
+      id: number
+      status: string
+      status_updated_at: string
+    }
     CreateReceiptRequest: {
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type?: "DIGITAL" | "PHYSICAL";
-      fileId?: string;
-      fileData?: string;
-      fileContentType?: string;
-    };
+      type?: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string
+      fileData?: string
+      fileContentType?: string
+    }
     UpdateReceiptRequest: {
-      fileId?: string;
-    };
+      fileId?: string
+    }
     /** @enum {string} */
-    ReceiptType: "LOAN" | "RETURN";
+    ReceiptType: 'LOAN' | 'RETURN'
     /** @enum {string} */
-    ReceiptFormat: "DIGITAL" | "PHYSICAL";
+    ReceiptFormat: 'DIGITAL' | 'PHYSICAL'
     ErrorResponse: {
       /** @example Internal server error */
-      error?: string;
-      reason?: string;
-    };
+      error?: string
+      reason?: string
+    }
     NotFoundResponse: {
       /** @example Resource not found */
-      reason: string;
-    };
+      reason: string
+    }
     BadRequestResponse: {
-      reason: string;
-    };
+      reason: string
+    }
     SchemaDownloadUrlResponse: {
-      url: string;
-      expiresIn: number;
-    };
+      url: string
+      expiresIn: number
+    }
     CardOwner: {
-      cardOwnerId: string;
-      cardOwnerType?: string | null;
-      familyName?: string | null;
-      specificName?: string | null;
-      primaryOrganization?: unknown;
-      cards?: (({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[]) | null;
-      comment?: string | null;
-      folderId?: number | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      pinCode?: string | null;
+      cardOwnerId: string
+      cardOwnerType?: string | null
+      familyName?: string | null
+      specificName?: string | null
+      primaryOrganization?: unknown
+      cards?:
+        | {
+            cardId: string
+            name?: string | null
+            owner?: unknown
+            appearanceCode?: string | null
+            classification?: string | null
+            disabled?: boolean
+            startTime?: string | null
+            stopTime?: string | null
+            createTime: string
+            pinCode?: string | null
+            state?: string | null
+            archivedAt?: string | null
+            codes?: unknown[] | null
+          }[]
+        | null
+      comment?: string | null
+      folderId?: number | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      pinCode?: string | null
       attributes?: {
-        [key: string]: string;
-      } | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      createTime?: string;
-    };
+        [key: string]: string
+      } | null
+      state?: string | null
+      archivedAt?: string | null
+      createTime?: string
+    }
     Card: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+    }
     CardDetails: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-      loans?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          loanType: "TENANT" | "MAINTENANCE";
-          contact?: string | null;
-          contact2?: string | null;
-          contactPerson?: string | null;
-          notes?: string | null;
-          /** Format: date-time */
-          returnedAt?: string | null;
-          /** Format: date-time */
-          availableToNextTenantFrom?: string | null;
-          /** Format: date-time */
-          pickedUpAt?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-          createdBy?: string | null;
-          updatedBy?: string | null;
-          keyCount?: number;
-          cardCount?: number;
-        })[]) | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+      loans?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            loanType: 'TENANT' | 'MAINTENANCE'
+            contact?: string | null
+            contact2?: string | null
+            contactPerson?: string | null
+            notes?: string | null
+            /** Format: date-time */
+            returnedAt?: string | null
+            /** Format: date-time */
+            availableToNextTenantFrom?: string | null
+            /** Format: date-time */
+            pickedUpAt?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+            createdBy?: string | null
+            updatedBy?: string | null
+            keyCount?: number
+            cardCount?: number
+          }[]
+        | null
+    }
     QueryCardOwnersParams: {
-      nameFilter?: string;
-      expand?: string;
-      idfilter?: string;
-      attributeFilter?: string;
-      selectedAttributes?: string;
-      folderFilter?: string;
-      organisationFilter?: string;
-      offset?: number;
-      limit?: number;
-    };
+      nameFilter?: string
+      expand?: string
+      idfilter?: string
+      attributeFilter?: string
+      selectedAttributes?: string
+      folderFilter?: string
+      organisationFilter?: string
+      offset?: number
+      limit?: number
+    }
     PaginatedResponse: {
-      content: unknown[];
+      content: unknown[]
       _meta: {
-        totalRecords: number;
-        page: number;
-        limit: number;
-        count: number;
-      };
-      _links: ({
-          href: string;
-          /** @enum {string} */
-          rel: "self" | "first" | "last" | "prev" | "next";
-        })[];
-    };
+        totalRecords: number
+        page: number
+        limit: number
+        count: number
+      }
+      _links: {
+        href: string
+        /** @enum {string} */
+        rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+      }[]
+    }
     SearchQueryParams: {
       /** @description The search query string used to find properties, buildings and residences */
-      q: string;
-    };
+      q: string
+    }
     PropertySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a property result
        * @enum {string}
        */
-      type: "property";
+      type: 'property'
       /** @description Property code */
-      code: string;
+      code: string
       /** @description Name or designation of the property */
-      name: string;
-    };
+      name: string
+    }
     BuildingSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a building result
        * @enum {string}
        */
-      type: "building";
+      type: 'building'
       /** @description Building code */
-      code: string;
+      code: string
       /** @description Name of the building */
-      name: string | null;
-      property?: ({
+      name: string | null
+      property?: {
         /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    };
+        name: string | null
+        id: string
+        code: string
+      } | null
+    }
     MaintenanceUnitSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a maintenance unit result
        * @enum {string}
        */
-      type: "maintenance-unit";
+      type: 'maintenance-unit'
       /** @description Code of the maintenance unit */
-      code: string;
+      code: string
       /** @description Caption/name of the maintenance unit */
-      caption: string | null;
+      caption: string | null
       /** @description Type of maintenance unit */
-      maintenanceType: string | null;
+      maintenanceType: string | null
       /** @description Property code */
-      estateCode: string | null;
+      estateCode: string | null
       /** @description Property name */
-      estate: string | null;
-    };
+      estate: string | null
+    }
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit or facility */
-    SearchResult: {
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a property result
-       * @enum {string}
-       */
-      type: "property";
-      /** @description Property code */
-      code: string;
-      /** @description Name or designation of the property */
-      name: string;
-    } | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a building result
-       * @enum {string}
-       */
-      type: "building";
-      /** @description Building code */
-      code: string;
-      /** @description Name of the building */
-      name: string | null;
-      property?: ({
-        /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a residence result
-       * @enum {string}
-       */
-      type: "residence";
-      /** @description Name of the residence */
-      name: string | null;
-      /** @description Rental object ID of the residence */
-      rentalId: string | null;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the residence */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a parking space result
-       * @enum {string}
-       */
-      type: "parking-space";
-      /** @description Name of the parking space */
-      name: string | null;
-      /** @description Rental ID of the parking space */
-      rentalId: string;
-      /** @description Code of the parking space */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a maintenance unit result
-       * @enum {string}
-       */
-      type: "maintenance-unit";
-      /** @description Code of the maintenance unit */
-      code: string;
-      /** @description Caption/name of the maintenance unit */
-      caption: string | null;
-      /** @description Type of maintenance unit */
-      maintenanceType: string | null;
-      /** @description Property code */
-      estateCode: string | null;
-      /** @description Property name */
-      estate: string | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a facility result
-       * @enum {string}
-       */
-      type: "facility";
-      /** @description Name of the facility */
-      name: string | null;
-      /** @description Rental ID of the facility */
-      rentalId: string;
-      /** @description Code of the facility */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the facility */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    });
+    SearchResult:
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a property result
+           * @enum {string}
+           */
+          type: 'property'
+          /** @description Property code */
+          code: string
+          /** @description Name or designation of the property */
+          name: string
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a building result
+           * @enum {string}
+           */
+          type: 'building'
+          /** @description Building code */
+          code: string
+          /** @description Name of the building */
+          name: string | null
+          property?: {
+            /** @description Property associated with the building */
+            name: string | null
+            id: string
+            code: string
+          } | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a residence result
+           * @enum {string}
+           */
+          type: 'residence'
+          /** @description Name of the residence */
+          name: string | null
+          /** @description Rental object ID of the residence */
+          rentalId: string | null
+          property: {
+            code: string | null
+            /** @description Name of property associated with the residence */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the residence */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a parking space result
+           * @enum {string}
+           */
+          type: 'parking-space'
+          /** @description Name of the parking space */
+          name: string | null
+          /** @description Rental ID of the parking space */
+          rentalId: string
+          /** @description Code of the parking space */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the parking space */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the parking space */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a maintenance unit result
+           * @enum {string}
+           */
+          type: 'maintenance-unit'
+          /** @description Code of the maintenance unit */
+          code: string
+          /** @description Caption/name of the maintenance unit */
+          caption: string | null
+          /** @description Type of maintenance unit */
+          maintenanceType: string | null
+          /** @description Property code */
+          estateCode: string | null
+          /** @description Property name */
+          estate: string | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a facility result
+           * @enum {string}
+           */
+          type: 'facility'
+          /** @description Name of the facility */
+          name: string | null
+          /** @description Rental ID of the facility */
+          rentalId: string
+          /** @description Code of the facility */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the facility */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the facility */
+            name: string | null
+          }
+        }
     Inspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          actions: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentNotes: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            wall1?: number;
-            /** @default 0 */
-            wall2?: number;
-            /** @default 0 */
-            wall3?: number;
-            /** @default 0 */
-            wall4?: number;
-            /** @default 0 */
-            floor?: number;
-            /** @default 0 */
-            ceiling?: number;
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall1?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall2?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall3?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall4?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            floor?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            ceiling?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: {
-              id: string;
-              type: string;
-              label: string;
-              note: string;
-            }[];
-        })[]) | null;
-    };
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              wall1: string
+              wall2: string
+              wall3: string
+              wall4: string
+              floor: string
+              ceiling: string
+              details: string
+            }
+            actions: {
+              wall1: string[]
+              wall2: string[]
+              wall3: string[]
+              wall4: string[]
+              floor: string[]
+              ceiling: string[]
+              details: string[]
+            }
+            componentNotes: {
+              wall1: string
+              wall2: string
+              wall3: string
+              wall4: string
+              floor: string
+              ceiling: string
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              wall1?: number
+              /** @default 0 */
+              wall2?: number
+              /** @default 0 */
+              wall3?: number
+              /** @default 0 */
+              wall4?: number
+              /** @default 0 */
+              floor?: number
+              /** @default 0 */
+              ceiling?: number
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              wall1: string[]
+              wall2: string[]
+              wall3: string[]
+              wall4: string[]
+              floor: string[]
+              ceiling: string[]
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall1?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall2?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall3?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall4?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              floor?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              ceiling?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+          }[]
+        | null
+    }
+    InspectionComponent: {
+      componentId: string
+      label: string
+      condition: string
+      action: string[]
+      note: string
+      photos: string[]
+      cost?: number
+      /**
+       * @default null
+       * @enum {string|null}
+       */
+      costResponsibility?: 'tenant' | 'landlord' | null
+    }
     InspectionRoom: {
-      roomId: string;
-      name?: string;
+      roomId: string
+      name?: string
       conditions: {
-        wall1: string;
-        wall2: string;
-        wall3: string;
-        wall4: string;
-        floor: string;
-        ceiling: string;
-        details: string;
-      };
+        wall1: string
+        wall2: string
+        wall3: string
+        wall4: string
+        floor: string
+        ceiling: string
+        details: string
+      }
       actions: {
-        wall1: string[];
-        wall2: string[];
-        wall3: string[];
-        wall4: string[];
-        floor: string[];
-        ceiling: string[];
-        details: string[];
-      };
+        wall1: string[]
+        wall2: string[]
+        wall3: string[]
+        wall4: string[]
+        floor: string[]
+        ceiling: string[]
+        details: string[]
+      }
       componentNotes: {
-        wall1: string;
-        wall2: string;
-        wall3: string;
-        wall4: string;
-        floor: string;
-        ceiling: string;
-        details: string;
-      };
+        wall1: string
+        wall2: string
+        wall3: string
+        wall4: string
+        floor: string
+        ceiling: string
+        details: string
+      }
       componentCosts: {
         /** @default 0 */
-        wall1?: number;
+        wall1?: number
         /** @default 0 */
-        wall2?: number;
+        wall2?: number
         /** @default 0 */
-        wall3?: number;
+        wall3?: number
         /** @default 0 */
-        wall4?: number;
+        wall4?: number
         /** @default 0 */
-        floor?: number;
+        floor?: number
         /** @default 0 */
-        ceiling?: number;
+        ceiling?: number
         /** @default 0 */
-        details?: number;
-      };
+        details?: number
+      }
       componentPhotos: {
-        wall1: string[];
-        wall2: string[];
-        wall3: string[];
-        wall4: string[];
-        floor: string[];
-        ceiling: string[];
-        details: string[];
-      };
+        wall1: string[]
+        wall2: string[]
+        wall3: string[]
+        wall4: string[]
+        floor: string[]
+        ceiling: string[]
+        details: string[]
+      }
       componentCostResponsibilities: {
         /**
          * @default null
          * @enum {string|null}
          */
-        wall1?: "tenant" | "landlord" | null;
+        wall1?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        wall2?: "tenant" | "landlord" | null;
+        wall2?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        wall3?: "tenant" | "landlord" | null;
+        wall3?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        wall4?: "tenant" | "landlord" | null;
+        wall4?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        floor?: "tenant" | "landlord" | null;
+        floor?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        ceiling?: "tenant" | "landlord" | null;
+        ceiling?: 'tenant' | 'landlord' | null
         /**
          * @default null
          * @enum {string|null}
          */
-        details?: "tenant" | "landlord" | null;
-      };
-      photos: string[];
-      isApproved: boolean;
-      isHandled: boolean;
+        details?: 'tenant' | 'landlord' | null
+      }
+      photos: string[]
+      isApproved: boolean
+      isHandled: boolean
       /** @default [] */
       detailComponents?: {
-          id: string;
-          type: string;
-          label: string;
-          note: string;
-        }[];
-    };
+        id: string
+        type: string
+        label: string
+        note: string
+      }[]
+      /** @default [] */
+      components?: {
+        componentId: string
+        label: string
+        condition: string
+        action: string[]
+        note: string
+        photos: string[]
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+      }[]
+    }
     DetailedInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
-        /** Format: date-time */
-        leaseStartDate: string;
-        /** Format: date-time */
-        leaseEndDate?: string;
-        /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
-        rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
-          roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+      lease: {
+        leaseId: string
+        leaseNumber: string
+        /** Format: date-time */
+        leaseStartDate: string
+        /** Format: date-time */
+        leaseEndDate?: string
+        /** @enum {string} */
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
+        rentalProperty?: {
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
+          roomTypes?: {
+            roomTypeId: string
+            name: string
+          }[]
+          /** Format: date-time */
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      residence: ({
-        id: string;
-        code: string;
-        name: string | null;
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      residence: {
+        id: string
+        code: string
+        name: string | null
         /** @enum {string|null} */
-        status: "VACANT" | "LEASED" | null;
-        entrance: string | null;
-        location: string | null;
-        floor: string | null;
-        partNo: number | null;
-        part: string | null;
-        deleted: boolean;
+        status: 'VACANT' | 'LEASED' | null
+        entrance: string | null
+        location: string | null
+        floor: string | null
+        partNo: number | null
+        part: string | null
+        deleted: boolean
         validityPeriod: {
           /** Format: date-time */
-          fromDate: string;
+          fromDate: string
           /** Format: date-time */
-          toDate: string;
-        };
+          toDate: string
+        }
         accessibility: {
-          wheelchairAccessible: boolean;
-          elevator: boolean;
-          residenceAdapted: boolean;
-        };
+          wheelchairAccessible: boolean
+          elevator: boolean
+          residenceAdapted: boolean
+        }
         features: {
-          hygieneFacility: string | null;
+          hygieneFacility: string | null
           balcony1?: {
-            location: string;
-            type: string;
-          };
+            location: string
+            type: string
+          }
           balcony2?: {
-            location: string;
-            type: string;
-          };
-          patioLocation: string | null;
-          sauna: boolean;
-          extraToilet: boolean;
-          sharedKitchen: boolean;
-          petAllergyFree: boolean;
+            location: string
+            type: string
+          }
+          patioLocation: string | null
+          sauna: boolean
+          extraToilet: boolean
+          sharedKitchen: boolean
+          petAllergyFree: boolean
           /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean;
-          smokeFree: boolean;
-          asbestos: boolean;
-        };
+          electricAllergyIntolerance: boolean
+          smokeFree: boolean
+          asbestos: boolean
+        }
         type: {
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-        };
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+        }
         residenceType: {
-          residenceTypeId: string;
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-          systemStandard: number;
-          checklistId: string | null;
-          componentTypeActionId: string | null;
-          statisticsGroupSCBId: string | null;
-          statisticsGroup2Id: string | null;
-          statisticsGroup3Id: string | null;
-          statisticsGroup4Id: string | null;
-          timestamp: string;
-        };
-        rentalInformation: ({
-          apartmentNumber: string | null;
-          rentalId: string | null;
+          residenceTypeId: string
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+          systemStandard: number
+          checklistId: string | null
+          componentTypeActionId: string | null
+          statisticsGroupSCBId: string | null
+          statisticsGroup2Id: string | null
+          statisticsGroup3Id: string | null
+          statisticsGroup4Id: string | null
+          timestamp: string
+        }
+        rentalInformation: {
+          apartmentNumber: string | null
+          rentalId: string | null
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
+            code: string
+            name: string | null
+          }
+        } | null
         propertyObject: {
           energy: {
-            energyClass: number;
+            energyClass: number
             /** Format: date-time */
-            energyRegistered?: string;
+            energyRegistered?: string
             /** Format: date-time */
-            energyReceived?: string;
-            energyIndex?: number;
-          };
-          rentalId: string | null;
-          rentalInformation: ({
+            energyReceived?: string
+            energyIndex?: number
+          }
+          rentalId: string | null
+          rentalInformation: {
             type: {
-              code: string;
-              name: string | null;
-            };
-          }) | null;
-          rentalBlocks: ({
-              id: string;
-              blockReasonId: string | null;
-              blockReason: string | null;
-              /** Format: date-time */
-              fromDate: string;
-              /** Format: date-time */
-              toDate: string | null;
-              amount: number | null;
-            })[];
-        };
+              code: string
+              name: string | null
+            }
+          } | null
+          rentalBlocks: {
+            id: string
+            blockReasonId: string | null
+            blockReason: string | null
+            /** Format: date-time */
+            fromDate: string
+            /** Format: date-time */
+            toDate: string | null
+            amount: number | null
+          }[]
+        }
         property: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
+          id: string | null
+          name: string | null
+          code: string | null
+        }
         building: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        staircase: ({
-          id: string;
-          code: string;
-          name: string | null;
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        staircase: {
+          id: string
+          code: string
+          name: string | null
           features: {
-            floorPlan: string | null;
-            accessibleByElevator: boolean;
-          };
+            floorPlan: string | null
+            accessibleByElevator: boolean
+          }
           dates: {
             /** Format: date-time */
-            from: string;
+            from: string
             /** Format: date-time */
-            to: string;
-          };
+            to: string
+          }
           property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
+            propertyId: string | null
+            propertyName: string | null
+            propertyCode: string | null
+          }
           building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
-          };
-          deleted: boolean;
-          timestamp: string;
-        }) | null;
-        areaSize: number | null;
-        malarEnergiFacilityId: string | null;
-      }) | null;
-    };
+            buildingId: string | null
+            buildingName: string | null
+            buildingCode: string | null
+          }
+          deleted: boolean
+          timestamp: string
+        } | null
+        areaSize: number | null
+        malarEnergiFacilityId: string | null
+      } | null
+    }
     DetailedInspectionRoom: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
-        /** Format: date-time */
-        leaseStartDate: string;
-        /** Format: date-time */
-        leaseEndDate?: string;
-        /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
-        rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
-          roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+      lease: {
+        leaseId: string
+        leaseNumber: string
+        /** Format: date-time */
+        leaseStartDate: string
+        /** Format: date-time */
+        leaseEndDate?: string
+        /** @enum {string} */
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
+        rentalProperty?: {
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
+          roomTypes?: {
+            roomTypeId: string
+            name: string
+          }[]
+          /** Format: date-time */
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      residence: ({
-        id: string;
-        code: string;
-        name: string | null;
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      residence: {
+        id: string
+        code: string
+        name: string | null
         /** @enum {string|null} */
-        status: "VACANT" | "LEASED" | null;
-        entrance: string | null;
-        location: string | null;
-        floor: string | null;
-        partNo: number | null;
-        part: string | null;
-        deleted: boolean;
+        status: 'VACANT' | 'LEASED' | null
+        entrance: string | null
+        location: string | null
+        floor: string | null
+        partNo: number | null
+        part: string | null
+        deleted: boolean
         validityPeriod: {
           /** Format: date-time */
-          fromDate: string;
+          fromDate: string
           /** Format: date-time */
-          toDate: string;
-        };
+          toDate: string
+        }
         accessibility: {
-          wheelchairAccessible: boolean;
-          elevator: boolean;
-          residenceAdapted: boolean;
-        };
+          wheelchairAccessible: boolean
+          elevator: boolean
+          residenceAdapted: boolean
+        }
         features: {
-          hygieneFacility: string | null;
+          hygieneFacility: string | null
           balcony1?: {
-            location: string;
-            type: string;
-          };
+            location: string
+            type: string
+          }
           balcony2?: {
-            location: string;
-            type: string;
-          };
-          patioLocation: string | null;
-          sauna: boolean;
-          extraToilet: boolean;
-          sharedKitchen: boolean;
-          petAllergyFree: boolean;
+            location: string
+            type: string
+          }
+          patioLocation: string | null
+          sauna: boolean
+          extraToilet: boolean
+          sharedKitchen: boolean
+          petAllergyFree: boolean
           /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean;
-          smokeFree: boolean;
-          asbestos: boolean;
-        };
+          electricAllergyIntolerance: boolean
+          smokeFree: boolean
+          asbestos: boolean
+        }
         type: {
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-        };
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+        }
         residenceType: {
-          residenceTypeId: string;
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-          systemStandard: number;
-          checklistId: string | null;
-          componentTypeActionId: string | null;
-          statisticsGroupSCBId: string | null;
-          statisticsGroup2Id: string | null;
-          statisticsGroup3Id: string | null;
-          statisticsGroup4Id: string | null;
-          timestamp: string;
-        };
-        rentalInformation: ({
-          apartmentNumber: string | null;
-          rentalId: string | null;
+          residenceTypeId: string
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+          systemStandard: number
+          checklistId: string | null
+          componentTypeActionId: string | null
+          statisticsGroupSCBId: string | null
+          statisticsGroup2Id: string | null
+          statisticsGroup3Id: string | null
+          statisticsGroup4Id: string | null
+          timestamp: string
+        }
+        rentalInformation: {
+          apartmentNumber: string | null
+          rentalId: string | null
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
+            code: string
+            name: string | null
+          }
+        } | null
         propertyObject: {
           energy: {
-            energyClass: number;
+            energyClass: number
             /** Format: date-time */
-            energyRegistered?: string;
+            energyRegistered?: string
             /** Format: date-time */
-            energyReceived?: string;
-            energyIndex?: number;
-          };
-          rentalId: string | null;
-          rentalInformation: ({
+            energyReceived?: string
+            energyIndex?: number
+          }
+          rentalId: string | null
+          rentalInformation: {
             type: {
-              code: string;
-              name: string | null;
-            };
-          }) | null;
-          rentalBlocks: ({
-              id: string;
-              blockReasonId: string | null;
-              blockReason: string | null;
-              /** Format: date-time */
-              fromDate: string;
-              /** Format: date-time */
-              toDate: string | null;
-              amount: number | null;
-            })[];
-        };
+              code: string
+              name: string | null
+            }
+          } | null
+          rentalBlocks: {
+            id: string
+            blockReasonId: string | null
+            blockReason: string | null
+            /** Format: date-time */
+            fromDate: string
+            /** Format: date-time */
+            toDate: string | null
+            amount: number | null
+          }[]
+        }
         property: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
+          id: string | null
+          name: string | null
+          code: string | null
+        }
         building: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        staircase: ({
-          id: string;
-          code: string;
-          name: string | null;
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        staircase: {
+          id: string
+          code: string
+          name: string | null
           features: {
-            floorPlan: string | null;
-            accessibleByElevator: boolean;
-          };
+            floorPlan: string | null
+            accessibleByElevator: boolean
+          }
           dates: {
             /** Format: date-time */
-            from: string;
+            from: string
             /** Format: date-time */
-            to: string;
-          };
+            to: string
+          }
           property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
+            propertyId: string | null
+            propertyName: string | null
+            propertyCode: string | null
+          }
           building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
-          };
-          deleted: boolean;
-          timestamp: string;
-        }) | null;
-        areaSize: number | null;
-        malarEnergiFacilityId: string | null;
-      }) | null;
-    };
+            buildingId: string | null
+            buildingName: string | null
+            buildingCode: string | null
+          }
+          deleted: boolean
+          timestamp: string
+        } | null
+        areaSize: number | null
+        malarEnergiFacilityId: string | null
+      } | null
+    }
     DetailedInspectionRemark: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
-        /** Format: date-time */
-        leaseStartDate: string;
-        /** Format: date-time */
-        leaseEndDate?: string;
-        /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
-        rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
-          roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+      lease: {
+        leaseId: string
+        leaseNumber: string
+        /** Format: date-time */
+        leaseStartDate: string
+        /** Format: date-time */
+        leaseEndDate?: string
+        /** @enum {string} */
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
+        rentalProperty?: {
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
+          roomTypes?: {
+            roomTypeId: string
+            name: string
+          }[]
+          /** Format: date-time */
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      residence: ({
-        id: string;
-        code: string;
-        name: string | null;
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      residence: {
+        id: string
+        code: string
+        name: string | null
         /** @enum {string|null} */
-        status: "VACANT" | "LEASED" | null;
-        entrance: string | null;
-        location: string | null;
-        floor: string | null;
-        partNo: number | null;
-        part: string | null;
-        deleted: boolean;
+        status: 'VACANT' | 'LEASED' | null
+        entrance: string | null
+        location: string | null
+        floor: string | null
+        partNo: number | null
+        part: string | null
+        deleted: boolean
         validityPeriod: {
           /** Format: date-time */
-          fromDate: string;
+          fromDate: string
           /** Format: date-time */
-          toDate: string;
-        };
+          toDate: string
+        }
         accessibility: {
-          wheelchairAccessible: boolean;
-          elevator: boolean;
-          residenceAdapted: boolean;
-        };
+          wheelchairAccessible: boolean
+          elevator: boolean
+          residenceAdapted: boolean
+        }
         features: {
-          hygieneFacility: string | null;
+          hygieneFacility: string | null
           balcony1?: {
-            location: string;
-            type: string;
-          };
+            location: string
+            type: string
+          }
           balcony2?: {
-            location: string;
-            type: string;
-          };
-          patioLocation: string | null;
-          sauna: boolean;
-          extraToilet: boolean;
-          sharedKitchen: boolean;
-          petAllergyFree: boolean;
+            location: string
+            type: string
+          }
+          patioLocation: string | null
+          sauna: boolean
+          extraToilet: boolean
+          sharedKitchen: boolean
+          petAllergyFree: boolean
           /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean;
-          smokeFree: boolean;
-          asbestos: boolean;
-        };
+          electricAllergyIntolerance: boolean
+          smokeFree: boolean
+          asbestos: boolean
+        }
         type: {
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-        };
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+        }
         residenceType: {
-          residenceTypeId: string;
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-          systemStandard: number;
-          checklistId: string | null;
-          componentTypeActionId: string | null;
-          statisticsGroupSCBId: string | null;
-          statisticsGroup2Id: string | null;
-          statisticsGroup3Id: string | null;
-          statisticsGroup4Id: string | null;
-          timestamp: string;
-        };
-        rentalInformation: ({
-          apartmentNumber: string | null;
-          rentalId: string | null;
+          residenceTypeId: string
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+          systemStandard: number
+          checklistId: string | null
+          componentTypeActionId: string | null
+          statisticsGroupSCBId: string | null
+          statisticsGroup2Id: string | null
+          statisticsGroup3Id: string | null
+          statisticsGroup4Id: string | null
+          timestamp: string
+        }
+        rentalInformation: {
+          apartmentNumber: string | null
+          rentalId: string | null
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
+            code: string
+            name: string | null
+          }
+        } | null
         propertyObject: {
           energy: {
-            energyClass: number;
+            energyClass: number
             /** Format: date-time */
-            energyRegistered?: string;
+            energyRegistered?: string
             /** Format: date-time */
-            energyReceived?: string;
-            energyIndex?: number;
-          };
-          rentalId: string | null;
-          rentalInformation: ({
+            energyReceived?: string
+            energyIndex?: number
+          }
+          rentalId: string | null
+          rentalInformation: {
             type: {
-              code: string;
-              name: string | null;
-            };
-          }) | null;
-          rentalBlocks: ({
-              id: string;
-              blockReasonId: string | null;
-              blockReason: string | null;
-              /** Format: date-time */
-              fromDate: string;
-              /** Format: date-time */
-              toDate: string | null;
-              amount: number | null;
-            })[];
-        };
+              code: string
+              name: string | null
+            }
+          } | null
+          rentalBlocks: {
+            id: string
+            blockReasonId: string | null
+            blockReason: string | null
+            /** Format: date-time */
+            fromDate: string
+            /** Format: date-time */
+            toDate: string | null
+            amount: number | null
+          }[]
+        }
         property: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
+          id: string | null
+          name: string | null
+          code: string | null
+        }
         building: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        staircase: ({
-          id: string;
-          code: string;
-          name: string | null;
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        staircase: {
+          id: string
+          code: string
+          name: string | null
           features: {
-            floorPlan: string | null;
-            accessibleByElevator: boolean;
-          };
+            floorPlan: string | null
+            accessibleByElevator: boolean
+          }
           dates: {
             /** Format: date-time */
-            from: string;
+            from: string
             /** Format: date-time */
-            to: string;
-          };
+            to: string
+          }
           property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
+            propertyId: string | null
+            propertyName: string | null
+            propertyCode: string | null
+          }
           building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
-          };
-          deleted: boolean;
-          timestamp: string;
-        }) | null;
-        areaSize: number | null;
-        malarEnergiFacilityId: string | null;
-      }) | null;
-    };
+            buildingId: string | null
+            buildingName: string | null
+            buildingCode: string | null
+          }
+          deleted: boolean
+          timestamp: string
+        } | null
+        areaSize: number | null
+        malarEnergiFacilityId: string | null
+      } | null
+    }
     TenantContactsResponse: {
       inspection: {
-        id: string;
-        address: string;
-        apartmentCode: string | null;
-      };
+        id: string
+        address: string
+        apartmentCode: string | null
+      }
       new_tenant?: {
         contacts: {
-            fullName: string;
-            emailAddress: string;
-            contactCode: string;
-          }[];
-        contractId: string;
-      };
-      tenant?: components["schemas"]["TenantContactsResponse"]["new_tenant"];
-    };
+          fullName: string
+          emailAddress: string
+          contactCode: string
+        }[]
+        contractId: string
+      }
+      tenant?: components['schemas']['TenantContactsResponse']['new_tenant']
+    }
     SendProtocolRequest: {
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
-    };
+      recipient: 'tenant' | 'new-tenant'
+    }
     SendProtocolResponse: {
-      success: boolean;
+      success: boolean
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
+      recipient: 'tenant' | 'new-tenant'
       sentTo: {
-        emails: string[];
-        contactNames: string[];
-        contractId: string;
-      };
-      error?: string;
-    };
+        emails: string[]
+        contactNames: string[]
+        contractId: string
+      }
+      error?: string
+    }
     CreateInspectionRequest: {
-      status: string;
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-    };
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
+          /** Format: date-time */
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+    }
     UpdateInspectionStatusRequest: {
       /** @enum {string} */
-      status?: "Registrerad" | "Påbörjad" | "Genomförd";
-      inspector?: string;
-    };
+      status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
+      inspector?: string
+    }
     InspectionWithSource: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
       /** @enum {string} */
-      source: "xpand" | "internal";
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      source: 'xpand' | 'internal'
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-    };
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+    }
     InternalInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      residenceId: string;
-      isFurnished: boolean;
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          actions: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentNotes: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            wall1?: number;
-            /** @default 0 */
-            wall2?: number;
-            /** @default 0 */
-            wall3?: number;
-            /** @default 0 */
-            wall4?: number;
-            /** @default 0 */
-            floor?: number;
-            /** @default 0 */
-            ceiling?: number;
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall1?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall2?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall3?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall4?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            floor?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            ceiling?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: {
-              id: string;
-              type: string;
-              label: string;
-              note: string;
-            }[];
-        })[]) | null;
-    };
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      residenceId: string
+      isFurnished: boolean
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              wall1: string
+              wall2: string
+              wall3: string
+              wall4: string
+              floor: string
+              ceiling: string
+              details: string
+            }
+            actions: {
+              wall1: string[]
+              wall2: string[]
+              wall3: string[]
+              wall4: string[]
+              floor: string[]
+              ceiling: string[]
+              details: string[]
+            }
+            componentNotes: {
+              wall1: string
+              wall2: string
+              wall3: string
+              wall4: string
+              floor: string
+              ceiling: string
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              wall1?: number
+              /** @default 0 */
+              wall2?: number
+              /** @default 0 */
+              wall3?: number
+              /** @default 0 */
+              wall4?: number
+              /** @default 0 */
+              floor?: number
+              /** @default 0 */
+              ceiling?: number
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              wall1: string[]
+              wall2: string[]
+              wall3: string[]
+              wall4: string[]
+              floor: string[]
+              ceiling: string[]
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall1?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall2?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall3?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              wall4?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              floor?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              ceiling?: 'tenant' | 'landlord' | null
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+          }[]
+        | null
+    }
     SaveInspectionDraftRequest: {
-      inspectorName: string;
-      rooms: ({
-          roomId: string;
-          name?: string;
-          conditions: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          actions: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentNotes: {
-            wall1: string;
-            wall2: string;
-            wall3: string;
-            wall4: string;
-            floor: string;
-            ceiling: string;
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            wall1?: number;
-            /** @default 0 */
-            wall2?: number;
-            /** @default 0 */
-            wall3?: number;
-            /** @default 0 */
-            wall4?: number;
-            /** @default 0 */
-            floor?: number;
-            /** @default 0 */
-            ceiling?: number;
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            wall1: string[];
-            wall2: string[];
-            wall3: string[];
-            wall4: string[];
-            floor: string[];
-            ceiling: string[];
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall1?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall2?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall3?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            wall4?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            floor?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            ceiling?: "tenant" | "landlord" | null;
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: {
-              id: string;
-              type: string;
-              label: string;
-              note: string;
-            }[];
-        })[];
-      isFurnished: boolean;
-    };
+      inspectorName: string
+      rooms: {
+        roomId: string
+        name?: string
+        conditions: {
+          wall1: string
+          wall2: string
+          wall3: string
+          wall4: string
+          floor: string
+          ceiling: string
+          details: string
+        }
+        actions: {
+          wall1: string[]
+          wall2: string[]
+          wall3: string[]
+          wall4: string[]
+          floor: string[]
+          ceiling: string[]
+          details: string[]
+        }
+        componentNotes: {
+          wall1: string
+          wall2: string
+          wall3: string
+          wall4: string
+          floor: string
+          ceiling: string
+          details: string
+        }
+        componentCosts: {
+          /** @default 0 */
+          wall1?: number
+          /** @default 0 */
+          wall2?: number
+          /** @default 0 */
+          wall3?: number
+          /** @default 0 */
+          wall4?: number
+          /** @default 0 */
+          floor?: number
+          /** @default 0 */
+          ceiling?: number
+          /** @default 0 */
+          details?: number
+        }
+        componentPhotos: {
+          wall1: string[]
+          wall2: string[]
+          wall3: string[]
+          wall4: string[]
+          floor: string[]
+          ceiling: string[]
+          details: string[]
+        }
+        componentCostResponsibilities: {
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          wall1?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          wall2?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          wall3?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          wall4?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          floor?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          ceiling?: 'tenant' | 'landlord' | null
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          details?: 'tenant' | 'landlord' | null
+        }
+        photos: string[]
+        isApproved: boolean
+        isHandled: boolean
+        /** @default [] */
+        detailComponents?: {
+          id: string
+          type: string
+          label: string
+          note: string
+        }[]
+        /** @default [] */
+        components?: {
+          componentId: string
+          label: string
+          condition: string
+          action: string[]
+          note: string
+          photos: string[]
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+        }[]
+      }[]
+      isFurnished: boolean
+    }
     FileListItem: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
-    };
+      size: number
+    }
     FileMetadata: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
+      size: number
       /** @description Custom metadata key-value pairs */
       metaData?: {
-        [key: string]: string;
-      };
-    };
+        [key: string]: string
+      }
+    }
     FileUploadRequest: {
       /** @description Target file name/path */
-      fileName: string;
+      fileName: string
       /** @description Base64 encoded file content */
-      fileData: string;
+      fileData: string
       /** @description MIME type of the file */
-      contentType: string;
-    };
+      contentType: string
+    }
     FileUploadResponse: {
       /** @description Stored file name/path */
-      fileName: string;
+      fileName: string
       /** @description Success message */
-      message: string;
-    };
+      message: string
+    }
     FileUrlResponse: {
       /**
        * Format: uri
        * @description Presigned download URL
        */
-      url: string;
+      url: string
       /** @description URL expiry time in seconds */
-      expiresIn: number;
-    };
+      expiresIn: number
+    }
     FileExistsResponse: {
       /** @description Whether the file exists */
-      exists: boolean;
-    };
+      exists: boolean
+    }
     ListFilesResponse: {
       /** @description Array of file metadata objects */
       files: {
-          /** @description Full file path/name */
-          name: string;
-          /**
-           * Format: date-time
-           * @description ISO 8601 timestamp
-           */
-          lastModified: string;
-          /** @description ETag for file version */
-          etag: string;
-          /** @description File size in bytes */
-          size: number;
-        }[];
-    };
+        /** @description Full file path/name */
+        name: string
+        /**
+         * Format: date-time
+         * @description ISO 8601 timestamp
+         */
+        lastModified: string
+        /** @description ETag for file version */
+        etag: string
+        /** @description File size in bytes */
+        size: number
+      }[]
+    }
     ListFilesQuery: {
       /** @description Filter files by prefix */
-      prefix?: string;
-    };
+      prefix?: string
+    }
     FileUrlQuery: {
       /**
        * @description URL expiry time
        * @default 3600
        */
-      expirySeconds?: number;
-    };
+      expirySeconds?: number
+    }
     BulkSmsResult: {
       /** @description Phone numbers that received SMS */
-      successful: string[];
+      successful: string[]
       /** @description Invalid phone numbers */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     BulkEmailResult: {
       /** @description Email addresses that received email */
-      successful: string[];
+      successful: string[]
       /** @description Invalid email addresses */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     KeycloakUser: {
-      id?: string;
-      username?: string;
-      firstName?: string;
-      lastName?: string;
-      email?: string;
-    };
+      id?: string
+      username?: string
+      firstName?: string
+      lastName?: string
+      email?: string
+    }
     RentalPropertyResponse: {
       content?: {
-        id?: string;
-        type?: string;
+        id?: string
+        type?: string
         property?: {
-          rentalTypeCode?: string;
-          rentalType?: string;
-          address?: string;
-          code?: string;
-          number?: string;
-          type?: string;
-          roomTypeCode?: string;
-          entrance?: string;
-          floor?: string;
-          hasElevator?: boolean;
-          washSpace?: string;
-          area?: number;
-          estateCode?: string;
-          estate?: string;
-          buildingCode?: string;
-          building?: string;
-        };
-      };
+          rentalTypeCode?: string
+          rentalType?: string
+          address?: string
+          code?: string
+          number?: string
+          type?: string
+          roomTypeCode?: string
+          entrance?: string
+          floor?: string
+          hasElevator?: boolean
+          washSpace?: string
+          area?: number
+          estateCode?: string
+          estate?: string
+          buildingCode?: string
+          building?: string
+        }
+      }
       _links?: {
         self?: {
-          href?: string;
-        };
+          href?: string
+        }
         link?: {
-          href?: string;
-          templated?: boolean;
-        };
-      };
-    };
-    ContactV1: ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "individual";
-      personal: {
-        nationalRegistrationNumber: string | null;
-        birthDate: string | null;
-        firstName: string | null;
-        lastName: string | null;
-        fullName: string;
-      };
-      trustee?: {
-        contactCode: string;
-        fullName?: string;
-      };
-    }) | ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "organisation";
-      organisation: {
-        organisationNumber: string;
-        name: string;
-      };
-    });
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+          href?: string
+          templated?: boolean
+        }
+      }
+    }
+    ContactV1:
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'individual'
+          personal: {
+            nationalRegistrationNumber: string | null
+            birthDate: string | null
+            firstName: string | null
+            lastName: string | null
+            fullName: string
+          }
+          trustee?: {
+            contactCode: string
+            fullName?: string
+          }
+        }
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'organisation'
+          organisation: {
+            organisationNumber: string
+            name: string
+          }
+        }
+  }
+  responses: never
+  parameters: never
+  requestBodies: never
+  headers: never
+  pathItems: never
 }
 
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 
-export type external = Record<string, never>;
+export type external = Record<string, never>
 
-export type operations = Record<string, never>;
+export type operations = Record<string, never>

--- a/apps/property-tree/src/features/inspections/hooks/useComponentInspection.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useComponentInspection.ts
@@ -4,7 +4,10 @@ import type { components } from '@/services/api/core/generated/api-types'
 
 import { CONDITION_TYPE, type CostResponsibility } from '../constants'
 
+import { emptyInspectionComponent } from '../lib/inspectionComponent'
+
 type InspectionRoom = components['schemas']['InspectionRoom']
+type InspectionComponent = NonNullable<InspectionRoom['components']>[number]
 
 export interface UseComponentInspectionReturn {
   updateCondition: (
@@ -52,6 +55,64 @@ export interface UseComponentInspectionReturn {
     componentId: string,
     note: string
   ) => void
+  updateComponentCondition: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    value: string
+  ) => void
+  updateComponentAction: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    action: string
+  ) => void
+  updateComponentNote: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    note: string
+  ) => void
+  addComponentPhoto: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    photoDataUrl: string
+  ) => void
+  removeComponentPhoto: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    photoIndex: number
+  ) => void
+  updateComponentCostById: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    cost: number
+  ) => void
+  updateComponentCostResponsibilityById: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    value: CostResponsibility
+  ) => void
+  setRoomHandled: (roomId: string, isHandled: boolean) => void
+}
+
+export function upsertComponent(
+  components: readonly InspectionComponent[] | undefined,
+  componentId: string,
+  label: string,
+  update: (existing: InspectionComponent) => InspectionComponent
+): InspectionComponent[] {
+  const list = components ?? []
+  const index = list.findIndex((c) => c.componentId === componentId)
+  if (index === -1) {
+    return [...list, update(emptyInspectionComponent(componentId, label))]
+  }
+  // Keep label fresh: the source of truth is the live fetched list.
+  return list.map((c, i) => (i === index ? update({ ...c, label }) : c))
 }
 
 export function useComponentInspection(
@@ -60,9 +121,10 @@ export function useComponentInspection(
   >
 ): UseComponentInspectionReturn {
   /**
-   * Update condition for a component in a room
-   * Auto-calculates isHandled based on whether all structural conditions are set
-   * (excludes 'details' which is handled by the detail components section)
+   * Update condition for a surface in a room.
+   * isHandled is computed at save time (see deriveRoomIsHandled) because the
+   * set of visible rows depends on fetched components, which this hook cannot
+   * see.
    */
   const updateCondition = useCallback(
     (
@@ -78,13 +140,6 @@ export function useComponentInspection(
             [field]: value,
           },
         }
-
-        // Auto-calculate isHandled based on structural conditions (excluding details)
-        const { details: _, ...structuralConditions } = updatedRoom.conditions
-        const allConditionsSet = Object.values(structuralConditions).every(
-          (condition) => condition && condition.trim() !== ''
-        )
-        updatedRoom.isHandled = allConditionsSet
 
         // Cost responsibility only applies to Acceptabel/Skadad; clear it when
         // the condition is switched back to God so stale data isn't persisted.
@@ -309,6 +364,203 @@ export function useComponentInspection(
     [setInspectionData]
   )
 
+  /**
+   * Update condition for a fetched component (keyed by componentId).
+   * Cost responsibility only applies to Acceptabel/Skadad; clear it when the
+   * condition is switched back to God so stale data isn't persisted. Mirrors
+   * the surface-keyed rule in updateCondition.
+   */
+  const updateComponentCondition = useCallback(
+    (roomId: string, componentId: string, label: string, value: string) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({
+              ...c,
+              condition: value,
+              ...(value === CONDITION_TYPE.GOOD
+                ? { costResponsibility: null }
+                : {}),
+            })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Toggle an action on a fetched component.
+   */
+  const updateComponentAction = useCallback(
+    (roomId: string, componentId: string, label: string, action: string) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({
+              ...c,
+              action: c.action.includes(action)
+                ? c.action.filter((a) => a !== action)
+                : [...c.action, action],
+            })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Update note on a fetched component.
+   */
+  const updateComponentNote = useCallback(
+    (roomId: string, componentId: string, label: string, note: string) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({ ...c, note })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Append a photo to a fetched component.
+   */
+  const addComponentPhoto = useCallback(
+    (
+      roomId: string,
+      componentId: string,
+      label: string,
+      photoDataUrl: string
+    ) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({ ...c, photos: [...c.photos, photoDataUrl] })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Explicitly set isHandled for a room. Driven by RoomInspectionEditor which
+   * is the only place that sees both surface state and fetched components.
+   * Guarded against no-op updates to prevent render loops.
+   */
+  const setRoomHandled = useCallback(
+    (roomId: string, isHandled: boolean) => {
+      setInspectionData((prev) => {
+        if (!prev[roomId] || prev[roomId].isHandled === isHandled) return prev
+        return {
+          ...prev,
+          [roomId]: { ...prev[roomId], isHandled },
+        }
+      })
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Remove a photo by index from a fetched component.
+   */
+  const removeComponentPhoto = useCallback(
+    (
+      roomId: string,
+      componentId: string,
+      label: string,
+      photoIndex: number
+    ) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({
+              ...c,
+              photos: c.photos.filter((_, i) => i !== photoIndex),
+            })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Update cost for a fetched component (keyed by componentId).
+   */
+  const updateComponentCostById = useCallback(
+    (roomId: string, componentId: string, label: string, cost: number) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({ ...c, cost })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
+  /**
+   * Update cost responsibility for a fetched component (keyed by componentId).
+   */
+  const updateComponentCostResponsibilityById = useCallback(
+    (
+      roomId: string,
+      componentId: string,
+      label: string,
+      value: CostResponsibility
+    ) => {
+      setInspectionData((prev) => ({
+        ...prev,
+        [roomId]: {
+          ...prev[roomId],
+          components: upsertComponent(
+            prev[roomId].components,
+            componentId,
+            label,
+            (c) => ({ ...c, costResponsibility: value })
+          ),
+        },
+      }))
+    },
+    [setInspectionData]
+  )
+
   return {
     updateCondition,
     updateAction,
@@ -320,5 +572,13 @@ export function useComponentInspection(
     addDetailComponent,
     removeDetailComponent,
     updateDetailComponentNote,
+    updateComponentCondition,
+    updateComponentAction,
+    updateComponentNote,
+    addComponentPhoto,
+    removeComponentPhoto,
+    updateComponentCostById,
+    updateComponentCostResponsibilityById,
+    setRoomHandled,
   }
 }

--- a/apps/property-tree/src/features/inspections/hooks/useInspectionForm.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useInspectionForm.ts
@@ -84,6 +84,17 @@ export function useInspectionForm(
     handleDetailComponentRemove: componentOps.removeDetailComponent,
     handleDetailComponentNoteUpdate: componentOps.updateDetailComponentNote,
 
+    // Fetched component operations (keyed by componentId)
+    handleComponentConditionUpdate: componentOps.updateComponentCondition,
+    handleComponentActionUpdate: componentOps.updateComponentAction,
+    handleComponentNoteUpdateById: componentOps.updateComponentNote,
+    handleComponentPhotoAddById: componentOps.addComponentPhoto,
+    handleComponentPhotoRemoveById: componentOps.removeComponentPhoto,
+    handleComponentCostUpdateById: componentOps.updateComponentCostById,
+    handleComponentCostResponsibilityUpdateById:
+      componentOps.updateComponentCostResponsibilityById,
+    handleRoomHandledSet: componentOps.setRoomHandled,
+
     // Legacy handlers
     handleCancel,
 

--- a/apps/property-tree/src/features/inspections/hooks/useInspectionFormState.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useInspectionFormState.ts
@@ -57,6 +57,12 @@ export function useInspectionFormState(
               room.componentCostResponsibilities ?? {
                 ...EMPTY_COMPONENT_COST_RESPONSIBILITIES,
               },
+            // Default costResponsibility: null for components saved before
+            // the field existed; Zod's server-side default covers writes.
+            components: (room.components ?? []).map((c) => ({
+              costResponsibility: null,
+              ...c,
+            })),
           }
           return acc
         },

--- a/apps/property-tree/src/features/inspections/lib/initialFormData.ts
+++ b/apps/property-tree/src/features/inspections/lib/initialFormData.ts
@@ -68,6 +68,7 @@ export const initialRoomData: InspectionRoom = {
   isApproved: false,
   isHandled: false,
   detailComponents: [],
+  components: [],
 }
 
 export const initializeInspectionData = (rooms: { id: string }[]) => {

--- a/apps/property-tree/src/features/inspections/lib/inspectionComponent.ts
+++ b/apps/property-tree/src/features/inspections/lib/inspectionComponent.ts
@@ -1,0 +1,55 @@
+import type { components } from '@/services/api/core/generated/api-types'
+
+import { mergeComponentsWithDefaults } from '../constants/components'
+
+type InspectionRoom = components['schemas']['InspectionRoom']
+type InspectionComponent = NonNullable<InspectionRoom['components']>[number]
+type FetchedComponent = components['schemas']['Component']
+
+export function emptyInspectionComponent(
+  componentId: string,
+  label: string
+): InspectionComponent {
+  return {
+    componentId,
+    label,
+    condition: '',
+    action: [],
+    note: '',
+    photos: [],
+  }
+}
+
+/**
+ * A room is handled when every visible row has a condition set.
+ *
+ * Visible rows are surface defaults (wall1–4, floor, ceiling) minus the ones
+ * superseded by fetched components, plus the fetched components themselves.
+ * Detail components (manual entries) are not counted.
+ */
+export function deriveRoomIsHandled(
+  room: InspectionRoom,
+  fetched: readonly FetchedComponent[]
+): boolean {
+  const rows = mergeComponentsWithDefaults(fetched)
+  const defaultRows = rows.filter((r) => r.isDefault)
+  const equipmentRows = rows.filter((r) => !r.isDefault)
+
+  if (defaultRows.length === 0 && equipmentRows.length === 0) return false
+
+  const componentsById = new Map(
+    (room.components ?? []).map((c) => [c.componentId, c])
+  )
+
+  const surfacesDone = defaultRows.every((row) => {
+    const key = row.key as keyof InspectionRoom['conditions']
+    return room.conditions[key]?.trim() !== ''
+  })
+  const equipmentDone = equipmentRows.every((row) => {
+    const id = row.componentId
+    if (!id) return false
+    return componentsById.get(id)?.condition?.trim() !== ''
+  })
+
+  return surfacesDone && equipmentDone
+}

--- a/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
@@ -79,6 +79,14 @@ export function InspectionForm({
     handleDetailComponentAdd,
     handleDetailComponentRemove,
     handleDetailComponentNoteUpdate,
+    handleComponentConditionUpdate,
+    handleComponentActionUpdate,
+    handleComponentNoteUpdateById,
+    handleComponentPhotoAddById,
+    handleComponentPhotoRemoveById,
+    handleComponentCostUpdateById,
+    handleComponentCostResponsibilityUpdateById,
+    handleRoomHandledSet,
   } = useInspectionForm(initialRooms, existingInspection)
 
   useEffect(() => {
@@ -210,6 +218,81 @@ export function InspectionForm({
                           note
                         )
                       }
+                      onFetchedComponentConditionUpdate={(
+                        componentId,
+                        label,
+                        value
+                      ) =>
+                        handleComponentConditionUpdate(
+                          room.id,
+                          componentId,
+                          label,
+                          value
+                        )
+                      }
+                      onFetchedComponentActionUpdate={(
+                        componentId,
+                        label,
+                        action
+                      ) =>
+                        handleComponentActionUpdate(
+                          room.id,
+                          componentId,
+                          label,
+                          action
+                        )
+                      }
+                      onFetchedComponentNoteUpdate={(
+                        componentId,
+                        label,
+                        note
+                      ) =>
+                        handleComponentNoteUpdateById(
+                          room.id,
+                          componentId,
+                          label,
+                          note
+                        )
+                      }
+                      onFetchedComponentPhotoAdd={(
+                        componentId,
+                        label,
+                        photoDataUrl
+                      ) =>
+                        handleComponentPhotoAddById(
+                          room.id,
+                          componentId,
+                          label,
+                          photoDataUrl
+                        )
+                      }
+                      onFetchedComponentPhotoRemove={(
+                        componentId,
+                        label,
+                        index
+                      ) =>
+                        handleComponentPhotoRemoveById(
+                          room.id,
+                          componentId,
+                          label,
+                          index
+                        )
+                      }
+                      onFetchedComponentCostResponsibilityUpdate={(
+                        componentId,
+                        label,
+                        value
+                      ) =>
+                        handleComponentCostResponsibilityUpdateById(
+                          room.id,
+                          componentId,
+                          label,
+                          value
+                        )
+                      }
+                      onRoomHandledChange={(isHandled) =>
+                        handleRoomHandledSet(room.id, isHandled)
+                      }
                     />
                   </AccordionContent>
                 </AccordionItem>
@@ -232,6 +315,13 @@ export function InspectionForm({
               inspectionData={inspectionData}
               rooms={rooms}
               onComponentCostUpdate={handleComponentCostUpdate}
+              onComponentCostByIdUpdate={handleComponentCostUpdateById}
+              onComponentCostResponsibilityUpdate={
+                handleComponentCostResponsibilityUpdate
+              }
+              onComponentCostResponsibilityByIdUpdate={
+                handleComponentCostResponsibilityUpdateById
+              }
             />
             <div
               className="p-4 border rounded-lg space-y-3"

--- a/apps/property-tree/src/features/inspections/ui/InspectionFormDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionFormDialog.tsx
@@ -43,15 +43,40 @@ interface InspectionFormDialogProps {
   rentalId?: string
 }
 
-// Check if inspection has actual saved data
+// Returns true if the room holds any user-entered data. The dialog uses this
+// to decide whether to offer the "resume draft" choice; a false negative here
+// causes the form to start fresh and silently overwrite the persisted draft
+// on next save.
+const roomHasAnyData = (room: InspectionRoom): boolean => {
+  if (Object.values(room.conditions).some((c) => c && c.trim() !== '')) {
+    return true
+  }
+  if (room.components && room.components.length > 0) return true
+  if (room.detailComponents && room.detailComponents.length > 0) return true
+  if (Object.values(room.componentNotes).some((n) => n && n.trim() !== '')) {
+    return true
+  }
+  if (Object.values(room.componentPhotos).some((p) => p.length > 0)) return true
+  if (Object.values(room.actions).some((a) => a.length > 0)) return true
+  if (
+    room.componentCosts &&
+    Object.values(room.componentCosts).some((c) => (c ?? 0) > 0)
+  ) {
+    return true
+  }
+  if (
+    room.componentCostResponsibilities &&
+    Object.values(room.componentCostResponsibilities).some((r) => r != null)
+  ) {
+    return true
+  }
+  if (room.photos.length > 0) return true
+  return false
+}
+
 const hasExistingData = (inspection?: Inspection): boolean => {
-  if (!inspection?.rooms) return false
-  return (
-    Object.keys(inspection.rooms).length > 0 &&
-    Object.values(inspection.rooms).some((room) =>
-      Object.values(room.conditions).some((c) => c && c.trim() !== '')
-    )
-  )
+  if (!inspection?.rooms || inspection.rooms.length === 0) return false
+  return inspection.rooms.some(roomHasAnyData)
 }
 
 export function InspectionFormDialog({

--- a/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
@@ -4,6 +4,13 @@ import type { Room } from '@/services/types'
 import { Badge } from '@/shared/ui/Badge'
 import { Input } from '@/shared/ui/Input'
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/Select'
+import {
   Table,
   TableBody,
   TableCell,
@@ -18,8 +25,244 @@ import {
   ROOM_COMPONENTS,
 } from '../constants/components'
 import { CONDITION_TYPE, getConditionConfig } from '../constants/conditions'
+import {
+  COST_RESPONSIBILITY,
+  COST_RESPONSIBILITY_LABEL,
+  type CostResponsibility,
+} from '../constants/costResponsibility'
 
 type InspectionRoom = components['schemas']['InspectionRoom']
+
+// Sentinel used in the <Select> since shadcn's SelectItem disallows empty values.
+// Parsed back to `null` before reaching the handler.
+const UNSET = '__unset__'
+
+interface Remark {
+  key: string
+  label: string
+  condition: string
+  componentId?: string
+  rawLabel?: string
+}
+
+function isReportable(condition: string | undefined): boolean {
+  return (
+    condition === CONDITION_TYPE.ACCEPTABLE ||
+    condition === CONDITION_TYPE.DAMAGED
+  )
+}
+
+function getSurfaceRemarks(roomData: InspectionRoom | undefined): Remark[] {
+  if (!roomData) return []
+  return ROOM_COMPONENTS.filter((component: ComponentDefinition) =>
+    isReportable(roomData.conditions[component.key])
+  ).map((component) => ({
+    key: `surface-${component.key}`,
+    label: getComponentLabel(component.key),
+    condition: roomData.conditions[component.key],
+  }))
+}
+
+function getComponentRemarks(roomData: InspectionRoom | undefined): Remark[] {
+  if (!roomData?.components?.length) return []
+  return roomData.components
+    .filter((c) => isReportable(c.condition))
+    .map((c) => ({
+      key: `component-${c.componentId}`,
+      // Label is snapshotted at write-time (see InspectionComponent.label) so
+      // renames or deletions in property-base don't break old summaries.
+      label: c.label || c.componentId,
+      rawLabel: c.label,
+      componentId: c.componentId,
+      condition: c.condition,
+    }))
+}
+
+function surfaceKeyFromRemarkKey(
+  key: string
+): keyof InspectionRoom['componentCosts'] {
+  return key.replace(/^surface-/, '') as keyof InspectionRoom['componentCosts']
+}
+
+function CostResponsibilitySelect({
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  value: CostResponsibility
+  onChange: (value: CostResponsibility) => void
+  ariaLabel: string
+}) {
+  return (
+    <Select
+      value={value ?? UNSET}
+      onValueChange={(v) =>
+        onChange(v === UNSET ? null : (v as Exclude<CostResponsibility, null>))
+      }
+    >
+      <SelectTrigger className="h-9" aria-label={ariaLabel}>
+        <SelectValue placeholder="—" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={UNSET}>—</SelectItem>
+        <SelectItem value={COST_RESPONSIBILITY.TENANT}>
+          {COST_RESPONSIBILITY_LABEL[COST_RESPONSIBILITY.TENANT]}
+        </SelectItem>
+        <SelectItem value={COST_RESPONSIBILITY.LANDLORD}>
+          {COST_RESPONSIBILITY_LABEL[COST_RESPONSIBILITY.LANDLORD]}
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  )
+}
+
+interface RoomSectionProps {
+  room: Room
+  roomData: InspectionRoom | undefined
+  onComponentCostUpdate: (
+    roomId: string,
+    field: keyof InspectionRoom['componentCosts'],
+    cost: number
+  ) => void
+  onComponentCostByIdUpdate: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    cost: number
+  ) => void
+  onComponentCostResponsibilityUpdate: (
+    roomId: string,
+    field: keyof InspectionRoom['componentCostResponsibilities'],
+    value: CostResponsibility
+  ) => void
+  onComponentCostResponsibilityByIdUpdate: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    value: CostResponsibility
+  ) => void
+}
+
+function RoomSummarySection({
+  room,
+  roomData,
+  onComponentCostUpdate,
+  onComponentCostByIdUpdate,
+  onComponentCostResponsibilityUpdate,
+  onComponentCostResponsibilityByIdUpdate,
+}: RoomSectionProps) {
+  const remarks = [
+    ...getSurfaceRemarks(roomData),
+    ...getComponentRemarks(roomData),
+  ]
+
+  if (remarks.length === 0) return null
+
+  return (
+    <section className="border rounded-lg p-4 space-y-3 bg-card">
+      <h3 className="text-base font-semibold">{room.name}</h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Komponent</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-40">Kostnad (kr)</TableHead>
+            <TableHead className="w-44">Kostnadsansvar</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {remarks.map((remark) => {
+            const conditionConfig = getConditionConfig(remark.condition)
+            const isSurface = remark.key.startsWith('surface-')
+            const surfaceKey = isSurface
+              ? surfaceKeyFromRemarkKey(remark.key)
+              : null
+            const component = !isSurface
+              ? roomData?.components?.find(
+                  (c) => c.componentId === remark.componentId
+                )
+              : null
+            const costValue = isSurface
+              ? (roomData?.componentCosts?.[surfaceKey!] ?? 0)
+              : (component?.cost ?? 0)
+            const costResponsibility = isSurface
+              ? (roomData?.componentCostResponsibilities?.[surfaceKey!] ?? null)
+              : (component?.costResponsibility ?? null)
+
+            return (
+              <TableRow key={remark.key}>
+                <TableCell className="font-medium">{remark.label}</TableCell>
+                <TableCell>
+                  {conditionConfig && (
+                    <Badge
+                      variant={conditionConfig.badgeVariant}
+                      className={conditionConfig.badgeClassName}
+                    >
+                      {conditionConfig.label}
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Input
+                    type="number"
+                    min={0}
+                    step={1}
+                    // Render 0 as an empty field so the placeholder shows and
+                    // the user can type from scratch without fighting a sticky
+                    // "0" from the controlled value.
+                    value={costValue === 0 ? '' : costValue}
+                    placeholder="0"
+                    onFocus={(e) => e.target.select()}
+                    onChange={(e) => {
+                      const raw = e.target.value
+                      const cost =
+                        raw === ''
+                          ? 0
+                          : Math.max(0, Math.trunc(Number(raw) || 0))
+                      if (isSurface) {
+                        onComponentCostUpdate(room.id, surfaceKey!, cost)
+                      } else if (remark.componentId) {
+                        onComponentCostByIdUpdate(
+                          room.id,
+                          remark.componentId,
+                          remark.rawLabel ?? remark.label,
+                          cost
+                        )
+                      }
+                    }}
+                    aria-label={`Kostnad för ${remark.label}`}
+                  />
+                </TableCell>
+                <TableCell>
+                  <CostResponsibilitySelect
+                    value={costResponsibility}
+                    onChange={(value) => {
+                      if (isSurface) {
+                        onComponentCostResponsibilityUpdate(
+                          room.id,
+                          surfaceKey!,
+                          value
+                        )
+                      } else if (remark.componentId) {
+                        onComponentCostResponsibilityByIdUpdate(
+                          room.id,
+                          remark.componentId,
+                          remark.rawLabel ?? remark.label,
+                          value
+                        )
+                      }
+                    }}
+                    ariaLabel={`Kostnadsansvar för ${remark.label}`}
+                  />
+                </TableCell>
+              </TableRow>
+            )
+          })}
+        </TableBody>
+      </Table>
+    </section>
+  )
+}
 
 interface InspectionSummaryProps {
   inspectionData: Record<string, InspectionRoom>
@@ -29,39 +272,46 @@ interface InspectionSummaryProps {
     field: keyof InspectionRoom['componentCosts'],
     cost: number
   ) => void
-}
-
-function getRoomRemarks(
-  roomData: InspectionRoom | undefined
-): ComponentDefinition[] {
-  if (!roomData) return []
-  return ROOM_COMPONENTS.filter((component) => {
-    const condition = roomData.conditions[component.key]
-    return (
-      condition === CONDITION_TYPE.ACCEPTABLE ||
-      condition === CONDITION_TYPE.DAMAGED
-    )
-  })
+  onComponentCostByIdUpdate: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    cost: number
+  ) => void
+  onComponentCostResponsibilityUpdate: (
+    roomId: string,
+    field: keyof InspectionRoom['componentCostResponsibilities'],
+    value: CostResponsibility
+  ) => void
+  onComponentCostResponsibilityByIdUpdate: (
+    roomId: string,
+    componentId: string,
+    label: string,
+    value: CostResponsibility
+  ) => void
 }
 
 export function InspectionSummary({
   inspectionData,
   rooms,
   onComponentCostUpdate,
+  onComponentCostByIdUpdate,
+  onComponentCostResponsibilityUpdate,
+  onComponentCostResponsibilityByIdUpdate,
 }: InspectionSummaryProps) {
-  const roomSections = rooms
-    .map((room) => ({
-      room,
-      roomData: inspectionData[room.id],
-      remarks: getRoomRemarks(inspectionData[room.id]),
-    }))
-    .filter((section) => section.remarks.length > 0)
+  const perRoom = rooms.map((room) => {
+    const roomData = inspectionData[room.id]
+    const surfaceCount = ROOM_COMPONENTS.filter((c) =>
+      isReportable(roomData?.conditions[c.key])
+    ).length
+    const componentCount = (roomData?.components ?? []).filter((c) =>
+      isReportable(c.condition)
+    ).length
+    return { room, roomData, total: surfaceCount + componentCount }
+  })
 
-  const totalRemarks = roomSections.reduce(
-    (sum, section) => sum + section.remarks.length,
-    0
-  )
-
+  const roomsWithRemarks = perRoom.filter((r) => r.total > 0)
+  const totalRemarks = roomsWithRemarks.reduce((sum, r) => sum + r.total, 0)
   const remarksLabel = totalRemarks === 1 ? 'anmärkning' : 'anmärkningar'
 
   return (
@@ -69,73 +319,30 @@ export function InspectionSummary({
       <header className="border rounded-lg p-4 space-y-1 bg-card">
         <h2 className="text-xl font-semibold">Sammanställning</h2>
         <p className="text-sm text-muted-foreground">
-          {totalRemarks} {remarksLabel} i {roomSections.length} rum
+          {totalRemarks} {remarksLabel} i {roomsWithRemarks.length} rum
         </p>
       </header>
 
-      {roomSections.length === 0 && (
+      {totalRemarks === 0 && (
         <div className="p-8 border rounded-lg text-center text-muted-foreground">
           Inga anmärkningar registrerade. Alla komponenter är i gott skick.
         </div>
       )}
 
-      {roomSections.map(({ room, roomData, remarks }) => (
-        <section
+      {roomsWithRemarks.map(({ room, roomData }) => (
+        <RoomSummarySection
           key={room.id}
-          className="border rounded-lg p-4 space-y-3 bg-card"
-        >
-          <h3 className="text-base font-semibold">{room.name}</h3>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Komponent</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead className="w-40">Kostnad (kr)</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {remarks.map((component) => {
-                const condition = roomData?.conditions[component.key]
-                const conditionConfig = getConditionConfig(condition)
-
-                return (
-                  <TableRow key={component.key}>
-                    <TableCell className="font-medium">
-                      {getComponentLabel(component.key)}
-                    </TableCell>
-                    <TableCell>
-                      {conditionConfig && (
-                        <Badge
-                          variant={conditionConfig.badgeVariant}
-                          className={conditionConfig.badgeClassName}
-                        >
-                          {conditionConfig.label}
-                        </Badge>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Input
-                        type="number"
-                        min={0}
-                        step={1}
-                        value={roomData?.componentCosts?.[component.key] ?? 0}
-                        onFocus={(e) => e.target.select()}
-                        onChange={(e) =>
-                          onComponentCostUpdate(
-                            room.id,
-                            component.key,
-                            Math.max(0, Math.trunc(Number(e.target.value) || 0))
-                          )
-                        }
-                        aria-label={`Kostnad för ${getComponentLabel(component.key)}`}
-                      />
-                    </TableCell>
-                  </TableRow>
-                )
-              })}
-            </TableBody>
-          </Table>
-        </section>
+          room={room}
+          roomData={roomData}
+          onComponentCostUpdate={onComponentCostUpdate}
+          onComponentCostByIdUpdate={onComponentCostByIdUpdate}
+          onComponentCostResponsibilityUpdate={
+            onComponentCostResponsibilityUpdate
+          }
+          onComponentCostResponsibilityByIdUpdate={
+            onComponentCostResponsibilityByIdUpdate
+          }
+        />
       ))}
     </div>
   )

--- a/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
+++ b/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
@@ -12,11 +12,21 @@ import {
   type CostResponsibility,
 } from '../constants'
 import { useRoomComponents } from '../hooks/useRoomComponents'
+import {
+  deriveRoomIsHandled,
+  emptyInspectionComponent,
+} from '../lib/inspectionComponent'
 import { ComponentDetailSheet } from './ComponentDetailSheet'
 import { ComponentInspectionCard } from './ComponentInspectionCard'
 import { DetailComponentsSection } from './DetailComponentsSection'
 
 type InspectionRoom = components['schemas']['InspectionRoom']
+type InspectionComponent = NonNullable<InspectionRoom['components']>[number]
+
+type OpenDetail =
+  | { kind: 'surface'; key: keyof InspectionRoom['conditions'] }
+  | { kind: 'component'; id: string }
+  | null
 
 interface RoomInspectionEditorProps {
   room: Room
@@ -48,6 +58,37 @@ interface RoomInspectionEditorProps {
   onDetailComponentAdd: (component: { type: string; label: string }) => void
   onDetailComponentRemove: (componentId: string) => void
   onDetailComponentNoteUpdate: (componentId: string, note: string) => void
+  onFetchedComponentConditionUpdate: (
+    componentId: string,
+    label: string,
+    value: string
+  ) => void
+  onFetchedComponentActionUpdate: (
+    componentId: string,
+    label: string,
+    action: string
+  ) => void
+  onFetchedComponentNoteUpdate: (
+    componentId: string,
+    label: string,
+    note: string
+  ) => void
+  onFetchedComponentPhotoAdd: (
+    componentId: string,
+    label: string,
+    photoDataUrl: string
+  ) => void
+  onFetchedComponentPhotoRemove: (
+    componentId: string,
+    label: string,
+    index: number
+  ) => void
+  onFetchedComponentCostResponsibilityUpdate: (
+    componentId: string,
+    label: string,
+    value: CostResponsibility
+  ) => void
+  onRoomHandledChange: (isHandled: boolean) => void
 }
 
 export function RoomInspectionEditor({
@@ -62,10 +103,15 @@ export function RoomInspectionEditor({
   onDetailComponentAdd,
   onDetailComponentRemove,
   onDetailComponentNoteUpdate,
+  onFetchedComponentConditionUpdate,
+  onFetchedComponentActionUpdate,
+  onFetchedComponentNoteUpdate,
+  onFetchedComponentPhotoAdd,
+  onFetchedComponentPhotoRemove,
+  onFetchedComponentCostResponsibilityUpdate,
+  onRoomHandledChange,
 }: RoomInspectionEditorProps) {
-  const [openDetailKey, setOpenDetailKey] = useState<
-    keyof InspectionRoom['conditions'] | null
-  >(null)
+  const [openDetail, setOpenDetail] = useState<OpenDetail>(null)
 
   const {
     data: fetchedComponents,
@@ -81,10 +127,34 @@ export function RoomInspectionEditor({
   const defaultRows = rows.filter((r) => r.isDefault)
   const equipmentRows = rows.filter((r) => !r.isDefault)
 
-  // Equipment rows render with the same UI as defaults for visual consistency,
-  // but inputs are non-persisted in this card — see follow-up "Spara
-  // besiktningsframsteg per komponent".
-  const noop = () => {}
+  const componentsByIdMemo = useMemo(() => {
+    const map = new Map<string, InspectionComponent>()
+    for (const c of inspectionData.components ?? []) {
+      map.set(c.componentId, c)
+    }
+    return map
+  }, [inspectionData.components])
+
+  const getComponentState = (
+    componentId: string,
+    label: string
+  ): InspectionComponent =>
+    componentsByIdMemo.get(componentId) ??
+    emptyInspectionComponent(componentId, label)
+
+  // A room is handled when every visible row has a condition set. Derived
+  // here because the set of visible rows depends on fetched components, which
+  // the data hook cannot see. See deriveRoomIsHandled for the rule.
+  const derivedIsHandled = useMemo(
+    () => deriveRoomIsHandled(inspectionData, fetchedComponents ?? []),
+    [inspectionData, fetchedComponents]
+  )
+
+  useEffect(() => {
+    if (derivedIsHandled !== inspectionData.isHandled) {
+      onRoomHandledChange(derivedIsHandled)
+    }
+  }, [derivedIsHandled, inspectionData.isHandled, onRoomHandledChange])
 
   return (
     <Card>
@@ -132,36 +202,57 @@ export function RoomInspectionEditor({
                 onPhotoCapture={(photoDataUrl) =>
                   onComponentPhotoAdd(surfaceKey, photoDataUrl)
                 }
-                onOpenDetail={() => setOpenDetailKey(surfaceKey)}
+                onOpenDetail={() =>
+                  setOpenDetail({ kind: 'surface', key: surfaceKey })
+                }
               />
             )
           })}
 
-          {equipmentRows.map((row) => (
-            <div
-              key={row.key}
-              className="opacity-60 pointer-events-none"
-              aria-disabled
-            >
+          {equipmentRows.map((row) => {
+            const componentId = row.componentId
+            if (!componentId) return null
+            const state = getComponentState(componentId, row.label)
+            return (
               <ComponentInspectionCard
+                key={row.key}
                 componentKey={row.key}
                 label={row.label}
-                condition=""
-                note=""
-                photoCount={0}
-                actions={[]}
-                costResponsibility={null}
-                onConditionChange={noop}
-                onNoteChange={noop}
-                onCostResponsibilityChange={noop}
-                onPhotoCapture={noop}
-                onOpenDetail={noop}
+                condition={state.condition}
+                note={state.note}
+                photoCount={state.photos.length}
+                actions={state.action}
+                costResponsibility={state.costResponsibility ?? null}
+                onConditionChange={(value) =>
+                  onFetchedComponentConditionUpdate(
+                    componentId,
+                    row.label,
+                    value
+                  )
+                }
+                onNoteChange={(note) =>
+                  onFetchedComponentNoteUpdate(componentId, row.label, note)
+                }
+                onCostResponsibilityChange={(value) =>
+                  onFetchedComponentCostResponsibilityUpdate(
+                    componentId,
+                    row.label,
+                    value
+                  )
+                }
+                onPhotoCapture={(photoDataUrl) =>
+                  onFetchedComponentPhotoAdd(
+                    componentId,
+                    row.label,
+                    photoDataUrl
+                  )
+                }
+                onOpenDetail={() =>
+                  setOpenDetail({ kind: 'component', id: componentId })
+                }
               />
-              <p className="text-xs text-muted-foreground -mt-2 mb-3 px-1">
-                Sparas inte än
-              </p>
-            </div>
-          ))}
+            )
+          })}
         </div>
 
         <Separator className="my-4" />
@@ -173,14 +264,15 @@ export function RoomInspectionEditor({
           onNoteUpdate={onDetailComponentNoteUpdate}
         />
 
-        {/* Detail sheets for surface defaults only */}
         {defaultRows.map((row) => {
           const surfaceKey = row.key as keyof InspectionRoom['conditions']
+          const isOpen =
+            openDetail?.kind === 'surface' && openDetail.key === surfaceKey
           return (
             <ComponentDetailSheet
               key={`detail-${row.key}`}
-              isOpen={openDetailKey === surfaceKey}
-              onClose={() => setOpenDetailKey(null)}
+              isOpen={isOpen}
+              onClose={() => setOpenDetail(null)}
               componentKey={row.key}
               label={row.label}
               condition={inspectionData.conditions[surfaceKey]}
@@ -196,6 +288,40 @@ export function RoomInspectionEditor({
                 onComponentPhotoRemove(surfaceKey, index)
               }
               onActionToggle={(action) => onActionUpdate(surfaceKey, action)}
+            />
+          )
+        })}
+
+        {equipmentRows.map((row) => {
+          const componentId = row.componentId
+          if (!componentId) return null
+          const state = getComponentState(componentId, row.label)
+          const isOpen =
+            openDetail?.kind === 'component' && openDetail.id === componentId
+          return (
+            <ComponentDetailSheet
+              key={`detail-${row.key}`}
+              isOpen={isOpen}
+              onClose={() => setOpenDetail(null)}
+              componentKey={row.key}
+              label={row.label}
+              condition={state.condition}
+              note={state.note}
+              photos={state.photos}
+              actions={state.action}
+              componentType={row.type}
+              onNoteChange={(note) =>
+                onFetchedComponentNoteUpdate(componentId, row.label, note)
+              }
+              onPhotoAdd={(photoDataUrl) =>
+                onFetchedComponentPhotoAdd(componentId, row.label, photoDataUrl)
+              }
+              onPhotoRemove={(index) =>
+                onFetchedComponentPhotoRemove(componentId, row.label, index)
+              }
+              onActionToggle={(action) =>
+                onFetchedComponentActionUpdate(componentId, row.label, action)
+              }
             />
           )
         })}

--- a/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
@@ -82,6 +82,13 @@ export function MobileInspectionForm({
     handleDetailComponentAdd,
     handleDetailComponentRemove,
     handleDetailComponentNoteUpdate,
+    handleComponentConditionUpdate,
+    handleComponentActionUpdate,
+    handleComponentNoteUpdateById,
+    handleComponentPhotoAddById,
+    handleComponentPhotoRemoveById,
+    handleComponentCostResponsibilityUpdateById,
+    handleRoomHandledSet,
   } = useInspectionForm(initialRooms, existingInspection)
 
   // After adding an ad-hoc room, jump to it so the inspector can start
@@ -293,6 +300,61 @@ export function MobileInspectionForm({
                   componentId,
                   note
                 )
+              }
+              onFetchedComponentConditionUpdate={(componentId, label, value) =>
+                handleComponentConditionUpdate(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  value
+                )
+              }
+              onFetchedComponentActionUpdate={(componentId, label, action) =>
+                handleComponentActionUpdate(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  action
+                )
+              }
+              onFetchedComponentNoteUpdate={(componentId, label, note) =>
+                handleComponentNoteUpdateById(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  note
+                )
+              }
+              onFetchedComponentPhotoAdd={(componentId, label, photoDataUrl) =>
+                handleComponentPhotoAddById(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  photoDataUrl
+                )
+              }
+              onFetchedComponentPhotoRemove={(componentId, label, index) =>
+                handleComponentPhotoRemoveById(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  index
+                )
+              }
+              onFetchedComponentCostResponsibilityUpdate={(
+                componentId,
+                label,
+                value
+              ) =>
+                handleComponentCostResponsibilityUpdateById(
+                  currentRoom.id,
+                  componentId,
+                  label,
+                  value
+                )
+              }
+              onRoomHandledChange={(isHandled) =>
+                handleRoomHandledSet(currentRoom.id, isHandled)
               }
             />
           </div>

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -11660,8 +11660,37 @@ export interface components {
               label: string
               note: string
             }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
           }[]
         | null
+    }
+    InspectionComponent: {
+      componentId: string
+      label: string
+      condition: string
+      action: string[]
+      note: string
+      photos: string[]
+      cost?: number
+      /**
+       * @default null
+       * @enum {string|null}
+       */
+      costResponsibility?: 'tenant' | 'landlord' | null
     }
     InspectionRoom: {
       roomId: string
@@ -11764,6 +11793,21 @@ export interface components {
         type: string
         label: string
         note: string
+      }[]
+      /** @default [] */
+      components?: {
+        componentId: string
+        label: string
+        condition: string
+        action: string[]
+        note: string
+        photos: string[]
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
       }[]
     }
     DetailedInspection: {
@@ -12935,6 +12979,21 @@ export interface components {
               label: string
               note: string
             }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
           }[]
         | null
     }
@@ -13041,6 +13100,21 @@ export interface components {
           type: string
           label: string
           note: string
+        }[]
+        /** @default [] */
+        components?: {
+          componentId: string
+          label: string
+          condition: string
+          action: string[]
+          note: string
+          photos: string[]
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
         }[]
       }[]
       isFurnished: boolean

--- a/apps/property-tree/src/shared/ui/Sheet.tsx
+++ b/apps/property-tree/src/shared/ui/Sheet.tsx
@@ -19,7 +19,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-[80] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-[100] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  'fixed z-[80] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-[100] gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       side: {

--- a/core/src/adapters/inspection-adapter/generated/api-types.ts
+++ b/core/src/adapters/inspection-adapter/generated/api-types.ts
@@ -625,8 +625,20 @@ export interface components {
       status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
       inspector?: string
     }
+    InspectionComponent: {
+      componentId: string
+      label: string
+      condition: string
+      action: string[]
+      note: string
+      photos: string[]
+      cost?: number
+      /** @default null */
+      costResponsibility?: ('tenant' | 'landlord') | null
+    }
     InspectionRoom: {
       roomId: string
+      name?: string
       conditions: {
         wall1: string
         wall2: string
@@ -705,6 +717,18 @@ export interface components {
         label: string
         note: string
       }[]
+      /** @default [] */
+      components?: {
+        componentId: string
+        label: string
+        condition: string
+        action: string[]
+        note: string
+        photos: string[]
+        cost?: number
+        /** @default null */
+        costResponsibility?: ('tenant' | 'landlord') | null
+      }[]
     }
     InternalInspection: {
       id: string
@@ -722,6 +746,7 @@ export interface components {
       rooms:
         | {
             roomId: string
+            name?: string
             conditions: {
               wall1: string
               wall2: string
@@ -800,6 +825,18 @@ export interface components {
               label: string
               note: string
             }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
+              /** @default null */
+              costResponsibility?: ('tenant' | 'landlord') | null
+            }[]
           }[]
         | null
     }
@@ -807,6 +844,7 @@ export interface components {
       inspectorName: string
       rooms: {
         roomId: string
+        name?: string
         conditions: {
           wall1: string
           wall2: string
@@ -884,6 +922,18 @@ export interface components {
           type: string
           label: string
           note: string
+        }[]
+        /** @default [] */
+        components?: {
+          componentId: string
+          label: string
+          condition: string
+          action: string[]
+          note: string
+          photos: string[]
+          cost?: number
+          /** @default null */
+          costResponsibility?: ('tenant' | 'landlord') | null
         }[]
       }[]
       isFurnished: boolean

--- a/core/src/services/inspection-service/index.ts
+++ b/core/src/services/inspection-service/index.ts
@@ -34,6 +34,7 @@ import {
  */
 export const routes = (router: KoaRouter) => {
   registerSchema('Inspection', schemas.InspectionSchema)
+  registerSchema('InspectionComponent', schemas.InspectionComponentSchema)
   registerSchema('InspectionRoom', schemas.InspectionRoomSchema)
   registerSchema('DetailedInspection', schemas.DetailedInspectionSchema)
   registerSchema('DetailedInspectionRoom', schemas.DetailedInspectionSchema)

--- a/core/src/services/inspection-service/schemas.ts
+++ b/core/src/services/inspection-service/schemas.ts
@@ -32,6 +32,19 @@ const DetailComponentSchema = z.object({
   note: z.string(),
 })
 
+export const InspectionComponentSchema = z.object({
+  componentId: z.string(),
+  // Snapshot of the display label at inspection time so the summary still
+  // reads correctly if the component is renamed or removed from property-base.
+  label: z.string(),
+  condition: z.string(),
+  action: z.array(z.string()),
+  note: z.string(),
+  photos: z.array(z.string()),
+  cost: z.number().optional(),
+  costResponsibility: z.enum(['tenant', 'landlord']).nullable().default(null),
+})
+
 // Note: 'details' fields in conditions/actions/componentNotes/componentPhotos are kept
 // for backward compatibility with existing persisted data. New detail inspections use
 // the detailComponents array instead. The UI no longer renders these fields.
@@ -99,6 +112,7 @@ export const InspectionRoomSchema = z.object({
   isApproved: z.boolean(),
   isHandled: z.boolean(),
   detailComponents: z.array(DetailComponentSchema).optional().default([]),
+  components: z.array(InspectionComponentSchema).optional().default([]),
 })
 
 export const InspectionSchema = XpandInspectionSchema.extend({
@@ -210,6 +224,7 @@ export const InspectionWithSourceSchema = XpandInspectionSchema.extend({
 export type XpandInspection = z.infer<typeof XpandInspectionSchema>
 export type InspectionWithSource = z.infer<typeof InspectionWithSourceSchema>
 export type Inspection = z.infer<typeof InspectionSchema>
+export type InspectionComponent = z.infer<typeof InspectionComponentSchema>
 export type InspectionRoom = z.infer<typeof InspectionRoomSchema>
 export type DetailedInspection = z.infer<typeof DetailedInspectionSchema>
 

--- a/services/inspection/src/services/inspection-service/index.ts
+++ b/services/inspection/src/services/inspection-service/index.ts
@@ -9,6 +9,7 @@ import {
   DetailedXpandInspectionSchema,
   GetInspectionsFromXpandQuerySchema,
   GetInspectionsByResidenceIdQuerySchema,
+  InspectionComponentSchema,
   InspectionRoomSchema,
   InternalInspectionSchema,
   SaveInspectionDraftRequestSchema,
@@ -39,6 +40,7 @@ export const routes = (router: KoaRouter) => {
   registerSchema('DetailedXpandInspectionRemark', DetailedXpandInspectionSchema)
   registerSchema('CreateInspection', CreateInspectionSchema)
   registerSchema('UpdateInspectionStatus', UpdateInspectionStatusSchema)
+  registerSchema('InspectionComponent', InspectionComponentSchema)
   registerSchema('InspectionRoom', InspectionRoomSchema)
   registerSchema('InternalInspection', InternalInspectionSchema)
   registerSchema('SaveInspectionDraftRequest', SaveInspectionDraftRequestSchema)

--- a/services/inspection/src/services/inspection-service/schemas.ts
+++ b/services/inspection/src/services/inspection-service/schemas.ts
@@ -154,6 +154,19 @@ const DetailComponentSchema = z.object({
   note: z.string(),
 })
 
+export const InspectionComponentSchema = z.object({
+  componentId: z.string(),
+  // Snapshot of the display label at inspection time so the summary still
+  // reads correctly if the component is renamed or removed from property-base.
+  label: z.string(),
+  condition: z.string(),
+  action: z.array(z.string()),
+  note: z.string(),
+  photos: z.array(z.string()),
+  cost: z.number().optional(),
+  costResponsibility: z.enum(['tenant', 'landlord']).nullable().default(null),
+})
+
 export const InspectionRoomSchema = z.object({
   roomId: z.string(),
   // Populated for ad-hoc rooms created by the inspector when the Xpand room
@@ -170,6 +183,7 @@ export const InspectionRoomSchema = z.object({
   isApproved: z.boolean(),
   isHandled: z.boolean(),
   detailComponents: z.array(DetailComponentSchema).optional().default([]),
+  components: z.array(InspectionComponentSchema).optional().default([]),
 })
 
 export const InternalInspectionSchema = XpandInspectionSchema.extend({
@@ -184,5 +198,6 @@ export const SaveInspectionDraftRequestSchema = z.object({
   isFurnished: z.boolean(),
 })
 
+export type InspectionComponent = z.infer<typeof InspectionComponentSchema>
 export type InspectionRoom = z.infer<typeof InspectionRoomSchema>
 export type InternalInspection = z.infer<typeof InternalInspectionSchema>

--- a/services/inspection/src/services/inspection-service/tests/factories/inspection.ts
+++ b/services/inspection/src/services/inspection-service/tests/factories/inspection.ts
@@ -279,6 +279,7 @@ export const InspectionRoomFactory = Factory.define<InspectionRoom>(() => ({
   isApproved: false,
   isHandled: false,
   detailComponents: [],
+  components: [],
 }))
 
 export const SaveInspectionDraftParamsFactory =


### PR DESCRIPTION
## Summary

Persists per-component inspection data (condition, actions, note, photos, cost, cost responsibility) for real components fetched from property-base — previously dimmed "Sparas inte än" rows. Data rides the existing `inspection.draftRooms` JSON; no DB migration.

Closes **MIM-1683**. Also completes **MIM-1674**  - sibling PR #522 shipped cost responsibility per-surface only; this PR extends it to fetched components (equipment rows + Sammanställning), which was the card's original intent.

### Changes

- **Schema.** New `InspectionComponentSchema` under `InspectionRoomSchema.components[]` with `componentId`, `label`, `condition`, `action[]`, `note`, `photos[]`, `cost?`, `costResponsibility`. Mirrored in `services/inspection` and `core`. `label` is snapshotted at write-time so summaries stay readable if property-base renames or deletes the component.
- **Hook layer.** 7 new handlers in `useComponentInspection` keyed by `componentId` — condition, action, note, add/remove photo, cost, cost responsibility. `updateComponentCondition` clears `costResponsibility: null` when the value flips back to God (mirrors the surface-keyed rule).
- **Editor.** `RoomInspectionEditor` wires equipment rows to the real handlers (including cost responsibility) and derives `isHandled` via a shared `deriveRoomIsHandled` helper — superseded surfaces drop out of the check automatically.
- **Summary (Sammanställning).** Per-component remarks now appear alongside surface remarks with the snapshotted `label`. Added 4th column "Kostnadsansvar" with a compact `<Select>` (Hyresgäst / Hyresvärd / —) for both surface and component rows. Per-component cost input is now controlled.
- **Hydration.** Defaults `costResponsibility: null` for components saved before the field existed.

### Out of scope

- Large-photo storage — inspection photos are still base64 in `draftRooms` JSON. Migration tracked in [MIM-1709](https://linear.app/mimer-onecore/issue/MIM-1709/migrate-inspection-photos-from-base64-in-draftrooms-to-file-storage).
- Writing condition/lastInspectionDate back to property-base `Components`.

## Test plan

- [ ] **Edit & save (desktop + mobile)** — on a fetched equipment row: set condition, toggle an action, enter note, capture a photo. Save draft, reopen — all data persists.
- [ ] **Cost & responsibility in editor** — set an equipment row to Acceptabel/Skadad → tenant/landlord radio appears. Pick one. Flip condition to God → radio clears and persists as `null`.
- [ ] **isHandled** — room flips to `Klar` only when every visible surface + every fetched component has a condition.
- [ ] **Summary** — Acceptabel/Skadad components appear in Sammanställning with their display name (not UUID), mixed with surface remarks. Both rows types edit cost + Kostnadsansvar inline; values round-trip through save/reload.
- [ ] **Label snapshot** — rename or delete the component in property-base after saving; summary still shows the original name.
- [ ] **Superseded surfaces** — rooms whose fetched components include a `Väggar` category hide the wall1–4 defaults; `isHandled` counts the real components.
- [ ] **Backward compatibility** — a draft saved before this PR (no `costResponsibility` on components) loads without schema errors; the field reads as `null`.
- [ ] **Finalize** — `Genomförd` transition still works.
- [ ] **CI** — `pnpm run typecheck` (18/18 green); `pnpm -F @onecore/inspection test` (105/105).
