### PR TITLE
Add "syncInjectedDepsAfterScripts: build" to pnpm-workspace.yaml for local build stability

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,8 @@ packages:
 injectWorkspacePackages: true
 
 minimumReleaseAge: 5760
+syncInjectedDepsAfterScripts:
+  - build
 
 onlyBuiltDependencies:
   - '@prisma/client'


### PR DESCRIPTION
## WHAT

Added `syncInjectedDepsAfterScripts: build` to `pnpm-workspace.yaml` to make both fresh, local and CI builds behave.

## WHY

Local and fresh builds get confused and raises hard-to-diagnose errors, because:

- This workspace uses `injectWorkspacePackages: true`, which means workspace dependencies are materialized as injected package copies in pnpm’s virtual store instead of being consumed directly from the source package directory.

- That is useful/required for the Docker build/deploy setup, but it has an important consequence: when a workspace package is rebuilt, dependent packages may still compile against the previously injected copy unless pnpm syncs the injected dependency after the build.

## NOTES

-  This does not remove injectWorkspacePackages or change CI behavior. It keeps the current Docker/deploy-compatible dependency model and makes it behave correctly during both fresh and recursive workspace builds.