### PR TITLE
fix(avtal-39): address second round of Copilot review comments on payment sync

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -33,7 +33,7 @@
     "script:bosociala": "node build/src/scripts/bosociala",
     "script:home-insurance-export": "node build/src/scripts/home-insurance-export",
     "script:sync-contacts": "node build/scripts/sync-contacts/index",
-    "script:sync-xledger-payments-to-tenfast": "node build/src/scripts/sync-xledger-payments-to-tenfast/index",
+    "script:sync-xledger-payments-to-tenfast": "node build/scripts/sync-xledger-payments-to-tenfast/index",
     "start": "node build/index.js",
     "test": "jest",
     "test:ci": "TZ=UTC jest --silent",

--- a/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
+++ b/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
@@ -36,8 +36,10 @@ describe('economy-adapter.getPaymentsSince', () => {
 
     const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
 
-    expect(result).toMatchObject({ ok: true })
-    expect(result.ok && result.data).toHaveLength(1)
+    expect(result).toEqual({
+      ok: true,
+      data: [expect.objectContaining({ invoiceId: '55123456' })],
+    })
   })
 
   it('coerces paymentDate ISO string to a Date instance', async () => {
@@ -45,17 +47,21 @@ describe('economy-adapter.getPaymentsSince', () => {
       .get('/payments/since')
       .query(true)
       .reply(200, {
-        content: [makePaymentEvent({ paymentDate: '2026-04-01T00:00:00.000Z' })],
+        content: [
+          makePaymentEvent({ paymentDate: '2026-04-01T00:00:00.000Z' }),
+        ],
       })
 
     const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) return
-    expect(result.data[0].paymentDate).toBeInstanceOf(Date)
-    expect(result.data[0].paymentDate.toISOString()).toBe(
-      '2026-04-01T00:00:00.000Z'
-    )
+    expect(result).toEqual({
+      ok: true,
+      data: [
+        expect.objectContaining({
+          paymentDate: new Date('2026-04-01T00:00:00.000Z'),
+        }),
+      ],
+    })
   })
 
   it('satisfies InvoicePaymentEventSchema on 200', async () => {
@@ -66,10 +72,11 @@ describe('economy-adapter.getPaymentsSince', () => {
 
     const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
 
-    expect(result.ok).toBe(true)
-    if (!result.ok) return
+    expect(result).toMatchObject({ ok: true })
     expect(() =>
-      schemas.v1.InvoicePaymentEventSchema.array().parse(result.data)
+      schemas.v1.InvoicePaymentEventSchema.array().parse(
+        (result as { ok: true; data: unknown }).data
+      )
     ).not.toThrow()
   })
 

--- a/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
+++ b/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
@@ -75,7 +75,7 @@ describe('economy-adapter.getPaymentsSince', () => {
     expect(result).toMatchObject({ ok: true })
     expect(() =>
       schemas.v1.InvoicePaymentEventSchema.array().parse(
-        (result as { ok: true; data: unknown }).data
+        result.ok ? result.data : null
       )
     ).not.toThrow()
   })

--- a/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
+++ b/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
@@ -1,0 +1,97 @@
+import nock from 'nock'
+
+import config from '../../../common/config'
+import * as economyAdapter from '../../economy-adapter'
+import { schemas } from '@onecore/types'
+
+afterEach(nock.cleanAll)
+
+const makePaymentEvent = (
+  overrides?: Partial<{
+    type: string
+    invoiceId: string
+    matchId: number
+    amount: number
+    paymentDate: string
+    text: string | null
+    transactionSourceCode: string
+  }>
+) => ({
+  type: 'SO',
+  invoiceId: '55123456',
+  matchId: 42,
+  amount: 1000,
+  paymentDate: '2026-04-01T00:00:00.000Z',
+  text: 'Hyra',
+  transactionSourceCode: 'SO',
+  ...overrides,
+})
+
+describe('economy-adapter.getPaymentsSince', () => {
+  it('returns ok with parsed payment events on 200', async () => {
+    nock(config.economyService.url)
+      .get('/payments/since')
+      .query(true)
+      .reply(200, { content: [makePaymentEvent()] })
+
+    const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
+
+    expect(result).toMatchObject({ ok: true })
+    expect(result.ok && result.data).toHaveLength(1)
+  })
+
+  it('coerces paymentDate ISO string to a Date instance', async () => {
+    nock(config.economyService.url)
+      .get('/payments/since')
+      .query(true)
+      .reply(200, {
+        content: [makePaymentEvent({ paymentDate: '2026-04-01T00:00:00.000Z' })],
+      })
+
+    const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(result.data[0].paymentDate).toBeInstanceOf(Date)
+    expect(result.data[0].paymentDate.toISOString()).toBe(
+      '2026-04-01T00:00:00.000Z'
+    )
+  })
+
+  it('satisfies InvoicePaymentEventSchema on 200', async () => {
+    nock(config.economyService.url)
+      .get('/payments/since')
+      .query(true)
+      .reply(200, { content: [makePaymentEvent()] })
+
+    const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) return
+    expect(() =>
+      schemas.v1.InvoicePaymentEventSchema.array().parse(result.data)
+    ).not.toThrow()
+  })
+
+  it('returns ok: false with err unknown on non-200 status', async () => {
+    nock(config.economyService.url)
+      .get('/payments/since')
+      .query(true)
+      .reply(500, { message: 'Internal Server Error' })
+
+    const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
+
+    expect(result).toMatchObject({ ok: false, err: 'unknown', statusCode: 500 })
+  })
+
+  it('returns ok: false with err unknown on network failure', async () => {
+    nock(config.economyService.url)
+      .get('/payments/since')
+      .query(true)
+      .replyWithError('Connection refused')
+
+    const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
+
+    expect(result).toMatchObject({ ok: false, err: 'unknown' })
+  })
+})

--- a/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
+++ b/core/src/adapters/tests/economy-adapter/get-payments-since.test.ts
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import nock from 'nock'
 
 import config from '../../../common/config'
@@ -72,11 +73,9 @@ describe('economy-adapter.getPaymentsSince', () => {
 
     const result = await economyAdapter.getPaymentsSince(new Date('2026-04-01'))
 
-    expect(result).toMatchObject({ ok: true })
+    assert(result.ok)
     expect(() =>
-      schemas.v1.InvoicePaymentEventSchema.array().parse(
-        result.ok ? result.data : null
-      )
+      schemas.v1.InvoicePaymentEventSchema.array().parse(result.data)
     ).not.toThrow()
   })
 

--- a/services/economy/src/services/common/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/common/adapters/xledger-adapter.ts
@@ -769,7 +769,7 @@ async function fetchPaymentsSince(
       }
     `,
     variables: {
-      since: since.toISOString(),
+      since: dateToGraphQlDateString(since),
       cursor: cursor ?? null,
     },
   }

--- a/services/economy/test/services/common/adapters/xledger-adapter.test.ts
+++ b/services/economy/test/services/common/adapters/xledger-adapter.test.ts
@@ -401,6 +401,29 @@ describe(adapter.getPaymentsSince, () => {
 
     expect(result[0].paymentDate).toEqual(new Date('2026-04-01'))
   })
+
+  it('sends since as YYYY-MM-DD date string, not ISO timestamp', async () => {
+    let capturedBody: any
+
+    nock(origin)
+      .post(pathname, (body) => {
+        capturedBody = body
+        return true
+      })
+      .reply(200, {
+        data: {
+          arTransactions: {
+            edges: [],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      })
+
+    await adapter.getPaymentsSince(new Date('2026-04-01T12:00:00Z'))
+
+    expect(capturedBody.variables.since).toBe('2026-04-01')
+    expect(capturedBody.variables.since).not.toMatch(/T/)
+  })
 })
 
 describe(adapter.getInvoiceMatchId, () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses the three Copilot comments raised on the second review of the `avtal-39-xledger-betalstatus` PR.

## Changes

### 1. `fix(xledger-adapter)`: Use `dateToGraphQlDateString` for `since` filter

`fetchPaymentsSince` was sending `since.toISOString()` (e.g. `2026-04-01T00:00:00.000Z`) as the `postedDate_gte` variable. Xledger's date fields expect `YYYY-MM-DD`, consistent with every other date filter in this adapter. Using an ISO timestamp would silently return incorrect or empty results.

- Changed `since.toISOString()` to `dateToGraphQlDateString(since)`
- Added a test that captures the request body and asserts `variables.since` is a `YYYY-MM-DD` string (no `T` character)

### 2. `fix(core)`: Correct npm script path for `sync-xledger-payments-to-tenfast`

`tsconfig.build.json` has `rootDir: "./src"` and `outDir: "./build"`, so TypeScript strips the `src/` segment on output. The script path `build/src/scripts/...` was wrong and would fail at runtime after build. Updated to `build/scripts/...`, matching the path used by `script:sync-contacts`.

### 3. `test(economy-adapter)`: Add unit tests for `getPaymentsSince`

Added `get-payments-since.test.ts` alongside the other economy-adapter tests, covering:
- Returns `ok: true` with parsed events on HTTP 200
- Coerces `paymentDate` ISO string back to a `Date` instance (via `z.coerce.date()`)
- Result satisfies `InvoicePaymentEventSchema` (catches future contract regressions)
- Returns `ok: false, err: 'unknown'` on non-200 status
- Returns `ok: false, err: 'unknown'` on network failure
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b0bb00-7ad2-4cd2-bd1f-1992bcfc1b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b0bb00-7ad2-4cd2-bd1f-1992bcfc1b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

