### PR TITLE
fix(avtal-39): address Copilot review comments on payment sync

### DIFF
--- a/core/src/adapters/economy-adapter/index.ts
+++ b/core/src/adapters/economy-adapter/index.ts
@@ -8,6 +8,7 @@ import {
   RentInvoiceRow,
   XledgerContact,
   XledgerProject,
+  schemas,
 } from '@onecore/types'
 
 import config from '../../common/config'
@@ -324,7 +325,10 @@ export async function getPaymentsSince(
     )
 
     if (response.status === 200) {
-      return { ok: true, data: response.data.content }
+      const parsed = schemas.v1.InvoicePaymentEventSchema.array().parse(
+        response.data.content
+      )
+      return { ok: true, data: parsed }
     }
 
     logger.error(response.data, 'economy-adapter.getPaymentsSince')

--- a/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
+++ b/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
@@ -29,9 +29,10 @@ async function saveLastTimestamp(ts: Date) {
   await fs.writeFile(STATE_FILE, ts.toISOString(), 'utf-8')
 }
 
-// Groups payment events by invoice ID so each unique invoice is looked up in
-// Tenfast only once — and if the invoice is not found, all its events are skipped
-// together rather than triggering a redundant lookup per event.
+// Groups payment events by invoice ID so that when an invoice is not found in
+// Tenfast all of its events can be skipped together without triggering a
+// separate lookup for each one. Invoices that are found still result in one
+// Tenfast call per payment event.
 function groupByInvoiceId(
   events: InvoicePaymentEvent[]
 ): Map<string, InvoicePaymentEvent[]> {

--- a/services/economy/src/services/common/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/common/adapters/xledger-adapter.ts
@@ -799,7 +799,7 @@ async function fetchPaymentsSince(
 
 function mapToInvoicePaymentEvent(event: any): InvoicePaymentEvent {
   return {
-    type: event.type,
+    type: event.transactionHeader.transactionSource.code,
     invoiceId: event.invoiceNumber,
     matchId: event.matchId,
     amount: parseFloat(event.amount),

--- a/services/economy/test/services/common/adapters/xledger-adapter.test.ts
+++ b/services/economy/test/services/common/adapters/xledger-adapter.test.ts
@@ -268,22 +268,26 @@ describe(adapter.getPaymentsSince, () => {
   const makeArTransactionEdge = (overrides?: {
     sourceCode?: string
     postedDate?: string
-  }) => ({
-    cursor: 'cursor-1',
-    node: {
-      matchId: 42,
-      invoiceNumber: '55123456',
-      amount: '1000.00',
-      text: 'Hyra',
-      paymentDate: '2026-04-01',
-      transactionHeader: {
-        postedDate: overrides?.postedDate ?? '2026-04-02',
-        transactionSource: {
-          code: overrides?.sourceCode ?? 'SO',
+  }) => {
+    const sourceCode = overrides?.sourceCode ?? 'SO'
+    return {
+      cursor: 'cursor-1',
+      node: {
+        matchId: 42,
+        invoiceNumber: '55123456',
+        amount: '1000.00',
+        text: 'Hyra',
+        paymentDate: '2026-04-01',
+        type: sourceCode,
+        transactionHeader: {
+          postedDate: overrides?.postedDate ?? '2026-04-02',
+          transactionSource: {
+            code: sourceCode,
+          },
         },
       },
-    },
-  })
+    }
+  }
 
   it('returns empty array when no transactions exist', async () => {
     nock(origin)
@@ -323,6 +327,9 @@ describe(adapter.getPaymentsSince, () => {
       paymentDate: new Date('2026-04-02'),
       transactionSourceCode: 'SO',
     })
+    expect(() =>
+      schemas.v1.InvoicePaymentEventSchema.array().parse(result)
+    ).not.toThrow()
   })
 
   it('filters out AR and OS source codes', async () => {
@@ -345,6 +352,9 @@ describe(adapter.getPaymentsSince, () => {
 
     expect(result).toHaveLength(1)
     expect(result[0].transactionSourceCode).toBe('SO')
+    expect(() =>
+      schemas.v1.InvoicePaymentEventSchema.array().parse(result)
+    ).not.toThrow()
   })
 
   it('paginates through multiple pages', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses all 4 Copilot review comments on #avtal-39-xledger-betalstatus, one commit per issue.

## Changes

### Commit 1 — Fix `type` always being `undefined` in `mapToInvoicePaymentEvent`
**File:** `services/economy/src/services/common/adapters/xledger-adapter.ts`

`mapToInvoicePaymentEvent` read `event.type`, but none of the `arTransactions` GraphQL queries include a `type` field in the selection set, so `InvoicePaymentEvent.type` was always `undefined`, breaking the required `InvoicePaymentEventSchema` contract. Fixed by deriving `type` from the already-fetched `transactionHeader.transactionSource.code`.

### Commit 2 — Coerce `paymentDate` back to `Date` in `economy-adapter.getPaymentsSince`
**File:** `core/src/adapters/economy-adapter/index.ts`

JSON serialisation turns a `Date` into an ISO string. The `sync-xledger-payments-to-tenfast` script passes `event.paymentDate` straight into `recordInvoicePayment`, which calls `.toISOString()` on it — crashing when the value is still a string. The response is now parsed through `InvoicePaymentEventSchema.array()` (which uses `z.coerce.date()`) before being returned.

### Commit 3 — Correct the misleading `groupByInvoiceId` comment
**File:** `core/src/scripts/sync-xledger-payments-to-tenfast/index.ts`

The comment claimed grouping ensures each invoice is "looked up in Tenfast only once". In reality the optimisation only applies to invoices that are _not_ found (all events are skipped together). Invoices that are found still trigger one Tenfast call per payment event. The comment now accurately describes this.

### Commit 4 — Add `type` to mock edges and schema assertions in tests
**File:** `services/economy/test/services/common/adapters/xledger-adapter.test.ts`

- `makeArTransactionEdge` now includes a `type` field (set to `sourceCode`) so the mock data matches the shape expected after fix 1.
- Two `getPaymentsSince` tests now assert `InvoicePaymentEventSchema.array().parse(result)` does not throw, guarding against future contract regressions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d769f277-04d0-49eb-8cfd-4991a855c939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d769f277-04d0-49eb-8cfd-4991a855c939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

