### PR TITLE
Feature/mim 1856 byt sms fran standard infobip till tele2 infobip i

### DIFF
--- a/apps/property-tree/src/entities/release-note/data/2026-06-05-v3.5.1.json
+++ b/apps/property-tree/src/entities/release-note/data/2026-06-05-v3.5.1.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "rn-2026-06-05-v351-1",
+    "date": "2026-06-05",
+    "title": "SMS skickas nu via Tele2",
+    "description": "Alla SMS som skickas från ONECore går nu via Tele2 i stället för Infobip, kopplat till kommunens avtal. Meddelandena ser likadana ut för mottagaren och avsändaren \"Mimer\" är oförändrad. E-post skickas fortsatt via egen instans av Infobip.",
+    "category": "improvement"
+  }
+]

--- a/services/communication/.env.template
+++ b/services/communication/.env.template
@@ -1,5 +1,8 @@
 INFOBIP__BASE_URL=
 INFOBIP__API_KEY=
+TELE2__BASE_URL=
+TELE2__API_KEY=
+
 APPLICATION_NAME=communication
 ELASTICSEARCH_LOGGING_HOST=http://localhost:9208
 LINEAR__URL=https://api.linear.app/graphql

--- a/services/communication/.env.test
+++ b/services/communication/.env.test
@@ -1,3 +1,5 @@
 INFOBIP__BASE_URL=test
 INFOBIP__API_KEY=test
+TELE2__BASE_URL=test
+TELE2__API_KEY=test
 APPLICATION_NAME=communication

--- a/services/communication/src/common/config.ts
+++ b/services/communication/src/common/config.ts
@@ -9,8 +9,16 @@ export interface Config {
     apiKey: string
     parkingSpaceOfferTempalteId: number
   }
