### PR TITLE
sanitize ströfaktura price input to digits and decimals (MIM-1727)

### DIFF
--- a/apps/property-tree/src/features/economy/components/ArticleSection.tsx
+++ b/apps/property-tree/src/features/economy/components/ArticleSection.tsx
@@ -27,9 +27,7 @@ interface ArticleSectionProps {
 }
 
 function sanitizePriceInput(value: string): string {
-  const stripped = value.replace(/[^\d.,]/g, '').replace(/,/g, '.')
-  const [integer, ...fractions] = stripped.split('.')
-  return fractions.length === 0 ? integer : `${integer}.${fractions.join('')}`
+  return value.replace(/\D/g, '')
 }
 
 export function ArticleSection({

--- a/apps/property-tree/src/features/economy/components/ArticleSection.tsx
+++ b/apps/property-tree/src/features/economy/components/ArticleSection.tsx
@@ -26,6 +26,12 @@ interface ArticleSectionProps {
   }
 }
 
+function sanitizePriceInput(value: string): string {
+  const stripped = value.replace(/[^\d.,]/g, '').replace(/,/g, '.')
+  const [integer, ...fractions] = stripped.split('.')
+  return fractions.length === 0 ? integer : `${integer}.${fractions.join('')}`
+}
+
 export function ArticleSection({
   invoiceRows,
   administrativeCosts,
@@ -35,7 +41,7 @@ export function ArticleSection({
 }: ArticleSectionProps) {
   const handleChangeRowPrice = (index: number, value: string) => {
     const newRows = [...invoiceRows]
-    newRows[index] = { ...newRows[index], price: value }
+    newRows[index] = { ...newRows[index], price: sanitizePriceInput(value) }
     onInvoiceRowsChange(newRows)
   }
 


### PR DESCRIPTION
## Summary
Users could type spaces in the ströfaktura price field (e.g. `17 156`). `parseFloat` truncated at the first space, so Xledger received `17` instead of `17156`. The same flaw applied to commas, periods, and letters (`17,50` → `17`, `17abc` → `17`).

## Change
Sanitize the price input on every keystroke in `ArticleSection.tsx` — only digits `0-9` are accepted. Spaces, commas, periods, letters and symbols are blocked at the keystroke and never appear in the field. Whole kronor only (no decimals).

## Test plan
- [ ] Run `pnpm run dev` for property-tree, open the ströfaktura form
- [ ] In *Pris (ink. moms)*, try pressing space, `,`, `.`, letters, symbols → nothing appears in the field
- [ ] Type `17156` → field shows `17156`
- [ ] Paste `17 156` into the field → field shows `17156`
- [ ] Submit a row with price `17156`, amount `1` — verify the request body to `/invoices/miscellaneous` has `price: 17156`
- [ ] For an article with `vatExcluded: true`, confirm the VAT-excluded amount is computed from the full price