### PR TITLE
bug: maintenance requests for residence etc are shown under maintenance units in property-tree (incorrectly created maintenance requests)

### DIFF
--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -273,9 +273,16 @@ export const createWorkOrder = async (
     const newLeaseRecord = await createLeaseRecord(lease)
     const newTenantRecord = await createTenantRecord(tenant, details)
 
-    const newMaintenanceUnitRecord = rentalPropertyInfo.maintenanceUnits
+    const rowMaintenanceUnitCode = details.Rows[0].MaintenanceUnitCode
+    const targetMaintenanceUnit = rowMaintenanceUnitCode
+      ? rentalPropertyInfo.maintenanceUnits?.find(
+          (mu) => mu.code === rowMaintenanceUnitCode
+        )
+      : undefined
+
+    const newMaintenanceUnitRecord = targetMaintenanceUnit
       ? await createMaintenanceUnitRecord(
-          rentalPropertyInfo.maintenanceUnits[0],
+          targetMaintenanceUnit,
           details.Rows[0]
         )
       : undefined

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -45,6 +45,7 @@ const WORK_ORDER_FIELDS: string[] = [
   'space_code',
   'equipment_code',
   'estate_code',
+  'property_code', // Mirrors `estate_code` for property-level maintenance requests; both fields hold the same value
   'building_code',
   'rental_property_id',
   'create_date',
@@ -95,7 +96,11 @@ export const getWorkOrdersByResidenceId = async (
 
     const odooWorkOrders = await odoo.searchRead<OdooWorkOrder>(
       'maintenance.request',
-      ['rental_property_id', '=', residenceId],
+      [
+        ['rental_property_id', '=', residenceId],
+        ['building_code', '=', false],
+        ['maintenance_unit_code', '=', false],
+      ],
       WORK_ORDER_FIELDS
     )
 
@@ -162,7 +167,12 @@ export const getWorkOrdersByPropertyId = async (
 
     const odooWorkOrders = await odoo.searchRead<OdooWorkOrder>(
       'maintenance.request',
-      ['estate_code', '=', propertyId],
+      [
+        ['property_code', '=', propertyId],
+        ['rental_property_id', '=', false],
+        ['building_code', '=', false],
+        ['maintenance_unit_code', '=', false],
+      ],
       WORK_ORDER_FIELDS
     )
 
@@ -197,7 +207,12 @@ export const getWorkOrdersByBuildingId = async (
 
     const odooWorkOrders = await odoo.searchRead<OdooWorkOrder>(
       'maintenance.request',
-      ['building_code', '=', buildingId],
+      [
+        ['building_code', '=', buildingId],
+        ['rental_property_id', '=', false],
+        ['maintenance_unit_code', '=', false],
+      ],
+
       WORK_ORDER_FIELDS
     )
 

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -2,6 +2,7 @@ import Odoo from 'odoo-await'
 import striptags from 'striptags'
 import { groupBy } from 'lodash'
 import z from 'zod'
+import { logger } from '@onecore/utilities'
 import Config from '../../../../common/config'
 import {
   transformWorkOrder,
@@ -274,15 +275,27 @@ export const createWorkOrder = async (
     const newTenantRecord = await createTenantRecord(tenant, details)
 
     const rowMaintenanceUnitCode = details.Rows[0].MaintenanceUnitCode
-    const targetMaintenanceUnit = rowMaintenanceUnitCode
+    const selectedMaintenanceUnit = rowMaintenanceUnitCode
       ? rentalPropertyInfo.maintenanceUnits?.find(
           (mu) => mu.code === rowMaintenanceUnitCode
         )
       : undefined
 
-    const newMaintenanceUnitRecord = targetMaintenanceUnit
+    if (rowMaintenanceUnitCode && !selectedMaintenanceUnit) {
+      logger.warn(
+        {
+          rowMaintenanceUnitCode,
+          rentalPropertyId: rentalPropertyInfo.id,
+          availableMaintenanceUnitCodes:
+            rentalPropertyInfo.maintenanceUnits?.map((mu) => mu.code) ?? [],
+        },
+        'createWorkOrder: maintenance unit code provided but not found on rental property'
+      )
+    }
+
+    const newMaintenanceUnitRecord = selectedMaintenanceUnit
       ? await createMaintenanceUnitRecord(
-          targetMaintenanceUnit,
+          selectedMaintenanceUnit,
           details.Rows[0]
         )
       : undefined

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -121,9 +121,9 @@ export const getWorkOrdersByResidenceId = async (
     }))
 
     return workOrders
-  } catch (error) {
-    console.error('Error fetching work orders:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrdersByResidenceId')
+    throw err
   }
 }
 
@@ -153,9 +153,9 @@ export const getWorkOrdersByContactCode = async (
     }))
 
     return workOrders
-  } catch (error) {
-    console.error('Error fetching work orders:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrdersByContactCode')
+    throw err
   }
 }
 
