### PR TITLE
Require role for access to /invoice-channels endpoint

### DIFF
--- a/core/src/app.ts
+++ b/core/src/app.ts
@@ -75,6 +75,10 @@ app.use(async (ctx, next) => {
     return requireRole(['api-access', 'contacts:read'])(ctx, next)
   }
 
+  if (ctx.path.startsWith('/invoice-channels')) {
+    return requireRole(['invoice-channels:read', 'api-access'])(ctx, next)
+  }
+
   return requireRole('api-access')(ctx, next)
 })
 


### PR DESCRIPTION
Adds a required role for Tenfast access to /invoice-channels endpoint.