+  tele2: {
+    baseUrl: string
+    apiKey: string
+  }
   health: {
     infobip: {
+      systemName: string
+      minimumMinutesBetweenRequests: number
+    }
+    tele2: {
       systemName: string
       minimumMinutesBetweenRequests: number
     }
@@ -36,9 +44,17 @@ const config = configPackage({
       baseUrl: '',
       apiKey: '',
     },
+    tele2: {
+      baseUrl: '',
+      apiKey: '',
+    },
     health: {
       infobip: {
         systemName: 'infobip',
+        minimumMinutesBetweenRequests: 5,
+      },
+      tele2: {
+        systemName: 'tele2',
         minimumMinutesBetweenRequests: 5,
       },
       linear: {
@@ -59,6 +75,7 @@ const config = configPackage({
 export default {
   port: config.get('port'),
   infobip: config.get('infobip'),
+  tele2: config.get('tele2'),
   health: config.get('health'),
   linear: config.get('linear'),
 } as Config

--- a/services/communication/src/services/health-service/index.ts
+++ b/services/communication/src/services/health-service/index.ts
@@ -1,6 +1,7 @@
 import KoaRouter from '@koa/router'
 import config from '../../common/config'
 import { healthCheck as infobipHealthCheck } from '../infobip-service/adapters/email-adapter'
+import { tele2SmsHealthCheck } from '../infobip-service/adapters/sms-adapter'
 import { linearHealthCheck } from '../linear-service/adapters/linear-adapter'
 import {
   HealthCheckTarget,
@@ -19,6 +20,16 @@ const subsystems: HealthCheckTarget[] = [
         healthChecks,
         config.health.infobip.minimumMinutesBetweenRequests,
         infobipHealthCheck
+      )
+    },
+  },
+  {
+    probe: async (): Promise<SystemHealth> => {
+      return await probe(
+        config.health.tele2.systemName,
+        healthChecks,
+        config.health.tele2.minimumMinutesBetweenRequests,
+        tele2SmsHealthCheck
       )
     },
   },

--- a/services/communication/src/services/infobip-service/adapters/sms-adapter.ts
+++ b/services/communication/src/services/infobip-service/adapters/sms-adapter.ts
@@ -9,14 +9,16 @@ import he from 'he'
 // SMS sender ID registered with Infobip
 const SMS_SENDER = 'Mimer'
 
-// Infobip v3 SMS API helper
+// SMS is sent via the Tele2 instance of the Infobip SMS platform.
+// Same /sms/3/messages contract as Infobip, but uses the separate
+// Tele2 procurement credentials (config.tele2). Email still uses config.infobip.
 const sendSmsV3 = async (
   destinations: { to: string }[],
   text: string
 ): Promise<unknown> => {
-  const baseUrl = config.infobip.baseUrl.replace(/\/$/, '') // Remove trailing slash
+  const baseUrl = config.tele2.baseUrl.replace(/\/$/, '') // Remove trailing slash
   const url = `${baseUrl}/sms/3/messages`
-  const apiKey = config.infobip.apiKey
+  const apiKey = config.tele2.apiKey
   logger.info({ url }, 'Sending SMS via v3 API')
   const response = await fetch(url, {
     method: 'POST',
@@ -56,7 +58,7 @@ export const sendParkingSpaceOfferSms = async (sms: ParkingSpaceOfferSms) => {
 }
 
 export const sendWorkOrderSms = async (sms: WorkOrderSms) => {
-  logger.info({ baseUrl: config.infobip.baseUrl }, 'Sending work order sms')
+  logger.info({ baseUrl: config.tele2.baseUrl }, 'Sending work order sms')
   const message = he.decode(striptags(sms.text.replace(/<br\s*\/?>/gi, '\n')))
   const noreply = sms.externalContractorName
     ? `Hälsningar, ${sms.externalContractorName} i uppdrag från Mimer`
@@ -77,7 +79,7 @@ export const sendBulkSms = async (sms: BulkSms) => {
   logger.info(
     {
       recipientCount: sms.phoneNumbers.length,
-      baseUrl: config.infobip.baseUrl,
+      baseUrl: config.tele2.baseUrl,
     },
     'Sending bulk SMS'
   )
@@ -95,5 +97,37 @@ export const sendBulkSms = async (sms: BulkSms) => {
   } catch (error) {
     logger.error(error, 'Error sending bulk SMS')
     throw error
+  }
+}
+
+// Verifies connectivity to the Tele2 (Infobip) SMS API used for sending SMS.
+export const tele2SmsHealthCheck = async () => {
+  const baseUrl = config.tele2.baseUrl.replace(/\/$/, '')
+  const url = `${baseUrl}/sms/3/messages`
+  const apiKey = config.tele2.apiKey
+
+  // Send a minimal invalid request to verify API connectivity
+  // We expect a 400 validation error, which proves the API is reachable
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `App ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ messages: [] }),
+  })
+
+  // If we get 401/403, there's an auth problem
+  if (response.status === 401 || response.status === 403) {
+    throw new Error(`Tele2 SMS authentication failed: ${response.status}`)
+  }
+
+  // If we get 400 (validation error), the API is reachable and working
+  // If we get 200 (shouldn't happen with empty messages), that's also fine
+  if (response.status !== 400 && response.status !== 200) {
+    const errorBody = await response.text()
+    throw new Error(
+      `Tele2 SMS health check failed: ${response.status} - ${errorBody}`
+    )
   }
 }


### PR DESCRIPTION
Tele2 procurement. Tele2 runs the same Infobip SMS platform (identical
/sms/3/messages contract and `App` auth), so only the base URL and API
key change — sender "Mimer" and request shape are unchanged. Email stays
on Infobip.

- Add tele2 + health.tele2 config (TELE2__BASE_URL / TELE2__API_KEY)
- Point sendSmsV3 and its logs at config.tele2
- Add tele2SmsHealthCheck and wire it into the health service
- Add TELE2 vars to .env.test


Added env variables to production in lens and in operations. 