### PR TITLE
Feature/mim 1706 hamtar fel objekt

### DIFF
--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -11210,16 +11210,16 @@ export interface components {
       code: string;
       /** @description Name (caption) of the staircase */
       name: string | null;
-      property: ({
-        code: string | null;
+      property: {
+        code: string;
         /** @description Name of property associated with the staircase */
         name: string | null;
-      }) | null;
-      building: ({
-        code: string | null;
+      };
+      building: {
+        code: string;
         /** @description Name of building associated with the staircase */
         name: string | null;
-      }) | null;
+      };
     };
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
     SearchResult: {
@@ -11352,16 +11352,16 @@ export interface components {
       code: string;
       /** @description Name (caption) of the staircase */
       name: string | null;
-      property: ({
-        code: string | null;
+      property: {
+        code: string;
         /** @description Name of property associated with the staircase */
         name: string | null;
-      }) | null;
-      building: ({
-        code: string | null;
+      };
+      building: {
+        code: string;
         /** @description Name of building associated with the staircase */
         name: string | null;
-      }) | null;
+      };
     });
     Inspection: {
       id: string;

--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -5481,7 +5481,8 @@ export interface paths {
      * - Parking Spaces: Matches on rental ID or parking space name
      * - Maintenance Units: Matches on code
      * - Facilities: Matches on rental ID or facility name
-     * Returns up to 10 results per entity type (max 60 total results).
+     * - Staircases: Matches on staircase name
+     * Returns up to 10 results per entity type (max 70 total results).
      */
     get: {
       parameters: {
@@ -11197,7 +11198,30 @@ export interface components {
       /** @description Property name */
       estate: string | null;
     };
-    /** @description A search result that can be either a property, building, residence, parking space, maintenance unit or facility */
+    StaircaseSearchResult: {
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: ({
+        code: string | null;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      }) | null;
+      building: ({
+        code: string | null;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      }) | null;
+    };
+    /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
     SearchResult: {
       /** @description Unique identifier for the search result */
       id: string;
@@ -11316,6 +11340,28 @@ export interface components {
         /** @description Name of building associated with the facility */
         name: string | null;
       };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: ({
+        code: string | null;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      }) | null;
+      building: ({
+        code: string | null;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      }) | null;
     });
     Inspection: {
       id: string;

--- a/apps/property-tree/src/features/search/ui/CommandPalette.tsx
+++ b/apps/property-tree/src/features/search/ui/CommandPalette.tsx
@@ -6,6 +6,7 @@ import {
   Building2,
   CarFront,
   Command,
+  DoorOpen,
   Loader2,
   SquareUser,
   Store,
@@ -28,6 +29,7 @@ const iconMap = {
   'parking-space': CarFront,
   'maintenance-unit': Wrench,
   facility: Store,
+  staircase: DoorOpen,
 } as const
 
 function getResultProps(item: CombinedSearchResult) {
@@ -97,6 +99,19 @@ function getResultProps(item: CombinedSearchResult) {
         prefix: '[LOK]',
         subtitle: item.property?.name,
         path: paths.facility(item.rentalId),
+        state: {
+          buildingCode: item.building?.code || null,
+          propertyCode: item.property?.code || null,
+        },
+      }
+    case 'staircase':
+      if (!item.building?.code) return null
+      return {
+        icon,
+        label: item.name ?? item.code,
+        prefix: '[UPP]',
+        subtitle: item.building?.name ?? item.property?.name ?? undefined,
+        path: paths.staircase(item.building.code, item.code),
         state: {
           buildingCode: item.building?.code || null,
           propertyCode: item.property?.code || null,

--- a/apps/property-tree/src/features/search/ui/CommandPalette.tsx
+++ b/apps/property-tree/src/features/search/ui/CommandPalette.tsx
@@ -105,16 +105,15 @@ function getResultProps(item: CombinedSearchResult) {
         },
       }
     case 'staircase':
-      if (!item.building?.code) return null
       return {
         icon,
         label: item.name ?? item.code,
         prefix: '[UPP]',
-        subtitle: item.building?.name ?? item.property?.name ?? undefined,
+        subtitle: item.building.name ?? item.property.name ?? undefined,
         path: paths.staircase(item.building.code, item.code),
         state: {
-          buildingCode: item.building?.code || null,
-          propertyCode: item.property?.code || null,
+          buildingCode: item.building.code,
+          propertyCode: item.property.code,
         },
       }
     default:

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -11210,16 +11210,16 @@ export interface components {
       code: string;
       /** @description Name (caption) of the staircase */
       name: string | null;
-      property: ({
-        code: string | null;
+      property: {
+        code: string;
         /** @description Name of property associated with the staircase */
         name: string | null;
-      }) | null;
-      building: ({
-        code: string | null;
+      };
+      building: {
+        code: string;
         /** @description Name of building associated with the staircase */
         name: string | null;
-      }) | null;
+      };
     };
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
     SearchResult: {
@@ -11352,16 +11352,16 @@ export interface components {
       code: string;
       /** @description Name (caption) of the staircase */
       name: string | null;
-      property: ({
-        code: string | null;
+      property: {
+        code: string;
         /** @description Name of property associated with the staircase */
         name: string | null;
-      }) | null;
-      building: ({
-        code: string | null;
+      };
+      building: {
+        code: string;
         /** @description Name of building associated with the staircase */
         name: string | null;
-      }) | null;
+      };
     });
     Inspection: {
       id: string;

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -5481,7 +5481,8 @@ export interface paths {
      * - Parking Spaces: Matches on rental ID or parking space name
      * - Maintenance Units: Matches on code
      * - Facilities: Matches on rental ID or facility name
-     * Returns up to 10 results per entity type (max 60 total results).
+     * - Staircases: Matches on staircase name
+     * Returns up to 10 results per entity type (max 70 total results).
      */
     get: {
       parameters: {
@@ -11197,7 +11198,30 @@ export interface components {
       /** @description Property name */
       estate: string | null;
     };
-    /** @description A search result that can be either a property, building, residence, parking space, maintenance unit or facility */
+    StaircaseSearchResult: {
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: ({
+        code: string | null;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      }) | null;
+      building: ({
+        code: string | null;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      }) | null;
+    };
+    /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
     SearchResult: {
       /** @description Unique identifier for the search result */
       id: string;
@@ -11316,6 +11340,28 @@ export interface components {
         /** @description Name of building associated with the facility */
         name: string | null;
       };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: ({
+        code: string | null;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      }) | null;
+      building: ({
+        code: string | null;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      }) | null;
     });
     Inspection: {
       id: string;

--- a/apps/property-tree/src/services/api/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/generated/api-types.ts
@@ -1623,6 +1623,41 @@ export interface paths {
       };
     };
   };
+  "/staircases/search": {
+    /**
+     * Search staircases
+     * @description Searches for staircases by name (caption). The query is matched against
+     * the staircase name using a case-insensitive contains operation. Staircases
+     * with placeholder codes ('00', '99') are excluded to stay consistent with
+     * the sidebar navigation. Returns up to 10 results.
+     */
+    get: {
+      parameters: {
+        query: {
+          /** @description The search query. Matches against staircase name. */
+          q: string;
+        };
+      };
+      responses: {
+        /** @description Successfully retrieved the staircases. */
+        200: {
+          content: {
+            "application/json": {
+              content?: components["schemas"]["Staircase"][];
+            };
+          };
+        };
+        /** @description Invalid query parameters. */
+        400: {
+          content: never;
+        };
+        /** @description Internal server error. */
+        500: {
+          content: never;
+        };
+      };
+    };
+  };
   "/rooms": {
     /**
      * Get rooms by residence id.

--- a/apps/property-tree/src/services/api/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/generated/api-types.ts
@@ -2330,16 +2330,6 @@ export interface components {
           /** Format: date-time */
           to: string;
         };
-        property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
-        building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
         deleted: boolean;
         timestamp: string;
       }) | null;
@@ -2524,18 +2514,18 @@ export interface components {
         /** Format: date-time */
         to: string;
       };
-      property?: {
-        propertyId: string | null;
-        propertyName: string | null;
-        propertyCode: string | null;
-      };
-      building?: {
-        buildingId: string | null;
-        buildingName: string | null;
-        buildingCode: string | null;
-      };
       deleted: boolean;
       timestamp: string;
+      property: {
+        propertyId: string;
+        propertyName: string | null;
+        propertyCode: string;
+      };
+      building: {
+        buildingId: string;
+        buildingName: string | null;
+        buildingCode: string;
+      };
     };
     Room: {
       id: string;
@@ -2749,16 +2739,6 @@ export interface components {
           /** Format: date-time */
           to: string;
         };
-        property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
-        building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
         deleted: boolean;
         timestamp: string;
       }) | null;
@@ -2922,16 +2902,6 @@ export interface components {
             from: string;
             /** Format: date-time */
             to: string;
-          };
-          property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
-          building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
           };
           deleted: boolean;
           timestamp: string;

--- a/core/src/adapters/property-base-adapter/generated/api-types.ts
+++ b/core/src/adapters/property-base-adapter/generated/api-types.ts
@@ -1623,6 +1623,41 @@ export interface paths {
       };
     };
   };
+  "/staircases/search": {
+    /**
+     * Search staircases
+     * @description Searches for staircases by name (caption). The query is matched against
+     * the staircase name using a case-insensitive contains operation. Staircases
+     * with placeholder codes ('00', '99') are excluded to stay consistent with
+     * the sidebar navigation. Returns up to 10 results.
+     */
+    get: {
+      parameters: {
+        query: {
+          /** @description The search query. Matches against staircase name. */
+          q: string;
+        };
+      };
+      responses: {
+        /** @description Successfully retrieved the staircases. */
+        200: {
+          content: {
+            "application/json": {
+              content?: components["schemas"]["Staircase"][];
+            };
+          };
+        };
+        /** @description Invalid query parameters. */
+        400: {
+          content: never;
+        };
+        /** @description Internal server error. */
+        500: {
+          content: never;
+        };
+      };
+    };
+  };
   "/rooms": {
     /**
      * Get rooms by residence id.

--- a/core/src/adapters/property-base-adapter/generated/api-types.ts
+++ b/core/src/adapters/property-base-adapter/generated/api-types.ts
@@ -2330,16 +2330,6 @@ export interface components {
           /** Format: date-time */
           to: string;
         };
-        property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
-        building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
         deleted: boolean;
         timestamp: string;
       }) | null;