@@ -193,9 +193,9 @@ export const getWorkOrdersByPropertyId = async (
     }))
 
     return workOrders
-  } catch (error) {
-    console.error('Error fetching work orders:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrdersByPropertyId')
+    throw err
   }
 }
 
@@ -233,9 +233,9 @@ export const getWorkOrdersByBuildingId = async (
     }))
 
     return workOrders
-  } catch (error) {
-    console.error('Error fetching work orders:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrdersByBuildingId')
+    throw err
   }
 }
 
@@ -268,9 +268,9 @@ export const getWorkOrdersByMaintenanceUnitCode = async (
     }))
 
     return workOrders
-  } catch (error) {
-    console.error('Error fetching work orders:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrdersByMaintenanceUnitCode')
+    throw err
   }
 }
 
@@ -325,9 +325,9 @@ export const createWorkOrder = async (
     )
 
     return { ok: true, data: newWorkOrderId }
-  } catch (error) {
-    console.error('Error creating work order:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createWorkOrder')
+    throw err
   }
 }
 
@@ -351,9 +351,9 @@ const createRentalPropertyRecord = async (
       building_code: apartmentProperty.buildingCode,
       building: apartmentProperty.building,
     })
-  } catch (error) {
-    console.error('Error creating rental property record:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createRentalPropertyRecord')
+    throw err
   }
 }
 
@@ -369,9 +369,9 @@ const createLeaseRecord = async (lease: Lease): Promise<number> => {
       contract_date: lease.contractDate || false,
       approval_date: lease.approvalDate || false,
     })
-  } catch (error) {
-    console.error('Error creating lease record:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createLeaseRecord')
+    throw err
   }
 }
 
@@ -397,9 +397,9 @@ const createTenantRecord = async (
         (tenant.phoneNumbers ? tenant.phoneNumbers[0].phoneNumber : ''),
       is_tenant: true,
     })
-  } catch (error) {
-    console.error('Error creating tenant record:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createTenantRecord')
+    throw err
   }
 }
 
@@ -417,9 +417,9 @@ const createMaintenanceUnitRecord = async (
       type: maintenanceUnit.type,
       code: code || maintenanceUnit.code,
     })
-  } catch (error) {
-    console.error('Error creating maintenance unit record:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createMaintenanceUnitRecord')
+    throw err
   }
 }
 
@@ -516,9 +516,9 @@ const createWorkOrderRecord = async (
       ),
       creation_origin: 'mimer-nu',
     })
-  } catch (error) {
-    console.error('Error creating work order record:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.createWorkOrderRecord')
+    throw err
   }
 }
 
@@ -533,9 +533,9 @@ const getMaintenanceTeamId = async (teamName: string): Promise<number> => {
     }
 
     return team[0]
-  } catch (error) {
-    console.error('Error getting maintenance team id:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getMaintenanceTeamId')
+    throw err
   }
 }
 
@@ -563,9 +563,9 @@ const getMaintenanceRequestCategoryId = async (
       })
       return categories[0]
     }
-  } catch (error) {
-    console.error('Error getting maintenance request category id:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getMaintenanceRequestCategoryId')
+    throw err
   }
 }
 
@@ -591,9 +591,9 @@ export const closeWorkOrder = async (workOrderId: number): Promise<boolean> => {
     return await odoo.update('maintenance.request', workOrderId, {
       stage_id: doneMaintenanceStages[0].id,
     })
-  } catch (error) {
-    console.error('Error closing work order:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.closeWorkOrder')
+    throw err
   }
 }
 
@@ -612,9 +612,9 @@ export const addMessageToWorkOrder = async (
         body_is_html: true,
       },
     ])
-  } catch (error) {
-    console.error('Error adding message to work order:', error)
-    throw error
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.addMessageToWorkOrder')
+    throw err
   }
 }
 

