### PR TITLE
Feat:AVTAL-107 Move RentalObjectType to Tenfast

### DIFF
--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -112,10 +112,8 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
             <Typography>Hyresform</Typography>
             <Box>
               <Typography fontWeight="bold">
-                {
-                  parkingSpaceListing.rentalObject.availabilityInfo
-                    ?.rentalTenureType?.name
-                }
+                {parkingSpaceListing.rentalObject.availabilityInfo
+                  ?.rentalTenureType?.name || '-'}
               </Typography>
             </Box>
           </Box>

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/components/ParkingSpaceInfo.tsx
@@ -109,6 +109,27 @@ export const ParkingSpaceInfo = (props: { listingId: number }) => {
             </Box>
           </Box>
           <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Hyresform</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {
+                  parkingSpaceListing.rentalObject.availabilityInfo
+                    ?.rentalTenureType?.name
+                }
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
+            <Typography>Uthyrningstyp</Typography>
+            <Box>
+              <Typography fontWeight="bold">
+                {parkingSpaceListing.rentalObject.availabilityInfo?.rentalTags
+                  ?.map((t) => t.name)
+                  .join(', ') || '-'}
+              </Typography>
+            </Box>
+          </Box>
+          <Box display="flex" justifyContent="space-between" flex="1">
             <Typography>Hyra</Typography>
             <Box>
               <Typography fontWeight="bold">{`${numberFormatter.format(

--- a/core/src/processes/parkingspaces/external/tests/index.test.ts
+++ b/core/src/processes/parkingspaces/external/tests/index.test.ts
@@ -103,6 +103,7 @@ describe('parkingspaces', () => {
                 rows: [],
               },
               rentalObjectCode: '705-808-00-0006',
+              rentalTenureType: { id: 'Bilplats', name: 'Bilplats' },
             },
             objectTypeCaption: 'Bilplats',
             objectTypeCode: 'BP',

--- a/core/test/factories/rental-object-availability-info.ts
+++ b/core/test/factories/rental-object-availability-info.ts
@@ -7,4 +7,6 @@ export const RentalObjectAvailabilityInfoFactory =
     rentalObjectCode: `R${sequence + 1000}`,
     rent: RentalObjectRentFactory.build(),
     vacantFrom: new Date(),
+    rentalTenureType: { id: 'Standard', name: 'Standard' },
+    rentalTags: [],
   }))

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -379,11 +379,18 @@ interface RentalObject {
   isSpecialProperty?: boolean
 }
 
+interface RentalTag {
+  id: string
+  name: string
+}
+
 // This type is used as the return type of the function that parses the availability info of a rental object.
 interface RentalObjectAvailabilityInfo {
   rentalObjectCode: string
   vacantFrom?: Date
   rent: RentalObjectRent
+  rentalTenureType: RentalTag
+  rentalTags?: RentalTag[]
 }
 
 interface RentalObjectRent {
@@ -450,6 +457,7 @@ export type {
   XledgerContact,
   XledgerProject,
   RentalObject,
+  RentalTag,
   RentalObjectAvailabilityInfo,
   RentalObjectRent,
   RentalObjectRentRow as RentRow,

--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -106,6 +106,7 @@ export type TenfastTenantByContactCodeResponse = z.infer<
 >
 export const TenfastTagSchema = z.object({
   _id: z.string(),
+  code: z.string(),
   name: z.string(),
 })
 

--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -57,6 +57,8 @@ export const TenfastRentalObjectSchema = z.object({
   stadsdel: z.string().nullish(),
   typ: z.string().optional(), // 'parkering', 'bostad', 'lokal'
   subType: z.string().optional(),
+  category: z.string(),
+  tags: z.array(z.string()).optional(),
   kvm: z.number().nullish(),
   roomCount: z.number().nullish(),
   avtal: z
@@ -99,6 +101,12 @@ export type TenfastTenant = z.infer<typeof TenfastTenantSchema>
 export type TenfastTenantByContactCodeResponse = z.infer<
   typeof TenfastTenantByContactCodeResponseSchema
 >
+export const TenfastTagSchema = z.object({
+  _id: z.string(),
+  name: z.string(),
+})
+
+export type TenfastTag = z.infer<typeof TenfastTagSchema>
 export type TenfastRentalObject = z.infer<typeof TenfastRentalObjectSchema>
 export type TenfastRentalObjectByRentalObjectCodeResponse = z.infer<
   typeof TenfastRentalObjectByRentalObjectCodeResponseSchema

--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -57,7 +57,10 @@ export const TenfastRentalObjectSchema = z.object({
   stadsdel: z.string().nullish(),
   typ: z.string().optional(), // 'parkering', 'bostad', 'lokal'
   subType: z.string().optional(),
-  category: z.string(),
+  category: z.object({
+    code: z.string(),
+    label: z.string(),
+  }),
   tags: z.array(z.string()).optional(),
   kvm: z.number().nullish(),
   roomCount: z.number().nullish(),

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -264,12 +264,25 @@ const getTags = (): Promise<Map<string, TenfastTag>> => {
         method: 'get',
         url: `${tenfastBaseUrl}/v1/hyresvard/tags?hyresvard=${tenfastCompanyId}`,
       })
-      if (res.status !== 200) return new Map()
+      if (res.status !== 200) {
+        tagsCache = null
+        tagsCachedAt = 0
+        return new Map()
+      }
       const tags = z.array(TenfastTagSchema).safeParse(res.data)
-      if (!tags.success) return new Map()
+      if (!tags.success) {
+        tagsCache = null
+        tagsCachedAt = 0
+        return new Map()
+      }
       return new Map(tags.data.map((t) => [t._id, t]))
-    } catch {
+    } catch (err) {
+      logger.error(
+        { err: JSON.stringify(err) },
+        'Failed to fetch tags from Tenfast '
+      )
       tagsCache = null
+      tagsCachedAt = 0
       return new Map()
     }
   })()

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -22,6 +22,7 @@ import {
   TenfastRentalObjectSchema,
   TenfastLeaseTemplateResponseSchema,
   TenfastLeasesByArticleResponseSchema,
+  TenfastTagSchema,
 } from './schemas'
 import config from '../../../../common/config'
 import { AdapterResult } from '../../adapters/types'
@@ -247,6 +248,33 @@ export enum RentalObjectType {
   Storage = 'förråd',
 }
 
+const TAGS_CACHE_TTL_MS = 5 * 60 * 1000
+let tagsCache: Promise<Map<string, string>> | null = null
+let tagsCachedAt = 0
+
+const getTags = (): Promise<Map<string, string>> => {
+  if (tagsCache && Date.now() - tagsCachedAt < TAGS_CACHE_TTL_MS) {
+    return tagsCache
+  }
+  tagsCachedAt = Date.now()
+  tagsCache = (async () => {
+    try {
+      const res = await tenfastApi.request({
+        method: 'get',
+        url: `${tenfastBaseUrl}/v1/hyresvard/tags?hyresvard=${tenfastCompanyId}`,
+      })
+      if (res.status !== 200) return new Map()
+      const tags = z.array(TenfastTagSchema).safeParse(res.data)
+      if (!tags.success) return new Map()
+      return new Map(tags.data.map((t) => [t._id, t.name]))
+    } catch {
+      tagsCache = null
+      return new Map()
+    }
+  })()
+  return tagsCache
+}
+
 export const getAvailabilityForVacantRentalObjects = async (
   type: RentalObjectType
 ): Promise<
@@ -258,6 +286,8 @@ export const getAvailabilityForVacantRentalObjects = async (
   >
 > => {
   try {
+    const tagsById = await getTags()
+
     let page = ''
     let allRecords: any[] = []
     let totalCount = 0
@@ -310,7 +340,7 @@ export const getAvailabilityForVacantRentalObjects = async (
     return {
       ok: true,
       data: recordsWithoutUpcomingLeases.map((record) =>
-        mapTenfastRentalObjectToAvailabilityInfo(false, record)
+        mapTenfastRentalObjectToAvailabilityInfo(false, record, tagsById)
       ),
     }
   } catch (err: any) {
@@ -329,7 +359,10 @@ export const getAvailabilityForRentalObject = async (
     | 'get-rental-object-bad-request'
   >
 > => {
-  const rentalObjectResult = await getRentalObject(rentalObjectCode)
+  const [rentalObjectResult, tagsById] = await Promise.all([
+    getRentalObject(rentalObjectCode),
+    getTags(),
+  ])
 
   if (!rentalObjectResult.ok) {
     return {
@@ -348,7 +381,8 @@ export const getAvailabilityForRentalObject = async (
   const availability: RentalObjectAvailabilityInfo =
     mapTenfastRentalObjectToAvailabilityInfo(
       includeVAT,
-      rentalObjectResult.data
+      rentalObjectResult.data,
+      tagsById
     )
 
   return {
@@ -370,6 +404,8 @@ export const getRentalObjectAvailabilityInfo = async (
   >
 > => {
   try {
+    const tagsById = await getTags()
+
     const batchSize = 500
     const batches: Array<Array<string>> = []
     for (let i = 0; i < rentalObjectCodes.length; i += batchSize) {
@@ -412,7 +448,8 @@ export const getRentalObjectAvailabilityInfo = async (
 
           return mapTenfastRentalObjectToAvailabilityInfo(
             includeVAT,
-            parsedRentalObject.data
+            parsedRentalObject.data,
+            tagsById
           )
         }
       )

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -23,6 +23,7 @@ import {
   TenfastLeaseTemplateResponseSchema,
   TenfastLeasesByArticleResponseSchema,
   TenfastTagSchema,
+  TenfastTag,
 } from './schemas'
 import config from '../../../../common/config'
 import { AdapterResult } from '../../adapters/types'
@@ -249,10 +250,10 @@ export enum RentalObjectType {
 }
 
 const TAGS_CACHE_TTL_MS = 5 * 60 * 1000
-let tagsCache: Promise<Map<string, string>> | null = null
+let tagsCache: Promise<Map<string, TenfastTag>> | null = null
 let tagsCachedAt = 0
 
-const getTags = (): Promise<Map<string, string>> => {
+const getTags = (): Promise<Map<string, TenfastTag>> => {
   if (tagsCache && Date.now() - tagsCachedAt < TAGS_CACHE_TTL_MS) {
     return tagsCache
   }
@@ -266,7 +267,7 @@ const getTags = (): Promise<Map<string, string>> => {
       if (res.status !== 200) return new Map()
       const tags = z.array(TenfastTagSchema).safeParse(res.data)
       if (!tags.success) return new Map()
-      return new Map(tags.data.map((t) => [t._id, t.name]))
+      return new Map(tags.data.map((t) => [t._id, t]))
     } catch {
       tagsCache = null
       return new Map()
@@ -982,8 +983,8 @@ export async function getLeaseByLeaseId(
 ): Promise<AdapterResult<TenfastLease, 'unknown' | 'not-found' | SchemaError>> {
   try {
     const res = await tenfastApi.request({
+      url: `${tenfastBaseUrl}/v1/hyresvard/extras/avtal/${encodeURIComponent(leaseId)}?hyresvard=${tenfastCompanyId}&populate=hyresobjekt,hyresgaster`,
       method: 'get',
-      url: `${tenfastBaseUrl}/v1/hyresvard/mimer/avtal/${leaseId}?populate=hyresobjekt`,
     })
 
     if (res.status !== 200) {

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
@@ -1,4 +1,4 @@
-import { RentalObjectAvailabilityInfo } from '@onecore/types'
+import { RentalObjectAvailabilityInfo, RentalTag } from '@onecore/types'
 import currency from 'currency.js'
 import { TenfastLease, TenfastRentalObject } from './schemas'
 import { filterByStatus } from './filters'
@@ -23,9 +23,16 @@ export const getLatestActiveLeasesEndDate = (
   return new Date(endDates[0]) // Return the latest end date
 }
 
+// TODO: Remove when Tenfast API returns category as { id, name } object instead of a space-separated string
+export const parseCategoryToRentalTag = (category: string): RentalTag => {
+  const [id, name] = category.split(' ')
+  return name ? { id, name } : { id: category, name: category }
+}
+
 export const mapTenfastRentalObjectToAvailabilityInfo = (
   includeVAT: boolean,
-  tenfastRentalObject: TenfastRentalObject
+  tenfastRentalObject: TenfastRentalObject,
+  tagsById: Map<string, string> = new Map()
 ): RentalObjectAvailabilityInfo => {
   const lastDebitDate = getLatestActiveLeasesEndDate(
     tenfastRentalObject.avtal ?? []
@@ -46,6 +53,11 @@ export const mapTenfastRentalObjectToAvailabilityInfo = (
   return {
     rentalObjectCode: tenfastRentalObject.externalId,
     vacantFrom: vacantFrom,
+    rentalTenureType: parseCategoryToRentalTag(tenfastRentalObject.category),
+    rentalTags: tenfastRentalObject.tags?.flatMap((id): RentalTag[] => {
+      const name = tagsById.get(id)
+      return name ? [{ id, name }] : []
+    }),
     rent: {
       amount: includeVAT
         ? tenfastRentalObject.hyra

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
@@ -1,6 +1,6 @@
 import { RentalObjectAvailabilityInfo, RentalTag } from '@onecore/types'
 import currency from 'currency.js'
-import { TenfastLease, TenfastRentalObject } from './schemas'
+import { TenfastLease, TenfastRentalObject, TenfastTag } from './schemas'
 import { filterByStatus } from './filters'
 
 // TODO: Säkerställ med expand att den här logiken håller för korttidskontrakt.
@@ -26,7 +26,7 @@ export const getLatestActiveLeasesEndDate = (
 export const mapTenfastRentalObjectToAvailabilityInfo = (
   includeVAT: boolean,
   tenfastRentalObject: TenfastRentalObject,
-  tagsById: Map<string, string> = new Map()
+  tagsById: Map<string, TenfastTag> = new Map()
 ): RentalObjectAvailabilityInfo => {
   const lastDebitDate = getLatestActiveLeasesEndDate(
     tenfastRentalObject.avtal ?? []
@@ -52,8 +52,8 @@ export const mapTenfastRentalObjectToAvailabilityInfo = (
       name: tenfastRentalObject.category.label,
     },
     rentalTags: tenfastRentalObject.tags?.flatMap((id): RentalTag[] => {
-      const name = tagsById.get(id)
-      return name ? [{ id, name }] : []
+      const tag = tagsById.get(id)
+      return tag ? [{ id: tag.code, name: tag.name }] : []
     }),
     rent: {
       amount: includeVAT

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-rental-object-helpers.ts
@@ -23,12 +23,6 @@ export const getLatestActiveLeasesEndDate = (
   return new Date(endDates[0]) // Return the latest end date
 }
 
-// TODO: Remove when Tenfast API returns category as { id, name } object instead of a space-separated string
-export const parseCategoryToRentalTag = (category: string): RentalTag => {
-  const [id, name] = category.split(' ')
-  return name ? { id, name } : { id: category, name: category }
-}
-
 export const mapTenfastRentalObjectToAvailabilityInfo = (
   includeVAT: boolean,
   tenfastRentalObject: TenfastRentalObject,
@@ -53,7 +47,10 @@ export const mapTenfastRentalObjectToAvailabilityInfo = (
   return {
     rentalObjectCode: tenfastRentalObject.externalId,
     vacantFrom: vacantFrom,
-    rentalTenureType: parseCategoryToRentalTag(tenfastRentalObject.category),
+    rentalTenureType: {
+      id: tenfastRentalObject.category.code,
+      name: tenfastRentalObject.category.label,
+    },
     rentalTags: tenfastRentalObject.tags?.flatMap((id): RentalTag[] => {
       const name = tagsById.get(id)
       return name ? [{ id, name }] : []

--- a/services/leasing/src/services/lease-service/helpers/tenfast.ts
+++ b/services/leasing/src/services/lease-service/helpers/tenfast.ts
@@ -12,6 +12,7 @@ import {
   TenfastInvoiceRow,
   TenfastRentalObject,
 } from '../adapters/tenfast/schemas'
+import { parseCategoryToRentalTag } from '../adapters/tenfast/tenfast-rental-object-helpers'
 
 /**
  * Map TenFAST rental object type to LeaseType enum.
@@ -72,6 +73,7 @@ const mapToOnecoreRentalObject = (
     address: rentalObject.postadress,
     availabilityInfo: {
       rentalObjectCode: rentalObject.externalId,
+      rentalTenureType: parseCategoryToRentalTag(rentalObject.category),
       rent: {
         amount: rentalObject.hyraExcludingVat,
         vat: rentalObject.hyraVat,

--- a/services/leasing/src/services/lease-service/helpers/tenfast.ts
+++ b/services/leasing/src/services/lease-service/helpers/tenfast.ts
@@ -12,7 +12,6 @@ import {
   TenfastInvoiceRow,
   TenfastRentalObject,
 } from '../adapters/tenfast/schemas'
-import { parseCategoryToRentalTag } from '../adapters/tenfast/tenfast-rental-object-helpers'
 
 /**
  * Map TenFAST rental object type to LeaseType enum.
@@ -73,7 +72,10 @@ const mapToOnecoreRentalObject = (
     address: rentalObject.postadress,
     availabilityInfo: {
       rentalObjectCode: rentalObject.externalId,
-      rentalTenureType: parseCategoryToRentalTag(rentalObject.category),
+      rentalTenureType: {
+        id: rentalObject.category.code,
+        name: rentalObject.category.label,
+      },
       rent: {
         amount: rentalObject.hyraExcludingVat,
         vat: rentalObject.hyraVat,

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
@@ -437,7 +437,7 @@ describe(tenfastAdapter.getAvailabilityForVacantRentalObjects, () => {
     it('includes rentalTenureType and rentalTags in availability info', async () => {
       const rentalObject = factory.tenfastRentalObject.build({
         externalId: 'R1001',
-        category: 'BP Bilplats',
+        category: { code: 'BP', label: 'Bilplats' },
         tags: ['tag-1'],
         avtal: [],
       })
@@ -1391,7 +1391,7 @@ describe(tenfastAdapter.getAvailabilityForRentalObject, () => {
     it('includes rentalTenureType and rentalTags in returned availability info', async () => {
       const rentalObject = factory.tenfastRentalObject.build({
         externalId: 'R1001',
-        category: 'BP Bilplats',
+        category: { code: 'BP', label: 'Bilplats' },
         tags: ['tag-1'],
       })
       jest
@@ -1659,7 +1659,7 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
     it('includes rentalTenureType derived from category', async () => {
       const rentalObject = factory.tenfastRentalObject.build({
         externalId: 'R1001',
-        category: 'BP Bilplats',
+        category: { code: 'BP', label: 'Bilplats' },
         tags: [],
       })
       ;(request as jest.Mock)
@@ -1731,12 +1731,12 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
     it('includes rentalTenureType and rentalTags across multiple objects in batch', async () => {
       const r1 = factory.tenfastRentalObject.build({
         externalId: 'R1001',
-        category: 'BP Bilplats',
+        category: { code: 'BP', label: 'Bilplats' },
         tags: ['tag-1'],
       })
       const r2 = factory.tenfastRentalObject.build({
         externalId: 'R1002',
-        category: 'LGH Lägenhet',
+        category: { code: 'LGH', label: 'Lägenhet' },
         tags: [],
       })
       ;(request as jest.Mock)

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
@@ -444,7 +444,7 @@ describe(tenfastAdapter.getAvailabilityForVacantRentalObjects, () => {
       ;(request as jest.Mock)
         .mockResolvedValueOnce({
           status: 200,
-          data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+          data: [{ _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
         })
         .mockResolvedValueOnce({
           status: 200,
@@ -466,7 +466,7 @@ describe(tenfastAdapter.getAvailabilityForVacantRentalObjects, () => {
         name: 'Bilplats',
       })
       expect(result.data![0].rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
       ])
     })
   })
@@ -1399,7 +1399,7 @@ describe(tenfastAdapter.getAvailabilityForRentalObject, () => {
         .mockResolvedValueOnce({ ok: true, data: rentalObject })
       ;(request as jest.Mock).mockResolvedValueOnce({
         status: 200,
-        data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+        data: [{ _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
       }) // tags
 
       const result = await tenfastAdapter.getAvailabilityForRentalObject(
@@ -1413,7 +1413,7 @@ describe(tenfastAdapter.getAvailabilityForRentalObject, () => {
         name: 'Bilplats',
       })
       expect(result.data.rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
       ])
     })
   })
@@ -1687,8 +1687,8 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
         .mockResolvedValueOnce({
           status: 200,
           data: [
-            { _id: 'tag-1', name: 'Ungdomslägenhet' },
-            { _id: 'tag-2', name: 'Seniorlägenhet' },
+            { _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' },
+            { _id: 'tag-2', code: 'SENIOR', name: 'Seniorlägenhet' },
           ],
         }) // tags
         .mockResolvedValueOnce({ status: 200, data: [rentalObject] }) // batch-get
@@ -1700,8 +1700,8 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
 
       assert(result.ok)
       expect(result.data[0].rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
-        { id: 'tag-2', name: 'Seniorlägenhet' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
+        { id: 'SENIOR', name: 'Seniorlägenhet' },
       ])
     })
 
@@ -1713,7 +1713,7 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
       ;(request as jest.Mock)
         .mockResolvedValueOnce({
           status: 200,
-          data: [{ _id: 'tag-known', name: 'Känd tagg' }],
+          data: [{ _id: 'tag-known', code: 'KNOWN', name: 'Känd tagg' }],
         }) // tags
         .mockResolvedValueOnce({ status: 200, data: [rentalObject] }) // batch-get
 
@@ -1724,7 +1724,7 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
 
       assert(result.ok)
       expect(result.data[0].rentalTags).toEqual([
-        { id: 'tag-known', name: 'Känd tagg' },
+        { id: 'KNOWN', name: 'Känd tagg' },
       ])
     })
 
@@ -1742,7 +1742,7 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
       ;(request as jest.Mock)
         .mockResolvedValueOnce({
           status: 200,
-          data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+          data: [{ _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
         }) // tags
         .mockResolvedValueOnce({ status: 200, data: [r1, r2] }) // batch-get
 
@@ -1757,7 +1757,7 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
         name: 'Bilplats',
       })
       expect(result.data[0].rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
       ])
       expect(result.data[1].rentalTenureType).toEqual({
         id: 'LGH',

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
@@ -8,6 +8,11 @@ import { request } from '../../../adapters/tenfast/tenfast-api'
 import * as factory from '../../factories'
 import { toYearMonthDayString } from '../../../adapters/tenfast/schemas'
 
+// Shared clock offset used to bust the module-level tag cache (TTL: 5 min) between tests.
+// Each test that needs a fresh tag fetch increments this by 1 hour before mocking Date.now.
+let tagTestClockOffset = 0
+const TAG_CACHE_BASE_TIME = new Date('2100-01-01').getTime()
+
 describe(tenfastAdapter.getLeaseTemplate, () => {
   it('should return template when response is valid and status is 200', async () => {
     // Arrange
@@ -412,6 +417,58 @@ describe(tenfastAdapter.getAvailabilityForVacantRentalObjects, () => {
     if (!result.ok) return
     expect(result.data).toHaveLength(1)
     expect(result.data![0].rentalObjectCode).toBe('R1003')
+  })
+
+  describe('tag propagation', () => {
+    let nowSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      tagTestClockOffset += 60 * 60 * 1000
+      nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(TAG_CACHE_BASE_TIME + tagTestClockOffset)
+      ;(request as jest.Mock).mockReset()
+    })
+
+    afterEach(() => {
+      nowSpy.mockRestore()
+    })
+
+    it('includes rentalTenureType and rentalTags in availability info', async () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        category: 'BP Bilplats',
+        tags: ['tag-1'],
+        avtal: [],
+      })
+      ;(request as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200,
+          data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+        })
+        .mockResolvedValueOnce({
+          status: 200,
+          data: {
+            records: [rentalObject],
+            prev: null,
+            next: null,
+            totalCount: 1,
+          },
+        })
+
+      const result = await tenfastAdapter.getAvailabilityForVacantRentalObjects(
+        tenfastAdapter.RentalObjectType.ParkingSpace
+      )
+
+      assert(result.ok)
+      expect(result.data![0].rentalTenureType).toEqual({
+        id: 'BP',
+        name: 'Bilplats',
+      })
+      expect(result.data![0].rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+      ])
+    })
   })
 })
 
@@ -1316,6 +1373,51 @@ describe(tenfastAdapter.getAvailabilityForRentalObject, () => {
     expect(result.err).toBe('could-not-find-rental-object')
   })
 
+  describe('tag and tenure type propagation', () => {
+    let nowSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      tagTestClockOffset += 60 * 60 * 1000
+      nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(TAG_CACHE_BASE_TIME + tagTestClockOffset)
+      ;(request as jest.Mock).mockReset()
+    })
+
+    afterEach(() => {
+      nowSpy.mockRestore()
+    })
+
+    it('includes rentalTenureType and rentalTags in returned availability info', async () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        category: 'BP Bilplats',
+        tags: ['tag-1'],
+      })
+      jest
+        .spyOn(tenfastAdapter, 'getRentalObject')
+        .mockResolvedValueOnce({ ok: true, data: rentalObject })
+      ;(request as jest.Mock).mockResolvedValueOnce({
+        status: 200,
+        data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+      }) // tags
+
+      const result = await tenfastAdapter.getAvailabilityForRentalObject(
+        'R1001',
+        true
+      )
+
+      assert(result.ok)
+      expect(result.data.rentalTenureType).toEqual({
+        id: 'BP',
+        name: 'Bilplats',
+      })
+      expect(result.data.rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+      ])
+    })
+  })
+
   it('should return rent with correct VAT values when includeVAT is true', async () => {
     // Arrange
     const mockRentalObject = factory.tenfastRentalObject.build({
@@ -1537,6 +1639,132 @@ describe(tenfastAdapter.getRentalObjectAvailabilityInfo, () => {
     // Assert
     assert(!result.ok)
     expect(result.err).toBe('unknown')
+  })
+
+  describe('tag and tenure type propagation', () => {
+    let nowSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      tagTestClockOffset += 60 * 60 * 1000
+      nowSpy = jest
+        .spyOn(Date, 'now')
+        .mockReturnValue(TAG_CACHE_BASE_TIME + tagTestClockOffset)
+      ;(request as jest.Mock).mockReset()
+    })
+
+    afterEach(() => {
+      nowSpy.mockRestore()
+    })
+
+    it('includes rentalTenureType derived from category', async () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        category: 'BP Bilplats',
+        tags: [],
+      })
+      ;(request as jest.Mock)
+        .mockResolvedValueOnce({ status: 200, data: [] }) // tags
+        .mockResolvedValueOnce({ status: 200, data: [rentalObject] }) // batch-get
+
+      const result = await tenfastAdapter.getRentalObjectAvailabilityInfo(
+        ['R1001'],
+        true
+      )
+
+      assert(result.ok)
+      expect(result.data[0].rentalTenureType).toEqual({
+        id: 'BP',
+        name: 'Bilplats',
+      })
+    })
+
+    it('resolves rentalTags from tag IDs via the tags API', async () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        tags: ['tag-1', 'tag-2'],
+      })
+      ;(request as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200,
+          data: [
+            { _id: 'tag-1', name: 'Ungdomslägenhet' },
+            { _id: 'tag-2', name: 'Seniorlägenhet' },
+          ],
+        }) // tags
+        .mockResolvedValueOnce({ status: 200, data: [rentalObject] }) // batch-get
+
+      const result = await tenfastAdapter.getRentalObjectAvailabilityInfo(
+        ['R1001'],
+        true
+      )
+
+      assert(result.ok)
+      expect(result.data[0].rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'tag-2', name: 'Seniorlägenhet' },
+      ])
+    })
+
+    it('omits tag IDs not present in the tags API response', async () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        tags: ['tag-known', 'tag-unknown'],
+      })
+      ;(request as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200,
+          data: [{ _id: 'tag-known', name: 'Känd tagg' }],
+        }) // tags
+        .mockResolvedValueOnce({ status: 200, data: [rentalObject] }) // batch-get
+
+      const result = await tenfastAdapter.getRentalObjectAvailabilityInfo(
+        ['R1001'],
+        true
+      )
+
+      assert(result.ok)
+      expect(result.data[0].rentalTags).toEqual([
+        { id: 'tag-known', name: 'Känd tagg' },
+      ])
+    })
+
+    it('includes rentalTenureType and rentalTags across multiple objects in batch', async () => {
+      const r1 = factory.tenfastRentalObject.build({
+        externalId: 'R1001',
+        category: 'BP Bilplats',
+        tags: ['tag-1'],
+      })
+      const r2 = factory.tenfastRentalObject.build({
+        externalId: 'R1002',
+        category: 'LGH Lägenhet',
+        tags: [],
+      })
+      ;(request as jest.Mock)
+        .mockResolvedValueOnce({
+          status: 200,
+          data: [{ _id: 'tag-1', name: 'Ungdomslägenhet' }],
+        }) // tags
+        .mockResolvedValueOnce({ status: 200, data: [r1, r2] }) // batch-get
+
+      const result = await tenfastAdapter.getRentalObjectAvailabilityInfo(
+        ['R1001', 'R1002'],
+        true
+      )
+
+      assert(result.ok)
+      expect(result.data[0].rentalTenureType).toEqual({
+        id: 'BP',
+        name: 'Bilplats',
+      })
+      expect(result.data[0].rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+      ])
+      expect(result.data[1].rentalTenureType).toEqual({
+        id: 'LGH',
+        name: 'Lägenhet',
+      })
+      expect(result.data[1].rentalTags).toEqual([])
+    })
   })
 })
 

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
@@ -1,7 +1,6 @@
 import {
   getLatestActiveLeasesEndDate,
   mapTenfastRentalObjectToAvailabilityInfo,
-  parseCategoryToRentalTag,
 } from '../../../adapters/tenfast/tenfast-rental-object-helpers'
 import * as factory from '../../factories'
 
@@ -153,22 +152,6 @@ describe('tenfast-rental-object-helpers', () => {
     })
   })
 
-  describe('parseCategoryToRentalTag', () => {
-    it('returns id and name as the same value for a single-word category', () => {
-      expect(parseCategoryToRentalTag('Bilplats')).toEqual({
-        id: 'Bilplats',
-        name: 'Bilplats',
-      })
-    })
-
-    it('splits a space-separated category into id and name', () => {
-      expect(parseCategoryToRentalTag('BP Bilplats')).toEqual({
-        id: 'BP',
-        name: 'Bilplats',
-      })
-    })
-  })
-
   describe('rentalTags in mapTenfastRentalObjectToAvailabilityInfo', () => {
     it('returns undefined rentalTags when rental object has no tags field', () => {
       const rentalObject = factory.tenfastRentalObject.build({
@@ -259,7 +242,7 @@ describe('tenfast-rental-object-helpers', () => {
 
     it('maps rentalTenureType from category', () => {
       const rentalObject = factory.tenfastRentalObject.build({
-        category: 'Bilplats',
+        category: { code: 'Bilplats', label: 'Bilplats' },
         avtal: [],
       })
       const result = mapTenfastRentalObjectToAvailabilityInfo(

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
@@ -179,8 +179,8 @@ describe('tenfast-rental-object-helpers', () => {
 
     it('maps tag ids to name objects using tagsById', () => {
       const tagsById = new Map([
-        ['tag-1', 'Ungdomslägenhet'],
-        ['tag-2', 'Rökfritt'],
+        ['tag-1', { _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
+        ['tag-2', { _id: 'tag-2', code: 'ROKFRITT', name: 'Rökfritt' }],
       ])
       const rentalObject = factory.tenfastRentalObject.build({
         tags: ['tag-1', 'tag-2'],
@@ -192,13 +192,15 @@ describe('tenfast-rental-object-helpers', () => {
         tagsById
       )
       expect(result.rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
-        { id: 'tag-2', name: 'Rökfritt' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
+        { id: 'ROKFRITT', name: 'Rökfritt' },
       ])
     })
 
     it('filters out tag ids not present in tagsById', () => {
-      const tagsById = new Map([['tag-1', 'Ungdomslägenhet']])
+      const tagsById = new Map([
+        ['tag-1', { _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
+      ])
       const rentalObject = factory.tenfastRentalObject.build({
         tags: ['tag-1', 'tag-unknown'],
         avtal: [],
@@ -209,12 +211,14 @@ describe('tenfast-rental-object-helpers', () => {
         tagsById
       )
       expect(result.rentalTags).toEqual([
-        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'UNGDOM', name: 'Ungdomslägenhet' },
       ])
     })
 
     it('returns empty array when no tag ids match tagsById', () => {
-      const tagsById = new Map([['tag-1', 'Ungdomslägenhet']])
+      const tagsById = new Map([
+        ['tag-1', { _id: 'tag-1', code: 'UNGDOM', name: 'Ungdomslägenhet' }],
+      ])
       const rentalObject = factory.tenfastRentalObject.build({
         tags: ['tag-unknown'],
         avtal: [],

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-rental-object-helpers.test.ts
@@ -1,6 +1,7 @@
 import {
   getLatestActiveLeasesEndDate,
   mapTenfastRentalObjectToAvailabilityInfo,
+  parseCategoryToRentalTag,
 } from '../../../adapters/tenfast/tenfast-rental-object-helpers'
 import * as factory from '../../factories'
 
@@ -149,6 +150,126 @@ describe('tenfast-rental-object-helpers', () => {
       )
       expect(result.rent.amount).toBe(1250)
       expect(result.rent.vat).toBe(250)
+    })
+  })
+
+  describe('parseCategoryToRentalTag', () => {
+    it('returns id and name as the same value for a single-word category', () => {
+      expect(parseCategoryToRentalTag('Bilplats')).toEqual({
+        id: 'Bilplats',
+        name: 'Bilplats',
+      })
+    })
+
+    it('splits a space-separated category into id and name', () => {
+      expect(parseCategoryToRentalTag('BP Bilplats')).toEqual({
+        id: 'BP',
+        name: 'Bilplats',
+      })
+    })
+  })
+
+  describe('rentalTags in mapTenfastRentalObjectToAvailabilityInfo', () => {
+    it('returns undefined rentalTags when rental object has no tags field', () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: undefined,
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject
+      )
+      expect(result.rentalTags).toBeUndefined()
+    })
+
+    it('returns empty array when rental object has empty tags', () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: [],
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject
+      )
+      expect(result.rentalTags).toEqual([])
+    })
+
+    it('maps tag ids to name objects using tagsById', () => {
+      const tagsById = new Map([
+        ['tag-1', 'Ungdomslägenhet'],
+        ['tag-2', 'Rökfritt'],
+      ])
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: ['tag-1', 'tag-2'],
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject,
+        tagsById
+      )
+      expect(result.rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+        { id: 'tag-2', name: 'Rökfritt' },
+      ])
+    })
+
+    it('filters out tag ids not present in tagsById', () => {
+      const tagsById = new Map([['tag-1', 'Ungdomslägenhet']])
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: ['tag-1', 'tag-unknown'],
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject,
+        tagsById
+      )
+      expect(result.rentalTags).toEqual([
+        { id: 'tag-1', name: 'Ungdomslägenhet' },
+      ])
+    })
+
+    it('returns empty array when no tag ids match tagsById', () => {
+      const tagsById = new Map([['tag-1', 'Ungdomslägenhet']])
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: ['tag-unknown'],
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject,
+        tagsById
+      )
+      expect(result.rentalTags).toEqual([])
+    })
+
+    it('returns empty array when tagsById is empty', () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        tags: ['tag-1', 'tag-2'],
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject,
+        new Map()
+      )
+      expect(result.rentalTags).toEqual([])
+    })
+
+    it('maps rentalTenureType from category', () => {
+      const rentalObject = factory.tenfastRentalObject.build({
+        category: 'Bilplats',
+        avtal: [],
+      })
+      const result = mapTenfastRentalObjectToAvailabilityInfo(
+        false,
+        rentalObject
+      )
+      expect(result.rentalTenureType).toEqual({
+        id: 'Bilplats',
+        name: 'Bilplats',
+      })
     })
   })
 })

--- a/services/leasing/src/services/lease-service/tests/factories/rental-object-availability-info.ts
+++ b/services/leasing/src/services/lease-service/tests/factories/rental-object-availability-info.ts
@@ -7,4 +7,6 @@ export const RentalObjectAvailabilityInfoFactory =
     rentalObjectCode: `R${sequence + 1000}`,
     rent: RentalObjectRentFactory.build(),
     vacantFrom: new Date(),
+    rentalTenureType: { id: 'STD', name: 'Standard' },
+    rentalTags: [{ id: 'ROKFRITT', name: 'Rökfritt' }],
   }))

--- a/services/leasing/src/services/lease-service/tests/factories/rental-object.ts
+++ b/services/leasing/src/services/lease-service/tests/factories/rental-object.ts
@@ -11,6 +11,8 @@ export const RentalObjectFactory = Factory.define<RentalObject>(
       rentalObjectCode: `R${sequence + 1000}`,
       rent: RentalObjectRentFactory.build(),
       vacantFrom: new Date(),
+      rentalTenureType: { id: 'STD', name: 'Standard' },
+      rentalTags: [{ id: 'ROKFRITT', name: 'Rökfritt' }],
     }),
     districtCaption: 'Malmaberg',
     districtCode: 'MAL',

--- a/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
+++ b/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
@@ -19,6 +19,8 @@ export const TenfastRentalObjectByRentalObjectCodeResponseFactory =
           externalId: `externalId-${sequence}`,
           contractTemplate: 'template-001',
           avtal: [],
+          category: 'Bilplats',
+          tags: [],
         },
       ],
       prev: null,
@@ -36,6 +38,8 @@ export const TenfastRentalObjectFactory = Factory.define<TenfastRentalObject>(
     hyror: [TenfastInvoiceRowFactory.build()],
     externalId: 'externalId-1',
     contractTemplate: 'template-001',
+    category: 'Bilplats',
+    tags: [],
     avtal: [],
   })
 )

--- a/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
+++ b/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
@@ -19,7 +19,7 @@ export const TenfastRentalObjectByRentalObjectCodeResponseFactory =
           externalId: `externalId-${sequence}`,
           contractTemplate: 'template-001',
           avtal: [],
-          category: 'Bilplats',
+          category: { code: 'Bilplats', label: 'Bilplats' },
           tags: [],
         },
       ],
@@ -38,7 +38,7 @@ export const TenfastRentalObjectFactory = Factory.define<TenfastRentalObject>(
     hyror: [TenfastInvoiceRowFactory.build()],
     externalId: 'externalId-1',
     contractTemplate: 'template-001',
-    category: 'Bilplats',
+    category: { code: 'Bilplats', label: 'Bilplats' },
     tags: [],
     avtal: [],
   })


### PR DESCRIPTION
RentalObjectType (ie STD Standard) is to be stored in Tenfast in two fields: category and tags.

* Adds rentalTenureType (for category) and rentalTags (for tags) to  RentalObjectAvailabilityInfo model
* Adjusts tenfast adapter to get categoy and tags for rental objects as well as the full tag list
* Parking space detail page now uses new fields to display rental tenure type and rental tags