@@ -2524,18 +2514,18 @@ export interface components {
         /** Format: date-time */
         to: string;
       };
-      property?: {
-        propertyId: string | null;
-        propertyName: string | null;
-        propertyCode: string | null;
-      };
-      building?: {
-        buildingId: string | null;
-        buildingName: string | null;
-        buildingCode: string | null;
-      };
       deleted: boolean;
       timestamp: string;
+      property: {
+        propertyId: string;
+        propertyName: string | null;
+        propertyCode: string;
+      };
+      building: {
+        buildingId: string;
+        buildingName: string | null;
+        buildingCode: string;
+      };
     };
     Room: {
       id: string;
@@ -2749,16 +2739,6 @@ export interface components {
           /** Format: date-time */
           to: string;
         };
-        property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
-        building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
         deleted: boolean;
         timestamp: string;
       }) | null;
@@ -2922,16 +2902,6 @@ export interface components {
             from: string;
             /** Format: date-time */
             to: string;
-          };
-          property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
-          building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
           };
           deleted: boolean;
           timestamp: string;

--- a/core/src/adapters/property-base-adapter/index.ts
+++ b/core/src/adapters/property-base-adapter/index.ts
@@ -83,6 +83,27 @@ export async function searchResidences(
   }
 }
 
+type SearchStaircasesResponse = components['schemas']['Staircase'][]
+
+export async function searchStaircases(
+  q: string
+): Promise<AdapterResult<SearchStaircasesResponse, 'staircase-search-failed'>> {
+  try {
+    const response = await client().GET('/staircases/search', {
+      params: { query: { q } },
+    })
+
+    if (response.data) {
+      return { ok: true, data: response.data.content ?? [] }
+    }
+
+    return { ok: false, err: 'staircase-search-failed' }
+  } catch (err) {
+    logger.error({ err }, '@onecore/property-adapter.searchStaircases')
+    return { ok: false, err: 'staircase-search-failed' }
+  }
+}
+
 type GetBuildingsResponse = components['schemas']['Building'][]
 
 export async function getBuildings(

--- a/core/src/services/search-service/index.ts
+++ b/core/src/services/search-service/index.ts
@@ -198,18 +198,14 @@ export const routes = (router: KoaRouter) => {
         type: 'staircase',
         code: staircase.code,
         name: staircase.name,
-        property: staircase.property
-          ? {
-              code: staircase.property.propertyCode,
-              name: staircase.property.propertyName,
-            }
-          : null,
-        building: staircase.building
-          ? {
-              code: staircase.building.buildingCode,
-              name: staircase.building.buildingName,
-            }
-          : null,
+        property: {
+          code: staircase.property.propertyCode,
+          name: staircase.property.propertyName,
+        },
+        building: {
+          code: staircase.building.buildingCode,
+          name: staircase.building.buildingName,
+        },
       })
     )
 

