### PR TITLE
fix(communication): send inspection protocol emails via Infobip SDK

### DIFF
--- a/services/communication/src/services/infobip-service/adapters/email-adapter.ts
+++ b/services/communication/src/services/infobip-service/adapters/email-adapter.ts
@@ -8,7 +8,6 @@ import {
   WorkOrderEmail,
   ParkingSpaceAcceptOfferEmail,
   BulkEmail,
-  InspectionProtocolEmail,
   NonScoredParkingSpaceApprovedEmail,
   NonScoredParkingSpaceDeniedEmail,
 } from '@onecore/types'
@@ -22,7 +21,6 @@ const ReplaceParkingSpaceOfferTemplateId = 200000000094058
 const ParkingSpaceAssignedToOtherTemplateId = 200000000092051
 const WorkOrderEmailTemplateId = 200000000146435
 const WorkOrderExternalContractorEmailTemplateId = 200000000173744
-const InspectionProtocolEmailTemplateId = 205000000035322
 const NonScoredParkingSpaceApprovedTemplateId = 205000000040764
 const NonScoredParkingSpaceDeniedTemplateId = 205000000040765
 
@@ -344,66 +342,6 @@ export const sendBulkEmail = async (email: BulkEmail) => {
     return { data: response }
   } catch (error) {
     logger.error(error, 'Error sending bulk email')
-    throw error
-  }
-}
-
-export const sendInspectionProtocolEmail = async (
-  email: InspectionProtocolEmail
-) => {
-  logger.info(
-    { baseUrl: config.infobip.baseUrl },
-    'Sending inspection protocol email'
-  )
-
-  try {
-    const baseUrl = config.infobip.baseUrl.replace(/\/$/, '')
-    const url = `${baseUrl}/email/4/messages`
-    const apiKey = config.infobip.apiKey
-
-    const placeholders = JSON.stringify({ firstName: email.firstName })
-    const messages = JSON.stringify([
-      {
-        sender: EMAIL_SENDER,
-        destinations: [
-          {
-            to: [{ destination: email.to, placeholders }],
-          },
-        ],
-        content: { templateId: InspectionProtocolEmailTemplateId },
-      },
-    ])
-
-    const formData = new FormData()
-    formData.append('messages', messages)
-
-    if (email.attachments && email.attachments.length > 0) {
-      for (const att of email.attachments) {
-        const buffer = Buffer.from(att.content, 'base64')
-        const blob = new Blob([buffer], { type: att.contentType })
-        formData.append('attachment', blob, att.filename)
-      }
-    }
-
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: `App ${apiKey}`,
-      },
-      body: formData,
-    })
-
-    if (!response.ok) {
-      const errorBody = await response.text()
-      throw new Error(
-        `Infobip Email API error: ${response.status} - ${errorBody}`
-      )
-    }
-
-    const data = await response.json()
-    return { data }
-  } catch (error) {
-    logger.error(error)
     throw error
   }
 }

--- a/services/communication/src/services/infobip-service/adapters/infobip-adapter.ts
+++ b/services/communication/src/services/infobip-service/adapters/infobip-adapter.ts
@@ -1,6 +1,10 @@
 import { Infobip, AuthType } from '@infobip-api/sdk'
+import { InspectionProtocolEmail } from '@onecore/types'
 import config from '../../../common/config'
 import { logger } from '@onecore/utilities'
+
+const EMAIL_SENDER = 'Bostads Mimer AB <noreply@mimer.nu>'
+const InspectionProtocolEmailTemplateId = 205000000035322
 
 const infobip = new Infobip({
   baseUrl: config.infobip.baseUrl,
@@ -25,7 +29,7 @@ export const sendEmailInfobipSdk = async (
   for (const to of recipients) {
     const infobipOptions = {
       to,
-      from: 'Bostads Mimer AB <noreply@mimer.nu>',
+      from: EMAIL_SENDER,
       subject: subject,
       text: body,
       attachment: attachments,
@@ -44,4 +48,39 @@ export const sendEmailInfobipSdk = async (
   }
 
   return result
+}
+
+export const sendInspectionProtocolEmail = async (
+  email: InspectionProtocolEmail
+) => {
+  logger.info(
+    { to: email.to, subject: email.subject },
+    'Sending inspection protocol email'
+  )
+
+  const attachment = email.attachments?.map((att) => ({
+    data: Buffer.from(att.content, 'base64'),
+    name: att.filename,
+  }))
+
+  const response = await infobip.channels.email.send({
+    to: email.to,
+    from: EMAIL_SENDER,
+    templateId: InspectionProtocolEmailTemplateId,
+    defaultPlaceholders: JSON.stringify({ firstName: email.firstName }),
+    attachment,
+  })
+
+  if (response.status !== 200) {
+    logger.error(
+      { status: response.status, body: response.body, to: email.to },
+      'Error sending inspection protocol email'
+    )
+    throw new Error(
+      `Infobip Email API error: ${response.status} - ${JSON.stringify(response.body)}`
+    )
+  }
+
+  logger.info({ to: email.to }, 'Sending inspection protocol email complete')
+  return { data: response.data ?? response.body }
 }

--- a/services/communication/src/services/infobip-service/index.ts
+++ b/services/communication/src/services/infobip-service/index.ts
@@ -8,7 +8,6 @@ import {
   sendParkingSpaceAssignedToOther,
   sendWorkOrderEmail,
   sendParkingSpaceAcceptOffer,
-  sendInspectionProtocolEmail,
   sendBulkEmail,
   sendNonScoredParkingSpaceApproved,
   sendNonScoredParkingSpaceDenied,
@@ -35,7 +34,10 @@ import {
 import { generateRouteMetadata, logger } from '@onecore/utilities'
 import { parseRequestBody } from '../../middlewares/parse-request-body'
 import z from 'zod'
-import { sendEmailInfobipSdk } from './adapters/infobip-adapter'
+import {
+  sendEmailInfobipSdk,
+  sendInspectionProtocolEmail,
+} from './adapters/infobip-adapter'
 
 /**
  * Extract Swedish phone number from text that may contain names/labels


### PR DESCRIPTION
## Summary
- Inspection protocol emails were failing in production with Infobip `HTTP 415 — multipart Content-Type with charset=UTF-8 not supported`. Root cause: Node's native `fetch` + `FormData` auto-appends `charset=UTF-8` to the multipart Content-Type, which Infobip rejects.
- Moved `sendInspectionProtocolEmail` from `email-adapter.ts` (hand-rolled `fetch`) to `infobip-adapter.ts` (uses `@infobip-api/sdk`, the same SDK already in use for `sendEmailInfobipSdk`). The SDK uses the `form-data` package internally and produces a Content-Type Infobip accepts.

## Test plan
- [x] `pnpm run typecheck` (clean)
- [x] `pnpm jest` in `services/communication` (33/33 pass)
- [x] Local POST to `http://localhost:5040/sendInspectionProtocolEmail` → 204, email delivered to test inbox
