### PR TITLE
added new listing text content form,  

### DIFF
--- a/apps/internal-portal/frontend/src/pages/ListingTextContent/ListingTextContentForm.tsx
+++ b/apps/internal-portal/frontend/src/pages/ListingTextContent/ListingTextContentForm.tsx
@@ -136,9 +136,8 @@ const ListingTextContentForm = () => {
           contentBlocks,
         })
         toast.success('Annonsinnehåll skapat!')
+        navigate(`/annonsinnehall/${objectCode}/redigera`, { replace: true })
       }
-
-      navigate('/annonsinnehall')
     } catch (error) {
       if (error instanceof AxiosError) {
         if (error.response?.status === 409) {

--- a/apps/internal-portal/frontend/src/pages/ListingTextContent/components/ContentBlockEditor.tsx
+++ b/apps/internal-portal/frontend/src/pages/ListingTextContent/components/ContentBlockEditor.tsx
@@ -45,6 +45,7 @@ const blockTypeLabels: Record<ContentBlockType, string> = {
   subtitle: 'Underrubrik',
   text: 'Text',
   bullet_list: 'Punktlista',
+  bold_text: 'Underrubrik 2',
   link: 'Länk',
 }
 
@@ -127,6 +128,7 @@ export const ContentBlockEditor = ({
               <MenuItem value="preamble">{blockTypeLabels.preamble}</MenuItem>
               <MenuItem value="headline">{blockTypeLabels.headline}</MenuItem>
               <MenuItem value="subtitle">{blockTypeLabels.subtitle}</MenuItem>
+              <MenuItem value="bold_text">{blockTypeLabels.bold_text}</MenuItem>
               <MenuItem value="text">{blockTypeLabels.text}</MenuItem>
               <MenuItem value="bullet_list">
                 {blockTypeLabels.bullet_list}

--- a/apps/internal-portal/frontend/src/pages/ListingTextContent/components/ListingPreview.tsx
+++ b/apps/internal-portal/frontend/src/pages/ListingTextContent/components/ListingPreview.tsx
@@ -125,6 +125,23 @@ export const ListingPreview = ({
           </Box>
         )
 
+      case 'bold_text':
+        return (
+          <Box key={index} sx={{ marginBottom: 0.5 }}>
+            {renderParagraphs(
+              block.content || '',
+              {
+                width: '100%',
+                fontSize: '1rem',
+                fontFamily: 'graphikRegular',
+                fontWeight: 700,
+                lineHeight: 1.7,
+              },
+              'Underrubrik 2...'
+            )}
+          </Box>
+        )
+
       case 'bullet_list':
         const items = (block.content || '')
           .split('\n')

--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -9239,6 +9239,10 @@ export interface components {
           content: string;
         } | {
           /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
           type: "link";
           name: string;
           /** Format: uri */
@@ -9273,6 +9277,10 @@ export interface components {
           content: string;
         } | {
           /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
           type: "link";
           name: string;
           /** Format: uri */
@@ -9299,6 +9307,10 @@ export interface components {
         } | {
           /** @enum {string} */
           type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
           content: string;
         } | {
           /** @enum {string} */

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -9239,6 +9239,10 @@ export interface components {
           content: string;
         } | {
           /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
           type: "link";
           name: string;
           /** Format: uri */
@@ -9273,6 +9277,10 @@ export interface components {
           content: string;
         } | {
           /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
           type: "link";
           name: string;
           /** Format: uri */
@@ -9299,6 +9307,10 @@ export interface components {
         } | {
           /** @enum {string} */
           type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
           content: string;
         } | {
           /** @enum {string} */

--- a/libs/types/src/leasing/v1/listing-text-content.ts
+++ b/libs/types/src/leasing/v1/listing-text-content.ts
@@ -6,6 +6,7 @@ export const ContentBlockTypeSchema = z.enum([
   'subtitle',
   'text',
   'bullet_list',
+  'bold_text',
   'link',
 ])
 
@@ -29,6 +30,10 @@ export const ContentBlockSchema = z.discriminatedUnion('type', [
   }),
   z.object({
     type: z.literal('bullet_list'),
+    content: z.string(),
+  }),
+  z.object({
+    type: z.literal('bold_text'),
     content: z.string(),
   }),
   z.object({


### PR DESCRIPTION
also changed navigation after saving 'annons' in the internal potal.

new bold_text block type ("Underrubrik 2") is wired through the shared zod schema in listing-text-content.ts, rendered as bold body text in ListingPreview.tsx, and selectable from the dropdown in ContentBlockEditor.tsx. 


minimal changes to future features. (not used yet by the organisation)