--- a/services/work-order/src/services/work-order-service/tests/adapters/odoo-adapter/index.test.ts
+++ b/services/work-order/src/services/work-order-service/tests/adapters/odoo-adapter/index.test.ts
@@ -1,0 +1,159 @@
+import * as factory from '../../factories'
+
+const odooMock = {
+  connect: jest.fn(),
+  create: jest.fn(),
+  search: jest.fn(),
+  searchRead: jest.fn(),
+  update: jest.fn(),
+}
+
+jest.mock('odoo-await', () => {
+  return jest.fn().mockImplementation(() => odooMock)
+})
+
+const loggerWarnMock = jest.fn()
+
+jest.mock('@onecore/utilities', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: (...args: unknown[]) => loggerWarnMock(...args),
+  },
+  generateRouteMetadata: jest.fn(() => ({})),
+}))
+
+import { createWorkOrder } from '../../../adapters/odoo-adapter'
+
+describe('odoo-adapter createWorkOrder', () => {
+  const setupCreateMocks = () => {
+    odooMock.create
+      .mockResolvedValueOnce(101) // rental property
+      .mockResolvedValueOnce(102) // lease
+      .mockResolvedValueOnce(103) // tenant
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    odooMock.connect.mockResolvedValue(undefined)
+    odooMock.search.mockImplementation(async (model: string) => {
+      if (model === 'maintenance.team') return [1]
+      if (model === 'maintenance.request.category') return [42]
+      return []
+    })
+  })
+
+  it('creates a maintenance unit record when MaintenanceUnitCode matches one on the rental property', async () => {
+    setupCreateMocks()
+    odooMock.create
+      .mockResolvedValueOnce(104) // maintenance unit
+      .mockResolvedValueOnce(999) // work order
+
+    const rentalProperty = factory.rentalProperty.build()
+    const details = factory.CreateWorkOrderDetails.build({
+      Rows: [
+        {
+          LocationCode: 'TV',
+          PartOfBuildingCode: 'TM',
+          Description: 'Trasig tvättmaskin',
+          MaintenanceUnitCode: '705T15',
+          MaintenanceUnitCaption: 'TVÄTTSTUGA Stentorpsgatan 7 C',
+        },
+      ],
+    })
+
+    const result = await createWorkOrder(
+      rentalProperty,
+      factory.tenant.build(),
+      factory.lease.build(),
+      details
+    )
+
+    expect(result).toEqual({ ok: true, data: 999 })
+
+    const maintenanceUnitCall = odooMock.create.mock.calls.find(
+      ([model]) => model === 'maintenance.maintenance.unit'
+    )
+    expect(maintenanceUnitCall).toBeDefined()
+    expect(maintenanceUnitCall?.[1]).toMatchObject({ code: '705T15' })
+
+    const requestCall = odooMock.create.mock.calls.find(
+      ([model]) => model === 'maintenance.request'
+    )
+    expect(requestCall?.[1]).toMatchObject({ maintenance_unit_id: '104' })
+
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('does not create a maintenance unit record when MaintenanceUnitCode is missing', async () => {
+    setupCreateMocks()
+    odooMock.create.mockResolvedValueOnce(999) // work order
+
+    const rentalProperty = factory.rentalProperty.build()
+    const details = factory.CreateWorkOrderDetails.build()
+
+    const result = await createWorkOrder(
+      rentalProperty,
+      factory.tenant.build(),
+      factory.lease.build(),
+      details
+    )
+
+    expect(result).toEqual({ ok: true, data: 999 })
+
+    const maintenanceUnitCall = odooMock.create.mock.calls.find(
+      ([model]) => model === 'maintenance.maintenance.unit'
+    )
+    expect(maintenanceUnitCall).toBeUndefined()
+
+    const requestCall = odooMock.create.mock.calls.find(
+      ([model]) => model === 'maintenance.request'
+    )
+    expect(requestCall?.[1]).toMatchObject({ maintenance_unit_id: false })
+
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('logs a warning and skips creating the maintenance unit when the code does not match any unit on the rental property', async () => {
+    setupCreateMocks()
+    odooMock.create.mockResolvedValueOnce(999) // work order
+
+    const rentalProperty = factory.rentalProperty.build()
+    const details = factory.CreateWorkOrderDetails.build({
+      Rows: [
+        {
+          LocationCode: 'TV',
+          PartOfBuildingCode: 'TM',
+          Description: 'Trasig tvättmaskin',
+          MaintenanceUnitCode: 'UNKNOWN-CODE',
+          MaintenanceUnitCaption: 'Okänd enhet',
+        },
+      ],
+    })
+
+    const result = await createWorkOrder(
+      rentalProperty,
+      factory.tenant.build(),
+      factory.lease.build(),
+      details
+    )
+
+    expect(result).toEqual({ ok: true, data: 999 })
+
+    const maintenanceUnitCall = odooMock.create.mock.calls.find(
+      ([model]) => model === 'maintenance.maintenance.unit'
+    )
+    expect(maintenanceUnitCall).toBeUndefined()
+
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+    const [context, message] = loggerWarnMock.mock.calls[0]
+    expect(context).toMatchObject({
+      rowMaintenanceUnitCode: 'UNKNOWN-CODE',
+      rentalPropertyId: rentalProperty.id,
+      availableMaintenanceUnitCodes: rentalProperty.maintenanceUnits?.map(
+        (mu) => mu.code
+      ),
+    })
+    expect(message).toMatch(/maintenance unit code provided but not found/i)
+  })
+})


### PR DESCRIPTION
When a tenant reported a problem through [Mimer.nu](http://mimer.nu/) (e.g. "my dishwasher is broken"), the system was incorrectly tagging that report as belonging to the building's laundry room, even though the report had nothing to do with the laundry room.

On most buildings, that first item happens to be the laundry room.

The fix: only tag the report with a shared space if the tenant actually picked one, and use what they picked (not the arbitrary first-in-the-list).
