### PR TITLE
fix(avtal-39): address third round of Copilot review comments on payment sync

### DIFF
--- a/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
+++ b/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
@@ -15,7 +15,7 @@ const FALLBACK_DAYS = 90
 // TODO: confirm valid method value with Tenfast (e.g. 'bank', 'bankgiro', 'autogiro')
 const DEFAULT_PAYMENT_METHOD = 'bank'
 
-async function getLastTimestamp(): Promise<Date | null> {
+async function getLastSyncDate(): Promise<Date | null> {
   try {
     const content = await fs.readFile(STATE_FILE, 'utf-8')
     const result = z.coerce.date().safeParse(content.trim())
@@ -25,8 +25,13 @@ async function getLastTimestamp(): Promise<Date | null> {
   }
 }
 
-async function saveLastTimestamp(ts: Date) {
-  await fs.writeFile(STATE_FILE, ts.toISOString(), 'utf-8')
+// Saves the day after syncDate as the next since-boundary (UTC YYYY-MM-DD).
+// Advancing by one day means a same-day re-run queries from the next day,
+// avoiding re-processing payments already recorded in this run.
+async function saveNextSyncDate(syncDate: Date) {
+  const next = new Date(syncDate)
+  next.setUTCDate(next.getUTCDate() + 1)
+  await fs.writeFile(STATE_FILE, next.toISOString().slice(0, 10), 'utf-8')
 }
 
 // Groups payment events by invoice ID so that when an invoice is not found in
@@ -47,19 +52,19 @@ function groupByInvoiceId(
 
 async function syncPayments() {
   const syncStart = new Date()
-  const lastTimestamp = await getLastTimestamp()
+  const lastSyncDate = await getLastSyncDate()
 
   const fallbackSince = new Date(syncStart)
-  fallbackSince.setDate(fallbackSince.getDate() - FALLBACK_DAYS)
+  fallbackSince.setUTCDate(fallbackSince.getUTCDate() - FALLBACK_DAYS)
 
-  const since = lastTimestamp ?? fallbackSince
+  const since = lastSyncDate ?? fallbackSince
 
-  if (lastTimestamp) {
-    logger.info({ since }, 'syncing Xledger payments since last timestamp')
+  if (lastSyncDate) {
+    logger.info({ since }, 'syncing Xledger payments since last sync date')
   } else {
     logger.info(
       { since },
-      `no saved timestamp, using ${FALLBACK_DAYS}-day fallback window`
+      `no saved sync date, using ${FALLBACK_DAYS}-day fallback window`
     )
   }
 
@@ -74,8 +79,8 @@ async function syncPayments() {
   logger.info({ count: payments.length }, 'payments fetched from Xledger')
 
   if (payments.length === 0) {
-    await saveLastTimestamp(syncStart)
-    logger.info('no new payments, timestamp advanced')
+    await saveNextSyncDate(syncStart)
+    logger.info('no new payments, sync date advanced')
     return
   }
 
@@ -118,10 +123,10 @@ async function syncPayments() {
     }
   }
 
-  await saveLastTimestamp(syncStart)
+  await saveNextSyncDate(syncStart)
   logger.info(
     { uniqueInvoices: byInvoice.size },
-    'all invoices processed, timestamp advanced'
+    'all invoices processed, sync date advanced'
   )
 }
 

--- a/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
+++ b/core/src/scripts/sync-xledger-payments-to-tenfast/index.ts
@@ -15,7 +15,7 @@ const FALLBACK_DAYS = 90
 // TODO: confirm valid method value with Tenfast (e.g. 'bank', 'bankgiro', 'autogiro')
 const DEFAULT_PAYMENT_METHOD = 'bank'
 
-async function getLastSyncDate(): Promise<Date | null> {
+async function getLastTimestamp(): Promise<Date | null> {
   try {
     const content = await fs.readFile(STATE_FILE, 'utf-8')
     const result = z.coerce.date().safeParse(content.trim())
@@ -25,11 +25,10 @@ async function getLastSyncDate(): Promise<Date | null> {
   }
 }
 
-// Saves the day after syncDate as the next since-boundary (UTC YYYY-MM-DD).
-// Advancing by one day means a same-day re-run queries from the next day,
-// avoiding re-processing payments already recorded in this run.
-async function saveNextSyncDate(syncDate: Date) {
-  const next = new Date(syncDate)
+// Advances the saved timestamp to the next UTC day so that a same-day re-run
+// queries from tomorrow, avoiding re-processing payments already recorded.
+async function saveLastTimestamp(ts: Date) {
+  const next = new Date(ts)
   next.setUTCDate(next.getUTCDate() + 1)
   await fs.writeFile(STATE_FILE, next.toISOString().slice(0, 10), 'utf-8')
 }
@@ -52,19 +51,19 @@ function groupByInvoiceId(
 
 async function syncPayments() {
   const syncStart = new Date()
-  const lastSyncDate = await getLastSyncDate()
+  const lastTimestamp = await getLastTimestamp()
 
   const fallbackSince = new Date(syncStart)
   fallbackSince.setUTCDate(fallbackSince.getUTCDate() - FALLBACK_DAYS)
 
-  const since = lastSyncDate ?? fallbackSince
+  const since = lastTimestamp ?? fallbackSince
 
-  if (lastSyncDate) {
-    logger.info({ since }, 'syncing Xledger payments since last sync date')
+  if (lastTimestamp) {
+    logger.info({ since }, 'syncing Xledger payments since last timestamp')
   } else {
     logger.info(
       { since },
-      `no saved sync date, using ${FALLBACK_DAYS}-day fallback window`
+      `no saved timestamp, using ${FALLBACK_DAYS}-day fallback window`
     )
   }
 
@@ -79,8 +78,8 @@ async function syncPayments() {
   logger.info({ count: payments.length }, 'payments fetched from Xledger')
 
   if (payments.length === 0) {
-    await saveNextSyncDate(syncStart)
-    logger.info('no new payments, sync date advanced')
+    await saveLastTimestamp(syncStart)
+    logger.info('no new payments, timestamp advanced')
     return
   }
 
@@ -123,10 +122,10 @@ async function syncPayments() {
     }
   }
 
-  await saveNextSyncDate(syncStart)
+  await saveLastTimestamp(syncStart)
   logger.info(
     { uniqueInvoices: byInvoice.size },
-    'all invoices processed, sync date advanced'
+    'all invoices processed, timestamp advanced'
   )
 }
 

--- a/services/economy/src/services/common/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/common/adapters/xledger-adapter.ts
@@ -138,12 +138,8 @@ const dateFromString = (dateString: string): Date => {
   return new Date(Date.parse(dateString))
 }
 
-const dateToGraphQlDateString = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = date.getMonth() + 1
-  const day = date.getDate()
-  return `${year}-${month > 9 ? month : `0${month}`}-${day > 9 ? day : `0${day}`}`
-}
+const dateToGraphQlDateString = (date: Date): string =>
+  date.toISOString().slice(0, 10)
 
 const dateFromXledgerDateString = (xledgerDateString: string): Date => {
   const dateString =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses two actionable Copilot comments from the third review of `avtal-39-xledger-betalstatus`. The third comment (misleading `since` contract in the payment-sync-service API) was assessed as not applicable — date format conversion is an internal adapter concern; callers correctly pass a `Date` and the adapter handles the Xledger-specific wire format.

## Changes

### 1. `fix(xledger-adapter)`: UTC-based date string in `dateToGraphQlDateString`

The original implementation used local-time getters (`getFullYear/getMonth/getDate`), which can produce the wrong date on servers in timezones behind UTC. `toISOString().slice(0, 10)` always produces the correct UTC date, is deterministic regardless of server timezone, and is simpler to read.

### 2. `fix(sync-script)`: Advance saved timestamp to next UTC day to prevent same-day re-processing

The Xledger filter is date-granular (`YYYY-MM-DD`), so multiple runs on the same day would re-fetch and re-record the same payments in Tenfast. After a successful run, the state is now saved as the next UTC calendar day. A same-day re-run will query from tomorrow, returning nothing rather than re-processing. State is stored as `YYYY-MM-DD` instead of a full ISO timestamp.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b0bb00-7ad2-4cd2-bd1f-1992bcfc1b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b0bb00-7ad2-4cd2-bd1f-1992bcfc1b48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

