### PR TITLE
Fix: includes landlord when creating tenants with sync-leases

### DIFF
--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -48,6 +48,7 @@ export const TenfastTenantSchema = z.object({
 export const TenfastRentalObjectSchema = z.object({
   _id: z.string(),
   externalId: z.string(),
+  hyresvard: z.string(),
   hyra: z.number().optional(), //total hyra inklusive moms
   hyraVat: z.number().optional(), // total moms pa hyran
   hyraExcludingVat: z.number().optional(), // hyran exklusive moms

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -103,14 +103,6 @@ export const createLease = async (
     | 'unknown'
   >
 > => {
-  const tenantResult = await getOrCreateTenant(
-    contact.contactCode,
-    buildTenantRequestData(contact)
-  )
-  if (!tenantResult.ok) return { ok: false, err: tenantResult.err }
-  else if (!tenantResult.data)
-    return { ok: false, err: 'could-not-retrieve-tenant' }
-
   const rentalObjectResponse = await getRentalObject(rentalObjectCode)
   if (!rentalObjectResponse.ok || !rentalObjectResponse.data)
     return { ok: false, err: 'could-not-find-rental-object' }
@@ -121,6 +113,17 @@ export const createLease = async (
     return { ok: false, err: 'rent-article-is-missing' }
   if (!rentalObjectResponse.data.contractTemplate)
     return { ok: false, err: 'rental-object-has-no-template' }
+
+  const rentalObjectHyresvard = rentalObjectResponse.data.hyresvard
+
+  const tenantResult = await getOrCreateTenant(
+    contact.contactCode,
+    buildTenantRequestData(contact),
+    rentalObjectHyresvard
+  )
+  if (!tenantResult.ok) return { ok: false, err: tenantResult.err }
+  else if (!tenantResult.data)
+    return { ok: false, err: 'could-not-retrieve-tenant' }
 
   const templateResponse = await getLeaseTemplate(
     rentalObjectResponse.data.contractTemplate
@@ -139,7 +142,7 @@ export const createLease = async (
 
     const leaseResponse = await tenfastApi.request({
       method: 'post',
-      url: `${tenfastBaseUrl}/v1/hyresvard/avtal?hyresvard=${tenfastCompanyId}`,
+      url: `${tenfastBaseUrl}/v1/hyresvard/avtal?hyresvard=${rentalObjectHyresvard}`,
       data: createLeaseRequestData,
     })
     if (leaseResponse.status === 400)
@@ -193,18 +196,20 @@ export const importLease = async (
       { leaseId, contactCode: contact.contactCode, rentalObjectCode },
       'tenfast-adapter.importLease: starting import'
     )
+    const rentalObjectResponse = await getRentalObject(rentalObjectCode)
+    if (!rentalObjectResponse.ok || !rentalObjectResponse.data)
+      return { ok: false, err: 'could-not-find-rental-object' }
+    const rentalObject = rentalObjectResponse.data
+
     const tenantResult = await getOrCreateTenant(
       contact.contactCode,
-      buildTenantRequestDataFromPayload(contact)
+      buildTenantRequestDataFromPayload(contact),
+      rentalObject.hyresvard
     )
     if (!tenantResult.ok) return { ok: false, err: tenantResult.err }
     if (!tenantResult.data)
       return { ok: false, err: 'could-not-retrieve-tenant' }
 
-    const rentalObjectResponse = await getRentalObject(rentalObjectCode)
-    if (!rentalObjectResponse.ok || !rentalObjectResponse.data)
-      return { ok: false, err: 'could-not-find-rental-object' }
-    const rentalObject = rentalObjectResponse.data
     const body = {
       // Pass the xpand leaseId as externalId so terminate/void can later look
       // up this lease via GET /extras/avtal/{externalId} (see
@@ -229,7 +234,7 @@ export const importLease = async (
 
     const response = await tenfastApi.request({
       method: 'post',
-      url: `${tenfastBaseUrl}/v1/hyresvard/avtal?hyresvard=${tenfastCompanyId}`,
+      url: `${tenfastBaseUrl}/v1/hyresvard/avtal?hyresvard=${rentalObject.hyresvard}`,
       data: body,
     })
 
@@ -680,7 +685,8 @@ export const getLeaseTemplate = async (
 }
 
 export const getTenantByContactCode = async (
-  contactCode: string
+  contactCode: string,
+  hyresvardId?: string
 ): Promise<
   AdapterResult<
     TenfastTenant | null,
@@ -718,9 +724,18 @@ export const getTenantByContactCode = async (
         'could-not-parse-tenant-response'
       )
     }
+    // Tenfast's /hyresgaster/search ignores the `hyresvard=` query param and
+    // returns every tenant the api-token can see. The same contactCode can
+    // legitimately exist under several hyresvärdar (one tenant record per
+    // landlord), so filter client-side when a hyresvärd was specified.
+    const records = hyresvardId
+      ? parsedTenantResponse.data.records.filter(
+          (r) => r.hyresvard === hyresvardId
+        )
+      : parsedTenantResponse.data.records
     return {
       ok: true,
-      data: parsedTenantResponse.data.records[0] ?? null,
+      data: records[0] ?? null,
     }
   } catch (err: any) {
     return handleTenfastError(err, 'unknown')
@@ -728,7 +743,8 @@ export const getTenantByContactCode = async (
 }
 
 const createTenantRequest = async (
-  requestData: object
+  requestData: object,
+  hyresvardId?: string
 ): Promise<
   AdapterResult<
     TenfastTenant | undefined,
@@ -739,7 +755,7 @@ const createTenantRequest = async (
 > => {
   const tenantResponse = await tenfastApi.request({
     method: 'post',
-    url: `${tenfastBaseUrl}/v1/hyresvard/hyresgaster?hyresvard=${tenfastCompanyId}`,
+    url: `${tenfastBaseUrl}/v1/hyresvard/hyresgaster?hyresvard=${hyresvardId ?? tenfastCompanyId}`,
     data: requestData,
   })
 
@@ -774,19 +790,23 @@ export const createTenant = (contact: Contact) =>
 
 async function getOrCreateTenant(
   contactCode: string,
-  requestData: object
+  requestData: object,
+  hyresvardId?: string
 ): Promise<
   AdapterResult<
     TenfastTenant,
     'could-not-retrieve-tenant' | 'could-not-create-tenant'
   >
 > {
-  const tenantResponse = await getTenantByContactCode(contactCode)
+  const tenantResponse = await getTenantByContactCode(contactCode, hyresvardId)
   if (!tenantResponse.ok) {
     return { ok: false, err: 'could-not-retrieve-tenant' }
   }
   if (!tenantResponse.data) {
-    const createTenantResult = await createTenantRequest(requestData)
+    const createTenantResult = await createTenantRequest(
+      requestData,
+      hyresvardId
+    )
     if (!createTenantResult.ok || !createTenantResult.data) {
       return { ok: false, err: 'could-not-create-tenant' }
     }

--- a/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/tenfast/tenfast-adapter.test.ts
@@ -356,6 +356,40 @@ describe(tenfastAdapter.getTenantByContactCode, () => {
       err: 'unknown',
     })
   })
+
+  it('filters records by hyresvardId when one is given', async () => {
+    // Tenfast's /hyresgaster/search ignores `hyresvard=` and returns every
+    // matching tenant across landlords; the same contactCode can legitimately
+    // exist under multiple hyresvärdar.
+    const tenantA = factory.tenfastTenant.build({ hyresvard: 'landlord-A' })
+    const tenantB = factory.tenfastTenant.build({ hyresvard: 'landlord-B' })
+    ;(request as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { records: [tenantA, tenantB] },
+    })
+
+    const result = await tenfastAdapter.getTenantByContactCode(
+      'TENANT_CODE',
+      'landlord-B'
+    )
+
+    expect(result).toEqual({ ok: true, data: tenantB })
+  })
+
+  it('returns null when no record matches the given hyresvardId', async () => {
+    const tenantA = factory.tenfastTenant.build({ hyresvard: 'landlord-A' })
+    ;(request as jest.Mock).mockResolvedValue({
+      status: 200,
+      data: { records: [tenantA] },
+    })
+
+    const result = await tenfastAdapter.getTenantByContactCode(
+      'TENANT_CODE',
+      'landlord-B'
+    )
+
+    expect(result).toEqual({ ok: true, data: null })
+  })
 })
 
 describe(tenfastAdapter.getAvailabilityForVacantRentalObjects, () => {
@@ -799,6 +833,12 @@ describe(tenfastAdapter.createLease, () => {
       data: mockTemplate,
     })
 
+    const mockRentalObject = factory.tenfastRentalObject.build()
+    jest.spyOn(tenfastAdapter, 'getRentalObject').mockResolvedValue({
+      ok: true,
+      data: mockRentalObject,
+    })
+
     jest.spyOn(tenfastAdapter, 'getTenantByContactCode').mockResolvedValue({
       ok: false,
       err: 'could-not-retrieve-tenant',
@@ -1083,6 +1123,12 @@ describe(tenfastAdapter.importLease, () => {
   })
 
   it('returns "could-not-retrieve-tenant" when getOrCreateTenant fails', async () => {
+    const mockRentalObject = factory.tenfastRentalObject.build()
+    jest.spyOn(tenfastAdapter, 'getRentalObject').mockResolvedValue({
+      ok: true,
+      data: mockRentalObject,
+    })
+
     jest.spyOn(tenfastAdapter, 'getTenantByContactCode').mockResolvedValue({
       ok: false,
       err: 'unknown',
@@ -1175,6 +1221,47 @@ describe(tenfastAdapter.importLease, () => {
     )
 
     expect(result).toEqual({ ok: false, err: 'unknown' })
+  })
+
+  it('routes tenant lookup and lease POST to the rental object\'s hyresvärd', async () => {
+    const rentalObjectHyresvard = 'landlord-A'
+    const mockRentalObject = factory.tenfastRentalObject.build({
+      hyresvard: rentalObjectHyresvard,
+    })
+    jest.spyOn(tenfastAdapter, 'getRentalObject').mockResolvedValue({
+      ok: true,
+      data: mockRentalObject,
+    })
+
+    const mockTenant = factory.tenfastTenant.build({
+      hyresvard: rentalObjectHyresvard,
+    })
+    const tenantSpy = jest
+      .spyOn(tenfastAdapter, 'getTenantByContactCode')
+      .mockResolvedValue({ ok: true, data: mockTenant })
+    ;(request as jest.Mock).mockResolvedValue({
+      status: 201,
+      data: { _id: 'lease-id' },
+    })
+
+    const payload = factory.syncTenantPayload.build()
+    const result = await tenfastAdapter.importLease(
+      leaseId,
+      payload,
+      rentalObjectCode,
+      fromDate
+    )
+
+    expect(result).toEqual({ ok: true, data: { _id: 'lease-id' } })
+    expect(tenantSpy).toHaveBeenCalledWith(
+      payload.contactCode,
+      rentalObjectHyresvard
+    )
+
+    const postCall = (request as jest.Mock).mock.calls.find(
+      ([req]) => req.method === 'post'
+    )?.[0]
+    expect(postCall.url).toContain(`hyresvard=${rentalObjectHyresvard}`)
   })
 })
 

--- a/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
+++ b/services/leasing/src/services/lease-service/tests/factories/tenfast-rental-object.ts
@@ -12,6 +12,7 @@ export const TenfastRentalObjectByRentalObjectCodeResponseFactory =
       records: [
         {
           _id: '67eb8af5545c8f1195bef2e6' + sequence,
+          hyresvard: '6344b398b63ff59d5bde8257',
           hyra: 287.17,
           hyraVat: 0, // total moms pa hyran
           hyraExcludingVat: 287.17, // hyran exklusive moms
@@ -32,6 +33,7 @@ export const TenfastRentalObjectByRentalObjectCodeResponseFactory =
 export const TenfastRentalObjectFactory = Factory.define<TenfastRentalObject>(
   ({ sequence }) => ({
     _id: `rental-object-${sequence}`,
+    hyresvard: '6344b398b63ff59d5bde8257',
     hyra: 287.17,
     hyraVat: 0,
     hyraExcludingVat: 287.17,


### PR DESCRIPTION
I Tenfast finns flera hyresvärdar i samma miljö, och varje hyresgäst hör till en specifik hyresvärd. När en hyresgäst tecknar avtal för ett hyresobjekt måste hyresgästen hamna under samma hyresvärd som hyresobjektet. Sync-leases använder config.tenfast.companyId både när hyresgästen slås upp och när avtalet POST:as. 

Fixen: hämta hyresobjektet först, läs dess hyresvard, och använd det vid både hyresgäst-uppslag/skapande och avtals-POST. 