--- a/core/src/services/search-service/index.ts
+++ b/core/src/services/search-service/index.ts
@@ -36,6 +36,7 @@ export const routes = (router: KoaRouter) => {
     schemas.MaintenanceUnitSearchResultSchema
   )
   registerSchema('FacilitySearchResult', schemas.FacilitySearchResultSchema)
+  registerSchema('StaircaseSearchResult', schemas.StaircaseSearchResultSchema)
   registerSchema('SearchResult', schemas.SearchResultSchema)
 
   /**
@@ -53,7 +54,8 @@ export const routes = (router: KoaRouter) => {
    *       - Parking Spaces: Matches on rental ID or parking space name
    *       - Maintenance Units: Matches on code
    *       - Facilities: Matches on rental ID or facility name
-   *       Returns up to 10 results per entity type (max 60 total results).
+   *       - Staircases: Matches on staircase name
+   *       Returns up to 10 results per entity type (max 70 total results).
    *     parameters:
    *       - in: query
    *         name: q
@@ -100,6 +102,7 @@ export const routes = (router: KoaRouter) => {
       getParkingSpaces,
       getMaintenanceUnits,
       getFacilities,
+      getStaircases,
     ] = await Promise.all([
       propertyBaseAdapter.searchProperties(q),
       propertyBaseAdapter.searchBuildings(q),
@@ -107,6 +110,7 @@ export const routes = (router: KoaRouter) => {
       propertyBaseAdapter.searchParkingSpaces(q),
       propertyBaseAdapter.searchMaintenanceUnits(q),
       propertyBaseAdapter.searchFacilities(q),
+      propertyBaseAdapter.searchStaircases(q),
     ])
 
     if (
@@ -115,7 +119,8 @@ export const routes = (router: KoaRouter) => {
       !getResidences.ok ||
       !getParkingSpaces.ok ||
       !getMaintenanceUnits.ok ||
-      !getFacilities.ok
+      !getFacilities.ok ||
+      !getStaircases.ok
     ) {
       ctx.status = 500
       return
@@ -187,6 +192,27 @@ export const routes = (router: KoaRouter) => {
       })
     )
 
+    const mappedStaircases = getStaircases.data.map(
+      (staircase): schemas.StaircaseSearchResult => ({
+        id: staircase.id,
+        type: 'staircase',
+        code: staircase.code,
+        name: staircase.name,
+        property: staircase.property
+          ? {
+              code: staircase.property.propertyCode,
+              name: staircase.property.propertyName,
+            }
+          : null,
+        building: staircase.building
+          ? {
+              code: staircase.building.buildingCode,
+              name: staircase.building.buildingName,
+            }
+          : null,
+      })
+    )
+
     ctx.body = {
       ...metadata,
       content: [
@@ -196,6 +222,7 @@ export const routes = (router: KoaRouter) => {
         ...mappedParkingSpaces,
         ...mappedMaintenanceUnits,
         ...mappedFacilities,
+        ...mappedStaircases,
       ] satisfies SearchResultResponseContent,
     }
   })

--- a/core/src/services/search-service/schemas.ts
+++ b/core/src/services/search-service/schemas.ts
@@ -89,24 +89,20 @@ export const StaircaseSearchResultSchema = z.object({
   type: z.literal('staircase').describe('Indicates this is a staircase result'),
   code: z.string().describe('Code of the staircase'),
   name: z.string().nullable().describe('Name (caption) of the staircase'),
-  property: z
-    .object({
-      code: z.string().nullable(),
-      name: z
-        .string()
-        .nullable()
-        .describe('Name of property associated with the staircase'),
-    })
-    .nullable(),
-  building: z
-    .object({
-      code: z.string().nullable(),
-      name: z
-        .string()
-        .nullable()
-        .describe('Name of building associated with the staircase'),
-    })
-    .nullable(),
+  property: z.object({
+    code: z.string(),
+    name: z
+      .string()
+      .nullable()
+      .describe('Name of property associated with the staircase'),
+  }),
+  building: z.object({
+    code: z.string(),
+    name: z
+      .string()
+      .nullable()
+      .describe('Name of building associated with the staircase'),
+  }),
 })
 
 export const FacilitySearchResultSchema = z.object({

--- a/core/src/services/search-service/schemas.ts
+++ b/core/src/services/search-service/schemas.ts
@@ -84,6 +84,31 @@ export const MaintenanceUnitSearchResultSchema = z.object({
   estate: z.string().nullable().describe('Property name'),
 })
 
+export const StaircaseSearchResultSchema = z.object({
+  id: z.string().describe('Unique identifier for the search result'),
+  type: z.literal('staircase').describe('Indicates this is a staircase result'),
+  code: z.string().describe('Code of the staircase'),
+  name: z.string().nullable().describe('Name (caption) of the staircase'),
+  property: z
+    .object({
+      code: z.string().nullable(),
+      name: z
+        .string()
+        .nullable()
+        .describe('Name of property associated with the staircase'),
+    })
+    .nullable(),
+  building: z
+    .object({
+      code: z.string().nullable(),
+      name: z
+        .string()
+        .nullable()
+        .describe('Name of building associated with the staircase'),
+    })
+    .nullable(),
+})
+
 export const FacilitySearchResultSchema = z.object({
   id: z.string().describe('Unique identifier for the search result'),
   type: z.literal('facility').describe('Indicates this is a facility result'),
@@ -114,9 +139,10 @@ export const SearchResultSchema = z
     ParkingSpaceSearchResultSchema,
     MaintenanceUnitSearchResultSchema,
     FacilitySearchResultSchema,
+    StaircaseSearchResultSchema,
   ])
   .describe(
-    'A search result that can be either a property, building, residence, parking space, maintenance unit or facility'
+    'A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase'
   )
 
 export const SearchQueryParamsSchema = z.object({
@@ -138,5 +164,6 @@ export type MaintenanceUnitSearchResult = z.infer<
   typeof MaintenanceUnitSearchResultSchema
 >
 export type FacilitySearchResult = z.infer<typeof FacilitySearchResultSchema>
+export type StaircaseSearchResult = z.infer<typeof StaircaseSearchResultSchema>
 export type SearchResult = z.infer<typeof SearchResultSchema>
 export type SearchQueryParams = z.infer<typeof SearchQueryParamsSchema>

--- a/core/src/services/search-service/tests/index.test.ts
+++ b/core/src/services/search-service/tests/index.test.ts
@@ -44,6 +44,9 @@ describe('search-service', () => {
       const searchFacilitiesSpy = jest
         .spyOn(propertyBaseAdapter, 'searchFacilities')
         .mockResolvedValueOnce({ ok: true, data: [] })
+      const searchStaircasesSpy = jest
+        .spyOn(propertyBaseAdapter, 'searchStaircases')
+        .mockResolvedValueOnce({ ok: true, data: [] })
 
       const res = await request(app.callback()).get('/search?q=asdf')
 
@@ -54,6 +57,7 @@ describe('search-service', () => {
       expect(searchParkingSpacesSpy).toHaveBeenCalled()
       expect(searchMaintenanceUnitsSpy).toHaveBeenCalled()
       expect(searchFacilitiesSpy).toHaveBeenCalled()
+      expect(searchStaircasesSpy).toHaveBeenCalled()
 
       expect(() =>
         z.array(SearchResultSchema).parse(res.body.content)

--- a/services/property/src/adapters/staircase-adapter.ts
+++ b/services/property/src/adapters/staircase-adapter.ts
@@ -1,80 +1,177 @@
 import { map } from 'lodash'
+import { logger } from '@onecore/utilities'
+
 import { toBoolean, trimStrings } from '../utils/data-conversion'
 
 import { prisma } from './db'
 
 //todo: add types
 
+type StaircasePropertyData = {
+  propertyId: string | null
+  propertyCode: string | null
+  propertyName: string | null
+  buildingId: string | null
+  buildingCode: string | null
+  buildingName: string | null
+}
+
+type StaircaseRow = Awaited<
+  ReturnType<typeof prisma.staircase.findMany>
+>[number]
+
+type PropertyStructureRow = Awaited<
+  ReturnType<typeof prisma.propertyStructure.findMany>
+>[number]
+
+function extractPropertyData(ps: PropertyStructureRow): StaircasePropertyData {
+  return {
+    propertyId: ps.propertyId,
+    propertyCode: ps.propertyCode,
+    propertyName: ps.propertyName,
+    buildingId: ps.buildingId,
+    buildingCode: ps.buildingCode,
+    buildingName: ps.buildingName,
+  }
+}
+
+function mapStaircase(
+  staircase: StaircaseRow,
+  propertyData: StaircasePropertyData | undefined
+) {
+  return {
+    id: staircase.id,
+    code: staircase.code,
+    name: staircase.name,
+    features: {
+      floorPlan: staircase.floorPlan,
+      accessibleByElevator: toBoolean(staircase.accessibleByElevator),
+    },
+    dates: {
+      from: staircase.fromDate,
+      to: staircase.toDate,
+    },
+    deleted: toBoolean(staircase.deleteMark),
+    timestamp: staircase.timestamp,
+    property: {
+      propertyId: propertyData?.propertyId ?? null,
+      propertyCode: propertyData?.propertyCode ?? null,
+      propertyName: propertyData?.propertyName ?? null,
+    },
+    building: {
+      buildingId: propertyData?.buildingId ?? null,
+      buildingCode: propertyData?.buildingCode ?? null,
+      buildingName: propertyData?.buildingName ?? null,
+    },
+  }
+}
+
 async function getStaircasesByBuildingCode(
   buildingCode: string,
   staircaseCode?: string
 ) {
-  const propertyStructures = await prisma.propertyStructure.findMany({
-    where: {
-      buildingCode: {
-        contains: buildingCode,
+  const propertyStructures = await prisma.propertyStructure
+    .findMany({
+      where: {
+        buildingCode: {
+          contains: buildingCode,
+        },
+        NOT: {
+          staircaseId: null,
+        },
+        residenceId: null,
+        localeId: null,
+        ...(staircaseCode ? { staircaseCode } : {}),
       },
-      NOT: {
-        staircaseId: null,
-      },
-      residenceId: null,
-      localeId: null,
-      ...(staircaseCode ? { staircaseCode } : {}),
-    },
-  })
+    })
+    .then(trimStrings)
 
-  const staircases = await prisma.staircase.findMany({
-    where: {
-      propertyObjectId: {
-        in: map(propertyStructures, 'propertyObjectId'),
+  const staircases = await prisma.staircase
+    .findMany({
+      where: {
+        propertyObjectId: {
+          in: map(propertyStructures, 'propertyObjectId'),
+        },
       },
-    },
-  })
+    })
+    .then(trimStrings)
 
   const propertyStructureMap = new Map(
-    propertyStructures.map(trimStrings).map((ps) => [
+    propertyStructures.map((ps) => [
       ps.propertyObjectId,
-      {
-        propertyId: ps.propertyId,
-        propertyCode: ps.propertyCode,
-        propertyName: ps.propertyName,
-        buildingId: ps.buildingId,
-        buildingCode: ps.buildingCode,
-        buildingName: ps.buildingName,
-      },
+      extractPropertyData(ps),
     ])
   )
 
-  return staircases.map(trimStrings).map((staircase) => {
-    const propertyData = propertyStructureMap.get(staircase.propertyObjectId)
-
-    return {
-      id: staircase.id,
-      code: staircase.code,
-      name: staircase.name,
-      buildingCode: buildingCode,
-      features: {
-        floorPlan: staircase.floorPlan,
-        accessibleByElevator: toBoolean(staircase.accessibleByElevator),
-      },
-      dates: {
-        from: staircase.fromDate,
-        to: staircase.toDate,
-      },
-      deleted: toBoolean(staircase.deleteMark),
-      timestamp: staircase.timestamp,
-      property: {
-        propertyId: propertyData?.propertyId,
-        propertyCode: propertyData?.propertyCode,
-        propertyName: propertyData?.propertyName,
-      },
-      building: {
-        buildingId: propertyData?.buildingId,
-        buildingCode: propertyData?.buildingCode,
-        buildingName: propertyData?.buildingName,
-      },
-    }
-  })
+  return staircases.map((staircase) => ({
+    ...mapStaircase(
+      staircase,
+      propertyStructureMap.get(staircase.propertyObjectId)
+    ),
+    buildingCode,
+  }))
 }
 
-export { getStaircasesByBuildingCode }
+// Staircase codes '00' and '99' are placeholder/synthetic entries not shown in
+// the UI sidebar (see apps/property-tree/src/widgets/sidebar/ui/StaircaseList.tsx).
+// We exclude them from global search results to stay consistent.
+const EXCLUDED_STAIRCASE_CODES = ['00', '99']
+
+async function searchStaircases(q: string) {
+  try {
+    const staircases = await prisma.staircase
+      .findMany({
+        where: {
+          name: { contains: q },
+          deleteMark: 0,
+          code: { notIn: EXCLUDED_STAIRCASE_CODES },
+          // Require a staircase-level PropertyStructure row with a non-null
+          // buildingCode so search results are guaranteed to be navigable.
+          PropertyStructure: {
+            some: {
+              companyCode: '001',
+              residenceId: null,
+              localeId: null,
+              buildingCode: { not: null },
+            },
+          },
+        },
+        take: 10,
+      })
+      .then(trimStrings)
+
+    if (staircases.length === 0) {
+      return []
+    }
+
+    const propertyStructures = await prisma.propertyStructure
+      .findMany({
+        where: {
+          staircaseId: { in: map(staircases, 'propertyObjectId') },
+          residenceId: null,
+          localeId: null,
+        },
+      })
+      .then(trimStrings)
+
+    const propertyStructureMap = new Map(
+      propertyStructures
+        .filter((ps): ps is PropertyStructureRow & { staircaseId: string } =>
+          Boolean(ps.staircaseId)
+        )
+        .map((ps) => [ps.staircaseId, extractPropertyData(ps)])
+    )
+
+    return staircases.map((staircase) =>
+      mapStaircase(
+        staircase,
+        propertyStructureMap.get(staircase.propertyObjectId)
+      )
+    )
+  } catch (err) {
+    logger.error({ err }, 'staircase-adapter.searchStaircases')
+    throw err
+  }
+}
+
+export { getStaircasesByBuildingCode, searchStaircases }

--- a/services/property/src/adapters/staircase-adapter.ts
+++ b/services/property/src/adapters/staircase-adapter.ts
@@ -99,47 +99,52 @@ async function getStaircasesByBuildingCode(
   buildingCode: string,
   staircaseCode?: string
 ): Promise<(Staircase & { buildingCode: string })[]> {
-  const propertyStructures = await prisma.propertyStructure
-    .findMany({
-      where: {
-        buildingCode: { contains: buildingCode },
-        staircaseId: { not: null },
-        residenceId: null,
-        localeId: null,
-        propertyId: { not: null },
-        propertyCode: { not: null },
-        ...(staircaseCode ? { staircaseCode } : {}),
-      },
-    })
-    .then(trimStrings)
-
-  const staircases = await prisma.staircase
-    .findMany({
-      where: {
-        propertyObjectId: {
-          in: map(propertyStructures, 'propertyObjectId'),
+  try {
+    const propertyStructures = await prisma.propertyStructure
+      .findMany({
+        where: {
+          buildingCode: { contains: buildingCode },
+          staircaseId: { not: null },
+          residenceId: null,
+          localeId: null,
+          propertyId: { not: null },
+          propertyCode: { not: null },
+          ...(staircaseCode ? { staircaseCode } : {}),
         },
-      },
-    })
-    .then(trimStrings)
+      })
+      .then(trimStrings)
 
-  const propertyStructureMap = new Map(
-    propertyStructures.map((ps) => [
-      ps.propertyObjectId,
-      extractPropertyData(ps),
-    ])
-  )
+    const staircases = await prisma.staircase
+      .findMany({
+        where: {
+          propertyObjectId: {
+            in: map(propertyStructures, 'propertyObjectId'),
+          },
+        },
+      })
+      .then(trimStrings)
 
-  return staircases.map((staircase) => ({
-    ...mapStaircase(
-      staircase,
-      requirePropertyData(
+    const propertyStructureMap = new Map(
+      propertyStructures.map((ps) => [
+        ps.propertyObjectId,
+        extractPropertyData(ps),
+      ])
+    )
+
+    return staircases.map((staircase) => ({
+      ...mapStaircase(
         staircase,
-        propertyStructureMap.get(staircase.propertyObjectId)
-      )
-    ),
-    buildingCode,
-  }))
+        requirePropertyData(
+          staircase,
+          propertyStructureMap.get(staircase.propertyObjectId)
+        )
+      ),
+      buildingCode,
+    }))
+  } catch (err) {
+    logger.error({ err }, 'staircase-adapter.getStaircasesByBuildingCode')
+    throw err
+  }
 }
 
 async function searchStaircases(q: string): Promise<Staircase[]> {

--- a/services/property/src/adapters/staircase-adapter.ts
+++ b/services/property/src/adapters/staircase-adapter.ts
@@ -32,7 +32,12 @@ type PropertyStructureRow = Awaited<
 >[number]
 
 function extractPropertyData(ps: PropertyStructureRow): StaircasePropertyData {
-  if (!ps.propertyId || !ps.propertyCode || !ps.buildingId || !ps.buildingCode) {
+  if (
+    !ps.propertyId ||
+    !ps.propertyCode ||
+    !ps.buildingId ||
+    !ps.buildingCode
+  ) {
     throw new Error(
       `staircase property structure ${ps.propertyObjectId} is missing required code/id fields`
     )

--- a/services/property/src/adapters/staircase-adapter.ts
+++ b/services/property/src/adapters/staircase-adapter.ts
@@ -2,17 +2,24 @@ import { map } from 'lodash'
 import { logger } from '@onecore/utilities'
 
 import { toBoolean, trimStrings } from '../utils/data-conversion'
+import { Staircase } from '../types/staircase'
 
 import { prisma } from './db'
 
-//todo: add types
+// Staircase codes '00' and '99' are placeholder/synthetic entries that aren't
+// real, navigable staircases. Also filtered out in the sidebar (see
+// apps/property-tree/src/widgets/sidebar/ui/StaircaseList.tsx).
+const PLACEHOLDER_STAIRCASE_CODES = ['00', '99']
 
+// Domain invariant: every staircase in onecore has a building and a property.
+// These codes/ids are guaranteed non-null in the returned data; the Prisma
+// `where` filters below enforce it at the query layer.
 type StaircasePropertyData = {
-  propertyId: string | null
-  propertyCode: string | null
+  propertyId: string
+  propertyCode: string
   propertyName: string | null
-  buildingId: string | null
-  buildingCode: string | null
+  buildingId: string
+  buildingCode: string
   buildingName: string | null
 }
 
@@ -25,6 +32,11 @@ type PropertyStructureRow = Awaited<
 >[number]
 
 function extractPropertyData(ps: PropertyStructureRow): StaircasePropertyData {
+  if (!ps.propertyId || !ps.propertyCode || !ps.buildingId || !ps.buildingCode) {
+    throw new Error(
+      `staircase property structure ${ps.propertyObjectId} is missing required code/id fields`
+    )
+  }
   return {
     propertyId: ps.propertyId,
     propertyCode: ps.propertyCode,
@@ -37,8 +49,8 @@ function extractPropertyData(ps: PropertyStructureRow): StaircasePropertyData {
 
 function mapStaircase(
   staircase: StaircaseRow,
-  propertyData: StaircasePropertyData | undefined
-) {
+  propertyData: StaircasePropertyData
+): Staircase {
   return {
     id: staircase.id,
     code: staircase.code,
@@ -54,33 +66,43 @@ function mapStaircase(
     deleted: toBoolean(staircase.deleteMark),
     timestamp: staircase.timestamp,
     property: {
-      propertyId: propertyData?.propertyId ?? null,
-      propertyCode: propertyData?.propertyCode ?? null,
-      propertyName: propertyData?.propertyName ?? null,
+      propertyId: propertyData.propertyId,
+      propertyCode: propertyData.propertyCode,
+      propertyName: propertyData.propertyName,
     },
     building: {
-      buildingId: propertyData?.buildingId ?? null,
-      buildingCode: propertyData?.buildingCode ?? null,
-      buildingName: propertyData?.buildingName ?? null,
+      buildingId: propertyData.buildingId,
+      buildingCode: propertyData.buildingCode,
+      buildingName: propertyData.buildingName,
     },
   }
+}
+
+function requirePropertyData(
+  staircase: StaircaseRow,
+  propertyData: StaircasePropertyData | undefined
+): StaircasePropertyData {
+  if (!propertyData) {
+    throw new Error(
+      `missing property structure for staircase ${staircase.id} (${staircase.propertyObjectId})`
+    )
+  }
+  return propertyData
 }
 
 async function getStaircasesByBuildingCode(
   buildingCode: string,
   staircaseCode?: string
-) {
+): Promise<(Staircase & { buildingCode: string })[]> {
   const propertyStructures = await prisma.propertyStructure
     .findMany({
       where: {
-        buildingCode: {
-          contains: buildingCode,
-        },
-        NOT: {
-          staircaseId: null,
-        },
+        buildingCode: { contains: buildingCode },
+        staircaseId: { not: null },
         residenceId: null,
         localeId: null,
+        propertyId: { not: null },
+        propertyCode: { not: null },
         ...(staircaseCode ? { staircaseCode } : {}),
       },
     })
@@ -106,33 +128,31 @@ async function getStaircasesByBuildingCode(
   return staircases.map((staircase) => ({
     ...mapStaircase(
       staircase,
-      propertyStructureMap.get(staircase.propertyObjectId)
+      requirePropertyData(
+        staircase,
+        propertyStructureMap.get(staircase.propertyObjectId)
+      )
     ),
     buildingCode,
   }))
 }
 
-// Staircase codes '00' and '99' are placeholder/synthetic entries not shown in
-// the UI sidebar (see apps/property-tree/src/widgets/sidebar/ui/StaircaseList.tsx).
-// We exclude them from global search results to stay consistent.
-const EXCLUDED_STAIRCASE_CODES = ['00', '99']
-
-async function searchStaircases(q: string) {
+async function searchStaircases(q: string): Promise<Staircase[]> {
   try {
     const staircases = await prisma.staircase
       .findMany({
         where: {
           name: { contains: q },
           deleteMark: 0,
-          code: { notIn: EXCLUDED_STAIRCASE_CODES },
-          // Require a staircase-level PropertyStructure row with a non-null
-          // buildingCode so search results are guaranteed to be navigable.
+          code: { notIn: PLACEHOLDER_STAIRCASE_CODES },
           PropertyStructure: {
             some: {
               companyCode: '001',
               residenceId: null,
               localeId: null,
               buildingCode: { not: null },
+              propertyCode: { not: null },
+              propertyId: { not: null },
             },
           },
         },
@@ -165,7 +185,10 @@ async function searchStaircases(q: string) {
     return staircases.map((staircase) =>
       mapStaircase(
         staircase,
-        propertyStructureMap.get(staircase.propertyObjectId)
+        requirePropertyData(
+          staircase,
+          propertyStructureMap.get(staircase.propertyObjectId)
+        )
       )
     )
   } catch (err) {

--- a/services/property/src/routes/staircases.ts
+++ b/services/property/src/routes/staircases.ts
@@ -6,8 +6,15 @@
 import KoaRouter from '@koa/router'
 import { generateRouteMetadata } from '@onecore/utilities'
 
-import { getStaircasesByBuildingCode } from '../adapters/staircase-adapter'
-import { staircasesQueryParamsSchema } from '../types/staircase'
+import {
+  getStaircasesByBuildingCode,
+  searchStaircases,
+} from '../adapters/staircase-adapter'
+import {
+  staircasesQueryParamsSchema,
+  staircasesSearchQueryParamsSchema,
+  type Staircase,
+} from '../types/staircase'
 import { parseRequest } from '../middleware/parse-request'
 
 /**
@@ -86,6 +93,65 @@ export const routes = (router: KoaRouter) => {
 
         ctx.body = {
           content: responseContent,
+          ...metadata,
+        }
+      } catch (err) {
+        ctx.status = 500
+        const errorMessage =
+          err instanceof Error ? err.message : 'unknown error'
+        ctx.body = { reason: errorMessage, ...metadata }
+      }
+    }
+  )
+
+  /**
+   * @swagger
+   * /staircases/search:
+   *   get:
+   *     summary: Search staircases
+   *     description: |
+   *       Searches for staircases by name (caption). The query is matched against
+   *       the staircase name using a case-insensitive contains operation. Staircases
+   *       with placeholder codes ('00', '99') are excluded to stay consistent with
+   *       the sidebar navigation. Returns up to 10 results.
+   *     tags:
+   *       - Staircases
+   *     parameters:
+   *       - in: query
+   *         name: q
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The search query. Matches against staircase name.
+   *     responses:
+   *       200:
+   *         description: Successfully retrieved the staircases.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/Staircase'
+   *       400:
+   *         description: Invalid query parameters.
+   *       500:
+   *         description: Internal server error.
+   */
+  router.get(
+    '(.*)/staircases/search',
+    parseRequest({ query: staircasesSearchQueryParamsSchema }),
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+      try {
+        const staircases: Staircase[] = await searchStaircases(
+          ctx.request.parsedQuery.q
+        )
+
+        ctx.body = {
+          content: staircases,
           ...metadata,
         }
       } catch (err) {

--- a/services/property/src/routes/staircases.ts
+++ b/services/property/src/routes/staircases.ts
@@ -13,7 +13,6 @@ import {
 import {
   staircasesQueryParamsSchema,
   staircasesSearchQueryParamsSchema,
-  type Staircase,
 } from '../types/staircase'
 import { parseRequest } from '../middleware/parse-request'
 
@@ -141,14 +140,12 @@ export const routes = (router: KoaRouter) => {
    *         description: Internal server error.
    */
   router.get(
-    '(.*)/staircases/search',
+    ['(.*)/staircases/search'],
     parseRequest({ query: staircasesSearchQueryParamsSchema }),
     async (ctx) => {
       const metadata = generateRouteMetadata(ctx)
       try {
-        const staircases: Staircase[] = await searchStaircases(
-          ctx.request.parsedQuery.q
-        )
+        const staircases = await searchStaircases(ctx.request.parsedQuery.q)
 
         ctx.body = {
           content: staircases,

--- a/services/property/src/tests/staircases.test.ts
+++ b/services/property/src/tests/staircases.test.ts
@@ -1,5 +1,6 @@
 import request from 'supertest'
 import app from '../app'
+import { Staircase } from '../types/staircase'
 
 describe('Staircases API', () => {
   let buildingCode: string
@@ -66,12 +67,12 @@ describe('Staircases API', () => {
         .query({ buildingCode })
 
       const namedStaircase = staircasesResponse.body.content.find(
-        (s: { name: string | null; code: string }) =>
-          s.name && !['00', '99'].includes(s.code)
+        (s: Staircase) => s.name && !['00', '99'].includes(s.code)
       )
 
-      // Skip if the test fixture happens not to expose a usable staircase name.
-      if (!namedStaircase) return
+      // The shared test fixture is expected to include a real staircase.
+      expect(namedStaircase).toBeDefined()
+      expect(namedStaircase.name).toBeTruthy()
 
       const response = await request(app.callback())
         .get('/staircases/search')
@@ -80,12 +81,10 @@ describe('Staircases API', () => {
       expect(response.status).toBe(200)
       expect(Array.isArray(response.body.content)).toBe(true)
 
-      response.body.content.forEach(
-        (s: { code: string; building: { buildingCode: string | null } }) => {
-          expect(['00', '99']).not.toContain(s.code)
-          expect(s.building.buildingCode).not.toBeNull()
-        }
-      )
+      response.body.content.forEach((s: Staircase) => {
+        expect(['00', '99']).not.toContain(s.code)
+        expect(s.building.buildingCode).toBeTruthy()
+      })
     })
   })
 })

--- a/services/property/src/tests/staircases.test.ts
+++ b/services/property/src/tests/staircases.test.ts
@@ -40,4 +40,52 @@ describe('Staircases API', () => {
     expect(response.status).toBe(400)
     expect(response.body.errors).toBeDefined()
   })
+
+  describe('GET /staircases/search', () => {
+    it('should reject queries shorter than 3 characters', async () => {
+      const response = await request(app.callback())
+        .get('/staircases/search')
+        .query({ q: 'ab' })
+
+      expect(response.status).toBe(400)
+      expect(response.body.errors).toBeDefined()
+    })
+
+    it('should return an empty array for a query with no matches', async () => {
+      const response = await request(app.callback())
+        .get('/staircases/search')
+        .query({ q: 'no-staircase-should-ever-match-this-query-zzz' })
+
+      expect(response.status).toBe(200)
+      expect(response.body.content).toEqual([])
+    })
+
+    it('should return matching staircases without placeholder codes (00, 99) and with a building', async () => {
+      const staircasesResponse = await request(app.callback())
+        .get('/staircases')
+        .query({ buildingCode })
+
+      const namedStaircase = staircasesResponse.body.content.find(
+        (s: { name: string | null; code: string }) =>
+          s.name && !['00', '99'].includes(s.code)
+      )
+
+      // Skip if the test fixture happens not to expose a usable staircase name.
+      if (!namedStaircase) return
+
+      const response = await request(app.callback())
+        .get('/staircases/search')
+        .query({ q: namedStaircase.name.substring(0, 3) })
+
+      expect(response.status).toBe(200)
+      expect(Array.isArray(response.body.content)).toBe(true)
+
+      response.body.content.forEach(
+        (s: { code: string; building: { buildingCode: string | null } }) => {
+          expect(['00', '99']).not.toContain(s.code)
+          expect(s.building.buildingCode).not.toBeNull()
+        }
+      )
+    })
+  })
 })

--- a/services/property/src/types/residence.ts
+++ b/services/property/src/types/residence.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { createGenericResponseSchema } from './response'
-import { StaircaseSchema } from './staircase'
+import { StaircaseBaseSchema } from './staircase'
 
 // Boolean schema for rental block active filtering
 const booleanStringSchema = z
@@ -197,7 +197,7 @@ export const ResidenceDetailedSchema = z.object({
     name: z.string().nullable(),
     code: z.string().nullable(),
   }),
-  staircase: StaircaseSchema.nullable(),
+  staircase: StaircaseBaseSchema.nullable(),
   areaSize: z.number().nullable(),
   malarEnergiFacilityId: z.string().nullable(),
 })

--- a/services/property/src/types/staircase.ts
+++ b/services/property/src/types/staircase.ts
@@ -7,6 +7,10 @@ export const staircasesQueryParamsSchema = z.object({
   staircaseCode: z.string().optional(),
 })
 
+export const staircasesSearchQueryParamsSchema = z.object({
+  q: z.string().min(3, { message: 'q must be at least 3 characters long.' }),
+})
+
 export const StaircaseSchema = z.object({
   id: z.string(),
   code: z.string(),

--- a/services/property/src/types/staircase.ts
+++ b/services/property/src/types/staircase.ts
@@ -11,7 +11,10 @@ export const staircasesSearchQueryParamsSchema = z.object({
   q: z.string().min(3, { message: 'q must be at least 3 characters long.' }),
 })
 
-export const StaircaseSchema = z.object({
+// Identity + features common to every staircase representation. Used directly
+// when the staircase is embedded inside another entity (e.g. a residence
+// already carries its own building/property at the top level).
+export const StaircaseBaseSchema = z.object({
   id: z.string(),
   code: z.string(),
   name: z.string().nullable(),
@@ -23,22 +26,24 @@ export const StaircaseSchema = z.object({
     from: z.date(),
     to: z.date(),
   }),
-  property: z
-    .object({
-      propertyId: z.string().nullable(),
-      propertyName: z.string().nullable(),
-      propertyCode: z.string().nullable(),
-    })
-    .optional(),
-  building: z
-    .object({
-      buildingId: z.string().nullable(),
-      buildingName: z.string().nullable(),
-      buildingCode: z.string().nullable(),
-    })
-    .optional(),
   deleted: z.boolean(),
   timestamp: z.string(),
+})
+
+// Full staircase entity. By domain rule a real staircase always belongs to
+// both a building and a property — the codes/ids are guaranteed non-null and
+// the property-service queries enforce it at the `where` clause.
+export const StaircaseSchema = StaircaseBaseSchema.extend({
+  property: z.object({
+    propertyId: z.string(),
+    propertyName: z.string().nullable(),
+    propertyCode: z.string(),
+  }),
+  building: z.object({
+    buildingId: z.string(),
+    buildingName: z.string().nullable(),
+    buildingCode: z.string(),
+  }),
 })
 
 export type Staircase = z.infer<typeof StaircaseSchema>


### PR DESCRIPTION
## Summary

Adds a `/staircases/search` endpoint to the property service, wires it into the core `/search` aggregator as a 7th result type, and surfaces staircase hits in the property-tree command palette. Also tightens the staircase schema so that the "a staircase always has a building and a property" invariant from Xpand is reflected end-to-end instead of being papered over with nullable fields in three places.

Closes MIM-1706.

## What changed

**`services/property`**
- New `searchStaircases` adapter (Prisma `findMany` on `Staircase`) with a nested `PropertyStructure` filter: `companyCode '001'`, `residenceId/localeId` null, `buildingCode/propertyCode/propertyId` not null. Placeholder codes `'00'` and `'99'` are excluded to stay consistent with the sidebar.
- New `GET /staircases/search` route behind `parseRequest({ query: staircasesSearchQueryParamsSchema })` with `q.min(3)` validation and swagger docs.
- Shared `extractPropertyData` / `mapStaircase` / `requirePropertyData` helpers deduplicate mapping between `getStaircasesByBuildingCode` and the new `searchStaircases`.
- `StaircaseSchema` split into `StaircaseBaseSchema` (id / features / dates, used by the embedded staircase on `ResidenceSchema`) and `StaircaseSchema` (base + non-null property + building).

**`core`**
- New `property-base-adapter.searchStaircases` returning `AdapterResult<Staircase[], 'staircase-search-failed'>` — specific error code rather than `'unknown'`.
- Search service aggregates staircase results alongside the existing types and registers `StaircaseSearchResultSchema` in the discriminated union. Max results bumped from 60 to 70 (10 per type × 7 types).

**`apps/property-tree`**
- Command palette renders staircase results with the `DoorOpen` icon and navigates via `paths.staircase(buildingCode, staircaseCode)`.
- Regenerated `api-types.ts` for `internal-portal`, `keys-portal`, and `property-tree`.

## Why the schema tightening is here

Before this PR, three layers (adapter, core mapper, frontend) each defended against a staircase with a null building or property. After dropping `.parse()` at the route (since the adapter now owns the invariant), there was no runtime gate catching drift. Moving the invariant into the Prisma `where` + `requirePropertyData` throw means we fail loudly at the source, the schema matches runtime, and the defensive branches in the mapper and frontend can go away.

## Test plan

- [ ] `pnpm run typecheck` — zero errors
- [ ] `pnpm -r run prettier --write` — no diff after running
- [ ] `pnpm --filter @onecore/property test staircases` — new `describe('GET /staircases/search')` passes (400 on `q < 3`, empty array on no matches, placeholder codes filtered and building present on real matches)
- [ ] Property-tree command palette: type 3+ chars matching a real staircase name → row renders with the door icon, subtitle shows building name, click navigates to the staircase page
- [ ] Hit core `/search?q=<staircase-name>` directly and verify the response includes `type: 'staircase'` entries with non-null `building.code` and `property.code`
- [ ] Verify placeholder staircases (code `00` / `99`) do **not** appear in results even when their building would match

## Out of scope

- `GET /staircases/:id` (details endpoint) — still a `//todo` in `routes/staircases.ts`.
- Migrating other search result schemas (`Property`, `Building`, `Residence`, etc.) to the specific-error-code pattern — only the new `searchStaircases` uses `'staircase-search-failed'`; the siblings still return `'unknown'`.
