### PR TITLE
AVTAL-104: Contacts role

### DIFF
--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -66,6 +66,11 @@ app.use(async (ctx, next) => {
   if (ctx.path.startsWith('/scan-receipt')) {
     return requireRole('scanner-upload')(ctx, next)
   }
+
+  if (ctx.path.startsWith('/v1/contacts') && ctx.method === 'GET') {
+    return requireRole(['api-access', 'contacts:read'])(ctx, next)
+  }
+
   return requireRole('api-access')(ctx, next)
 })
 


### PR DESCRIPTION
Adds role based access to v1 contacts read routes

Added contacts:read role (to staging keycloak) and assigned it to a new tenfast client per this wiki:
https://dev.azure.com/mimeronline/ONECore/_wiki/wikis/Digital-verksamhetsutveckling.wiki/201/Keycloak-service-clients-med-beh%C3%B6righetskontroll

This role doesn't exist in keycloak prod. AFAIK shouldn't be a problem since `requireRole` is "or"-based