### PR TITLE
MIM-1861: Create Odoo work orders from inspection

### DIFF
--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -3,9 +3,8 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/auth/generatehash": {
+  '/auth/generatehash': {
     /**
      * Generates a salt and hashes the given password using that salt.
      * @description Generates a salt and hashes the given password using that salt. Pass cleartext password as query parameter.
@@ -14,18 +13,18 @@ export interface paths {
       parameters: {
         query: {
           /** @description The cleartext password that should be hashed */
-          password: string;
-        };
-      };
+          password: string
+        }
+      }
       responses: {
         /** @description Hashed password and salt */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/generatetoken": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/generatetoken': {
     /**
      * Generates a JWT token
      * @description Validates username and password from request body and returns a JWT token.
@@ -33,41 +32,41 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/x-www-form-urlencoded": {
-            username?: string;
-            password?: string;
-          };
-        };
-      };
+          'application/x-www-form-urlencoded': {
+            username?: string
+            password?: string
+          }
+        }
+      }
       responses: {
         /** @description A valid JWT token */
         200: {
           content: {
-            "application/json": {
-              token?: string;
-            };
-          };
-        };
+            'application/json': {
+              token?: string
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
-              errorMessage?: string;
-            };
-          };
-        };
+            'application/json': {
+              errorMessage?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/auth/login": {
+            'application/json': {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/auth/login': {
     /**
      * Redirects to Keycloak login
      * @description Redirects the user to the Keycloak login page
@@ -76,12 +75,12 @@ export interface paths {
       responses: {
         /** @description Redirect to Keycloak login */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/callback": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/callback': {
     /**
      * OAuth callback endpoint
      * @description Handles the OAuth callback from Keycloak
@@ -89,21 +88,21 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            code?: string;
-            redirectUri?: string;
-          };
-        };
-      };
+          'application/json': {
+            code?: string
+            redirectUri?: string
+          }
+        }
+      }
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/logout": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/logout': {
     /**
      * Logout endpoint
      * @description Clears authentication cookies and redirects to Keycloak logout
@@ -112,12 +111,12 @@ export interface paths {
       responses: {
         /** @description Redirect to login page */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/profile": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/profile': {
     /**
      * Get user profile
      * @description Returns the authenticated user's profile information
@@ -126,16 +125,16 @@ export interface paths {
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/refresh": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/refresh': {
     /**
      * Refresh access token
      * @description Uses refresh_token cookie to get new access_token
@@ -144,16 +143,16 @@ export interface paths {
       responses: {
         /** @description Token refreshed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid or expired refresh token */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/roles/{roleName}/users": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/roles/{roleName}/users': {
     /**
      * Get users by realm role (via group membership)
      * @description Returns all users that belong to groups assigned the given Keycloak realm role. Users are deduplicated across groups.
@@ -162,46 +161,44 @@ export interface paths {
       parameters: {
         path: {
           /** @description The name of the Keycloak realm role */
-          roleName: string;
-        };
-      };
+          roleName: string
+        }
+      }
       responses: {
         /** @description List of users with the given role */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeycloakUser"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeycloakUser'][]
+            }
+          }
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Forbidden — insufficient permissions to query role members */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Role not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Keycloak unreachable */
         502: {
-          content: never;
-        };
-      };
-    };
-  };
-  "openapi": {
-  };
-  "security": {
-  };
-  "/sendBulkSms": {
+          content: never
+        }
+      }
+    }
+  }
+  openapi: {}
+  security: {}
+  '/sendBulkSms': {
     /**
      * Send SMS to multiple contacts
      * @description Send SMS messages to multiple phone numbers
@@ -209,35 +206,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of phone numbers */
-            phoneNumbers: string[];
+            phoneNumbers: string[]
             /** @description SMS message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description SMS sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkSmsResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkSmsResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/sendBulkEmail": {
+          content: never
+        }
+      }
+    }
+  }
+  '/sendBulkEmail': {
     /**
      * Send email to multiple contacts
      * @description Send email messages to multiple email addresses
@@ -245,37 +242,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of email addresses */
-            emails: string[];
+            emails: string[]
             /** @description Email subject */
-            subject: string;
+            subject: string
             /** @description Email message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description Email sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkEmailResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkEmailResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearTickets": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearTickets': {
     /**
      * Get Linear tickets with mimer-visible label
      * @description Fetch Linear issues that have the mimer-visible label
@@ -284,24 +281,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of tickets to fetch */
-          first?: number;
+          first?: number
           /** @description Cursor for pagination */
-          after?: string;
-        };
-      };
+          after?: string
+        }
+      }
       responses: {
         /** @description Linear tickets fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/createLinearErrand": {
+          content: never
+        }
+      }
+    }
+  }
+  '/createLinearErrand': {
     /**
      * Create a new Linear errand
      * @description Create a new issue in Linear with specified team, project, and labels
@@ -309,33 +306,33 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Errand title */
-            title: string;
+            title: string
             /** @description Errand description */
-            description: string;
+            description: string
             /** @description Label ID for category (Bug, Improvement, etc.) */
-            categoryLabelId: string;
-          };
-        };
-      };
+            categoryLabelId: string
+          }
+        }
+      }
       responses: {
         /** @description Linear errand created successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearLabels": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearLabels': {
     /**
      * Get Linear category labels
      * @description Fetch available category labels (Bug, Improvement, new feature)
@@ -344,16 +341,16 @@ export interface paths {
       responses: {
         /** @description Linear labels fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/health": {
+          content: never
+        }
+      }
+    }
+  }
+  '/health': {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -363,35 +360,35 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /**
                * @description Name of the system.
                * @example core
                */
-              name?: string;
+              name?: string
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string;
-              subsystems?: ({
-                  /** @description Name of the subsystem. */
-                  name?: string;
-                  /**
-                   * @description Status of the subsystem.
-                   * @enum {string}
-                   */
-                  status?: "active" | "impaired" | "failure" | "unknown";
-                  /** @description Additional details about the subsystem status. */
-                  details?: string;
-                })[];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/search": {
+              status?: string
+              subsystems?: {
+                /** @description Name of the subsystem. */
+                name?: string
+                /**
+                 * @description Status of the subsystem.
+                 * @enum {string}
+                 */
+                status?: 'active' | 'impaired' | 'failure' | 'unknown'
+                /** @description Additional details about the subsystem status. */
+                details?: string
+              }[]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/search': {
     /**
      * Search and filter leases
      * @description Search leases with comprehensive filtering options including text search, object type, status, date ranges, and property hierarchy filters.
@@ -400,64 +397,70 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking)) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
+          buildingManager?: string[]
           /** @description Page number */
-          page?: number;
+          page?: number
           /** @description Items per page */
-          limit?: number;
+          limit?: number
           /** @description Include Upphört (ended) contracts. Excluded by default for performance. */
-          includeEnded?: boolean;
+          includeEnded?: boolean
           /** @description Sort field */
-          sortBy?: "leaseStartDate" | "lastDebitDate" | "leaseId" | "address" | "objectType" | "rentalObjectCode";
+          sortBy?:
+            | 'leaseStartDate'
+            | 'lastDebitDate'
+            | 'leaseId'
+            | 'address'
+            | 'objectType'
+            | 'rentalObjectCode'
           /** @description Sort direction */
-          sortOrder?: "asc" | "desc";
-        };
-      };
+          sortOrder?: 'asc' | 'desc'
+        }
+      }
       responses: {
         /** @description Successfully retrieved lease search results with pagination */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["LeaseSearchResult"][];
-              _meta?: components["schemas"]["PaginationMeta"];
-              _links?: components["schemas"]["PaginationLinks"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['LeaseSearchResult'][]
+              _meta?: components['schemas']['PaginationMeta']
+              _links?: components['schemas']['PaginationLinks'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/building-managers": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/building-managers': {
     /**
      * Get all building managers
      * @description Returns a list of all building managers (Kvartersvärd) with their code, name and district.
@@ -467,23 +470,23 @@ export interface paths {
         /** @description List of building managers */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  name?: string;
-                  district?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                name?: string
+                district?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/parking-space-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/parking-space-types': {
     /**
      * Get all parking space types
      * @description Returns a list of all parking space types (P-platstyper).
@@ -493,22 +496,22 @@ export interface paths {
         /** @description List of parking space types */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/export": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/export': {
     /**
      * Export leases to Excel
      * @description Export lease search results to Excel file. Uses same filters as /leases/search but without pagination.
@@ -517,44 +520,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/from-lease-search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/from-lease-search': {
     /**
      * Get contacts matching lease search filters
      * @description Retrieves contact information for tenants matching the given lease search filters.
@@ -563,48 +566,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ContactInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ContactInfo'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/by-rental-property-id/{rentalPropertyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get leases with related entities for a specific rental property id
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified rental property id.
@@ -613,38 +616,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
+          includeTerminatedLeases?: boolean
           /** @description Whether to include contact information in the response */
-          includeContacts?: boolean;
+          includeContacts?: boolean
           /** @description Whether to include rent information in the response */
-          includeRentInfo?: boolean;
-        };
+          includeRentInfo?: boolean
+        }
         path: {
           /** @description Rental roperty id of the building/residence to fetch leases for. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-pnr/{pnr}': {
     /**
      * Get leases with related entities for a specific Personal Number (PNR)
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
@@ -653,28 +656,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Personal Number (PNR) of the individual to fetch leases for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-contact-code/{contactCode}': {
     /**
      * Get leases with related entities for a specific contact code
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified contact code.
@@ -683,28 +686,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Contact code of the individual to fetch leases for. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/consumer-reports/by-pnr/{pnr}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/consumer-reports/by-pnr/{pnr}': {
     /**
      * Get consumer report for a specific Personal Number (PNR)
      * @description Retrieves credit information and consumer report for the specified Personal Number (PNR).
@@ -713,20 +716,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch credit information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with credit information and consumer report */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/by-pnr/{pnr}': {
     /**
      * Get contact information for a specific Personal Number (PNR)
      * @description Retrieves contact information associated with the specified Personal Number (PNR).
@@ -735,20 +738,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch contact information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/offers": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/offers': {
     /**
      * Get offers for a contact
      * @description Retrieves all offers associated with a specific contact based on the provided contact code.
@@ -757,28 +760,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique code identifying the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with a list of offers for the contact. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description The contact was not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve offers. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/comments": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/comments': {
     /**
      * Get comments for a contact
      * @description Retrieves all comments/notes for a contact from Xpand
@@ -787,57 +790,57 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by comment type. If omitted, returns all comment types. */
-          commentType?: "Standard" | "Sökande";
-        };
+          commentType?: 'Standard' | 'Sökande'
+        }
         path: {
           /**
            * @description The unique code identifying the contact.
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved comments */
         200: {
           content: {
-            "application/json": {
-              content?: ({
-                  contactKey?: string;
-                  contactCode?: string;
-                  commentKey?: string;
-                  id?: number;
-                  commentType?: string | null;
-                  /** @description Array of individual notes parsed from comment text */
-                  notes?: ({
-                      /**
-                       * Format: date
-                       * @description Date in YYYY-MM-DD format
-                       */
-                      date?: string | null;
-                      /** @description Time in HH:MM format */
-                      time?: string | null;
-                      /** @description Author initials (6 letters) or "Notering utan signatur" */
-                      author?: string;
-                      /** @description Note content (plain text) */
-                      text?: string;
-                    })[];
-                  priority?: number | null;
-                  kind?: number | null;
-                })[];
-            };
-          };
-        };
+            'application/json': {
+              content?: {
+                contactKey?: string
+                contactCode?: string
+                commentKey?: string
+                id?: number
+                commentType?: string | null
+                /** @description Array of individual notes parsed from comment text */
+                notes?: {
+                  /**
+                   * Format: date
+                   * @description Date in YYYY-MM-DD format
+                   */
+                  date?: string | null
+                  /** @description Time in HH:MM format */
+                  time?: string | null
+                  /** @description Author initials (6 letters) or "Notering utan signatur" */
+                  author?: string
+                  /** @description Note content (plain text) */
+                  text?: string
+                }[]
+                priority?: number | null
+                kind?: number | null
+              }[]
+            }
+          }
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Create or append to contact comment
      * @description Creates a new comment if none exists for the contact, or appends to existing comment in Xpand
@@ -849,56 +852,56 @@ export interface paths {
            * @description The unique code identifying the contact
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /**
              * @description Plain text content of the note
              * @example Customer contacted regarding lease renewal
              */
-            content: string;
+            content: string
             /**
              * @description Author name or code (1-50 characters)
              * @example DAVLIN
              */
-            author: string;
+            author: string
             /**
              * @description Type of comment. Defaults to 'Standard' if not specified.
              * @default Standard
              * @enum {string}
              */
-            commentType?: "Standard" | "Sökande";
-          };
-        };
-      };
+            commentType?: 'Standard' | 'Sökande'
+          }
+        }
+      }
       responses: {
         /** @description Comment updated successfully (appended to existing comment) */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Comment created successfully (new comment) */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body (validation failed) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/applicants/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/applicants/{contactCode}': {
     /**
      * Get a specific offer for an applicant
      * @description Retrieve details of a specific offer associated with an applicant using contact code and offer ID.
@@ -907,30 +910,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the offer. */
-          offerId: string;
+          offerId: string
           /** @description The unique code identifying the applicant. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Details of the specified offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Offer not found for the specified contact code and offer ID. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}': {
     /**
      * Get offers for a specific listing
      * @description Get all offers for a listing.
@@ -939,24 +942,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description A list of offers. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}/active": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}/active': {
     /**
      * Gets active offer for a specific listing
      * @description Get an offer for a listing.
@@ -965,24 +968,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description The active offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/search': {
     /**
      * Search contacts by name, PNR, contact code, or email
      * @description Search contacts by contact code, personal registration number, name, or email. Supports searching by full name or partial name (e.g., "john smith" or "smith"). Multiple search terms are matched with AND logic. Email search is triggered when query contains "@".
@@ -991,30 +994,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description Search query - can be contact code, personal registration number, name, or email (if query contains "@"). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successful response with search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Contact'][]
+            }
+          }
+        }
         /** @description Bad request. The query parameter 'q' must be a string. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve contacts. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/for-identity-check": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/for-identity-check': {
     /**
      * Get contacts for deceased/protected identity check
      * @description Returns paginated list of person contacts eligible for deceased/protected identity verification. Note - Results are validated using the personnummer package, so the actual count may be fewer than the requested limit if invalid personnummer are filtered out.
@@ -1023,38 +1026,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved contacts for identity check. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["IdentityCheckContact"][];
+            'application/json': {
+              content?: components['schemas']['IdentityCheckContact'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}': {
     /**
      * Get contact by contact code
      * @description Retrieves a contact based on the provided contact code.
@@ -1063,22 +1066,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/tenants/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Contact']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/tenants/by-contact-code/{contactCode}': {
     /**
      * Get tenant by contact code
      * @description Retrieves a tenant based on the provided contact code.
@@ -1087,31 +1090,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant information. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The tenant data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve Tenant information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/by-phone-number/{pnr}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/by-phone-number/{pnr}': {
     /**
      * Get contact by phone number
      * @description Retrieves a contact based on the provided phone number.
@@ -1120,20 +1123,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The phone number used to identify the contact. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/{id}': {
     /**
      * Get lease by ID
      * @description Retrieves lease details along with related entities based on the provided ID.
@@ -1142,22 +1145,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the lease to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested lease and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/accept": {
+            'application/json': {
+              content?: components['schemas']['Lease']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/accept': {
     /**
      * Accept an offer
      * @description Accepts an offer for the contact of the contactCode provided
@@ -1166,22 +1169,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to accept */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer accepted successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to accept the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/deny": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/deny': {
     /**
      * Deny an offer
      * @description Denies an offer
@@ -1190,22 +1193,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to deny */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer denied successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to deny the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/expire": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/expire': {
     /**
      * Expire an offer
      * @description Expires an offer
@@ -1214,22 +1217,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to expire */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer expired successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to expire the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/applicants": {
+          content: never
+        }
+      }
+    }
+  }
+  '/applicants': {
     /**
      * Get applicants by contact code
      * @description Retrieves applicants based on the contact code.
@@ -1238,20 +1241,20 @@ export interface paths {
       parameters: {
         query: {
           /** @description The contact code used to fetch applicants. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}': {
     /**
      * Validate property rental rules for applicant
      * @description Validate property rental rules for an applicant based on contact code and listing ID.
@@ -1260,61 +1263,61 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand rental object code of the property. */
-          rentalObjectCode: number;
-        };
-      };
+          rentalObjectCode: number
+        }
+      }
       responses: {
         /** @description No property rental rules apply to this property. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
+              applicationType?: string
               /** @example No property rental rules applies to this property. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Rental object code is not a parking space. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental object code entity is not a parking space. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the property based on property rental rules. */
         403: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description Listing, property info, or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating property rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating property rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}': {
     /**
      * Validate residential area rental rules for applicant
      * @description Validate residential area rental rules for an applicant based on contact code and district code.
@@ -1323,52 +1326,52 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand district code of the residential area to validate against. */
-          districtCode: string;
-        };
-      };
+          districtCode: string
+        }
+      }
       responses: {
         /** @description Either no residential area rental rules apply or applicant is eligible to apply for parking space. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
-              reason?: string;
-            };
-          };
-        };
+              applicationType?: string
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the listing based on residential area rental rules. */
         403: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant does not have any current or upcoming housing contracts in the residential area. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Listing or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating residential area rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating residential area rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants-with-listings/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants-with-listings/by-contact-code/{contactCode}': {
     /**
      * Get applicants with listings by contact code
      * @description Retrieves applicants along with their listings based on the contact code.
@@ -1377,20 +1380,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch applicants and their associated listings. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants with their listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{contactCode}/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{contactCode}/{listingId}': {
     /**
      * Get applicant by contact code and listing ID
      * @description Retrieves an applicant by their contact code and listing ID.
@@ -1399,22 +1402,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The ID of the listing associated with the applicant. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the applicant. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-manager": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-manager': {
     /**
      * Withdraw applicant by manager
      * @description Withdraws an applicant by the manager using the applicant ID.
@@ -1423,32 +1426,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
-        };
-      };
+          applicantId: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by manager. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by manager. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-user/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-user/{contactCode}': {
     /**
      * Withdraw applicant by user
      * @description Withdraws an applicant by the user identified by contact code and applicant ID.
@@ -1457,34 +1460,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
+          applicantId: string
           /** @description The contact code of the user initiating the withdrawal. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by user. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by user. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile': {
     /**
      * Gets an application profile by contact code
      * @description Retrieve application profile information by contact code.
@@ -1493,31 +1496,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/admin": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/admin': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1526,41 +1529,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/client": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/client': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1569,41 +1572,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/{rentalObjectCode}/verify-application": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/{rentalObjectCode}/verify-application': {
     /**
      * Validate max num residents.
      * @description Checks if application is allowed based on current number of residents.
@@ -1612,32 +1615,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
+          contactCode: string
           /** @description The rental object code associated with the rental property. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Application allowed. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Application not allowed. */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings': {
     /**
      * Get listings
      * @description Retrieves a list of listings.
@@ -1646,28 +1649,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The listing category, either PARKING_SPACE, APARTMENT or STORAGE. */
-          listingCategory?: string;
+          listingCategory?: string
           /** @description true for published listings, false for unpublished listings. */
-          published?: boolean;
+          published?: boolean
           /** @description The rental rule for the listings, either SCORED or NON_SCORED. */
-          rentalRule?: string;
+          rentalRule?: string
           /** @description A contact code to filter out listings that are not valid to rent for the contact. */
-          validToRentForContactCode?: string;
+          validToRentForContactCode?: string
           /** @description A Rental Object Code to filter the listings. */
-          rentalObjectCode?: string;
-        };
-      };
+          rentalObjectCode?: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested list of listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}': {
     /**
      * Delete a Listing by ID
      * @description Deletes a listing by it's ID.
@@ -1676,31 +1679,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description Successfully deleted listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Conflict. */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/status": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/status': {
     /**
      * Update a listings status by ID
      * @description Updates a listing status by it's ID.
@@ -1709,36 +1712,36 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/offers": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/offers': {
     /**
      * Create an offer for a listing
      * @description Creates an offer for the specified listing.
@@ -1747,22 +1750,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to create an offer for. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Offer creation successful. */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/applicants/details": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/applicants/details': {
     /**
      * Get listing by ID with detailed applicants
      * @description Retrieves a listing by ID along with detailed information about its applicants.
@@ -1771,20 +1774,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to fetch along with detailed applicant information. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the listing with detailed applicant information. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{id}': {
     /**
      * Get listing by ID
      * @description Retrieves details of a listing based on the provided ID.
@@ -1793,20 +1796,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested listing details. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings-with-applicants": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings-with-applicants': {
     /**
      * Get listings with applicants
      * @description Retrieves a list of listings along with their associated applicants.
@@ -1815,24 +1818,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filters listings by one of the above types. Must be one of the specified values. */
-          type?: "published" | "ready-for-offer" | "offered" | "historical";
-        };
-      };
+          type?: 'published' | 'ready-for-offer' | 'offered' | 'historical'
+        }
+      }
       responses: {
         /** @description Successful response with listings and their applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>[];
-          };
-        };
+            'application/json': Record<string, never>[]
+          }
+        }
         /** @description Internal server error. Failed to retrieve listings with applicants. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/batch": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/batch': {
     /**
      * Create multiple listings
      * @description Create multiple listings in a single request.
@@ -1840,48 +1843,54 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            listings: ({
-                rentalObjectCode: string;
-                /** Format: date-time */
-                publishedFrom: string;
-                /** Format: date-time */
-                publishedTo: string;
-                /** @enum {string} */
-                status: "ACTIVE" | "INACTIVE" | "CLOSED" | "ASSIGNED" | "EXPIRED" | "NO_APPLICANTS";
-                /** @enum {string} */
-                rentalRule: "SCORED" | "NON_SCORED";
-                /** @enum {string} */
-                listingCategory: "PARKING_SPACE" | "APARTMENT" | "STORAGE";
-              })[];
-          };
-        };
-      };
+          'application/json': {
+            listings: {
+              rentalObjectCode: string
+              /** Format: date-time */
+              publishedFrom: string
+              /** Format: date-time */
+              publishedTo: string
+              /** @enum {string} */
+              status:
+                | 'ACTIVE'
+                | 'INACTIVE'
+                | 'CLOSED'
+                | 'ASSIGNED'
+                | 'EXPIRED'
+                | 'NO_APPLICANTS'
+              /** @enum {string} */
+              rentalRule: 'SCORED' | 'NON_SCORED'
+              /** @enum {string} */
+              listingCategory: 'PARKING_SPACE' | 'APARTMENT' | 'STORAGE'
+            }[]
+          }
+        }
+      }
       responses: {
         /** @description All listings created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Partial success. Some listings created, some failed. */
         207: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request. Invalid input data. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create listings. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/vacant-parkingspaces": {
+          content: never
+        }
+      }
+    }
+  }
+  '/vacant-parkingspaces': {
     /**
      * Get all vacant parking spaces
      * @description Retrieves a list of all vacant parking spaces.
@@ -1891,39 +1900,39 @@ export interface paths {
         /** @description A list of vacant parking spaces. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve vacant parking spaces. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-objects/by-code/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-objects/by-code/{rentalObjectCode}': {
     /**
      * Get a rental object by code
      * @description Fetches a rental object by Rental Object Code.
@@ -1932,46 +1941,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the rental object to fetch. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rental object. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to fetch rental object. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listing-text-content/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listing-text-content/{rentalObjectCode}': {
     /**
      * Get listing text content by rental object code
      * @description Fetch the listing text content for a specific rental object.
@@ -1980,28 +1989,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to fetch text content for. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update listing text content
      * @description Update existing listing text content.
@@ -2010,37 +2019,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to update. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete listing text content
      * @description Delete listing text content.
@@ -2049,26 +2058,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to delete. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listing-text-content": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listing-text-content': {
     /**
      * Create listing text content
      * @description Create new listing text content for a rental object.
@@ -2076,34 +2085,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content already exists for rental object code */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/floorplan": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/floorplan': {
     /**
      * Get floor plan for a rental property
      * @description Returns the floor plan image for the specified rental property.
@@ -2112,100 +2121,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved floor plan image */
         200: {
           content: {
-            "image/jpeg": string;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options": {
+            'image/jpeg': string
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options': {
     /** Get room types with material options by rental property ID */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch room types for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with room types and their material options */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options/{materialOptionId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options/{materialOptionId}': {
     /** Get material option by ID for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material options from */
-          id: string;
+          id: string
           /** @description ID of the material option to fetch */
-          materialOptionId: string;
-        };
-      };
+          materialOptionId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material option */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{apartmentId}/contracts/{contractId}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{apartmentId}/contracts/{contractId}/material-choices': {
     /** Get material choices for a specific apartment and contract */
     get: {
       parameters: {
         path: {
           /** @description ID of the apartment to fetch material choices for */
-          apartmentId: string;
+          apartmentId: string
           /** @description ID of the contract to fetch material choices for */
-          contractId: string;
-        };
-      };
+          contractId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/rooms-with-material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/rooms-with-material-choices': {
     /** Get rooms with material choices for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch rooms with material choices for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested rooms and their material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-choices': {
     /**
      * Get material choices for a specific rental property
      * @description Retrieve material choices associated with a rental property identified by {id}.
@@ -2214,18 +2223,18 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
     /**
      * Save material choices for a rental property
      * @description Saves material choices for a specific rental property.
@@ -2234,25 +2243,25 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to save material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Material choices successfully saved */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/material-choice-statuses": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/material-choice-statuses': {
     /**
      * Get material choice statuses for rental properties
      * @description Retrieves statuses of material choices associated with rental properties. Optionally includes rental property details if specified in query parameter.
@@ -2261,20 +2270,20 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional parameter to include rental property details in response. */
-          includeRentalProperties?: "true";
-        };
-      };
+          includeRentalProperties?: 'true'
+        }
+      }
       responses: {
         /** @description Successful response with material choice statuses */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}': {
     /**
      * Get rental property by ID
      * @description Retrieves details of a rental property based on the provided ID.
@@ -2283,22 +2292,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with rental property details */
         200: {
           content: {
-            "application/json": {
-              data?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/leases": {
+            'application/json': {
+              data?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/leases': {
     /**
      * Create lease for an external parking space
      * @description Creates a new lease for the specified external parking space.
@@ -2307,38 +2316,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the lease is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Lease successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space id is missing. It needs to be passed in the url. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/note-of-interests": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/note-of-interests': {
     /**
      * Create a note of interest for an internal parking space
      * @description Creates a new note of interest for the specified internal parking space.
@@ -2347,38 +2356,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the note of interest is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Note of interest successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Contact code is missing. It needs to be passed in the body (contactCode) */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/by-rental-object-code/{rentalObjectCode}": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/by-rental-object-code/{rentalObjectCode}': {
     /**
      * Get rental property information from Xpand
      * @description Retrieves detailed information about a rental property from Xpand based on the provided rental object code.
@@ -2387,32 +2396,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental object code used to identify the specific rental property in Xpand. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental property information */
         200: {
           content: {
-            "application/json": components["schemas"]["RentalPropertyResponse"];
-          };
-        };
+            'application/json': components['schemas']['RentalPropertyResponse']
+          }
+        }
         /** @description Rental property not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}': {
     /**
      * Get maintenance units for a rental property
      * @description Retrieves maintenance units for a specific rental property, optionally filtered by type.
@@ -2421,22 +2430,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch maintenance units for. */
-          rentalPropertyId: string;
+          rentalPropertyId: string
           /** @description Optional type filter for maintenance units. */
-          type: string;
-        };
-      };
+          type: string
+        }
+      }
       responses: {
         /** @description Successful response with maintenance units */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-contact-code/{contactCode}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-contact-code/{contactCode}': {
     /**
      * Get maintenance units by contact code.
      * @description Returns all maintenance units belonging to a contact code.
@@ -2445,33 +2454,33 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code for which to retrieve maintenance units. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  ok?: boolean;
-                  data?: components["schemas"]["MaintenanceUnit"][];
-                }[];
-            };
-          };
-        };
+                ok?: boolean
+                data?: components['schemas']['MaintenanceUnit'][]
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/work-orders/data/{identifier}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/data/{identifier}': {
     /**
      * Get work order data by different identifiers
      * @description Retrieves work order data along with associated leases based on the provided identifier type.
@@ -2480,50 +2489,55 @@ export interface paths {
       parameters: {
         query: {
           /** @description The type of the identifier used to fetch work order data. */
-          handler: "rentalObjectId" | "leaseId" | "pnr" | "phoneNumber" | "contactCode";
-        };
+          handler:
+            | 'rentalObjectId'
+            | 'leaseId'
+            | 'pnr'
+            | 'phoneNumber'
+            | 'contactCode'
+        }
         path: {
           /** @description The identifier value for fetching work order data. */
-          identifier: string;
-        };
-      };
+          identifier: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order data. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalPropertyId?: string;
-                  leases?: {
-                      leaseId?: string;
-                      rentalPropertyId?: string;
-                    }[];
-                }[];
-            };
-          };
-        };
+                rentalPropertyId?: string
+                leases?: {
+                  leaseId?: string
+                  rentalPropertyId?: string
+                }[]
+              }[]
+            }
+          }
+        }
         /** @description Invalid handler */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid handler */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -2532,34 +2546,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id
      * @description Retrieves work orders based on the provided rental property id.
@@ -2568,34 +2582,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -2604,34 +2618,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -2640,34 +2654,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2676,34 +2690,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -2712,42 +2726,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id from xpand
      * @description Retrieves work orders based on the provided rental property id.
@@ -2756,34 +2770,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders based on the provided property id.
@@ -2792,34 +2806,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders based on the provided building id.
@@ -2828,34 +2842,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2864,42 +2878,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/{code}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/{code}': {
     /**
      * Get work order details by rental property id from xpand
      * @description Retrieves work order details.
@@ -2908,40 +2922,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["XpandWorkOrder"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['XpandWorkOrder']
+            }
+          }
+        }
         /** @description Work order not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders': {
     /**
      * Create a new work order
      * @description Creates a new work order.
@@ -2949,64 +2963,121 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The contact code of the tenant. */
-            ContactCode?: string;
+            ContactCode?: string
             /** @description The rental property ID. */
-            RentalObjectCode?: string;
+            RentalObjectCode?: string
             Rows?: {
-                /** @description The location code of the work order. */
-                LocationCode?: string;
-              }[];
+              /** @description The location code of the work order. */
+              LocationCode?: string
+            }[]
             /** @description Access options for the work order. */
-            AccessOptions?: Record<string, never>;
+            AccessOptions?: Record<string, never>
             /** @description Pet information for the work order. */
-            Pet?: Record<string, never>;
-            Images?: string[];
-          };
-        };
-      };
+            Pet?: Record<string, never>
+            Images?: string[]
+          }
+        }
+      }
       responses: {
         /** @description Successfully created the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order created */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example ContactCode is missing */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Not found. Rental property or active lease not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental property not found */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to create the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to create a new work order */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/update": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/maintenance-teams': {
+    /**
+     * List maintenance teams (resursgrupper)
+     * @description Returns the selectable Odoo maintenance teams (resursgrupper) for the inspection work-order picker.
+     */
+    get: {
+      responses: {
+        /** @description Maintenance teams retrieved successfully */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['MaintenanceTeam'][]
+            }
+          }
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/from-inspection': {
+    /**
+     * Create work orders from an inspection (one per resursgrupp)
+     * @description Resolves the apartment from rentalObjectCode, then creates one work order per resursgrupp group. Each group is an independent Odoo commit, so the response reports per-group success/failure.
+     */
+    post: {
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['CreateInspectionWorkOrdersRequest']
+        }
+      }
+      responses: {
+        /** @description Work orders processed (see per-group results) */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['CreateInspectionWorkOrdersResponse']
+            }
+          }
+        }
+        /** @description Bad request (invalid body or not an apartment). */
+        400: {
+          content: never
+        }
+        /** @description Rental property not found. */
+        404: {
+          content: never
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/update': {
     /**
      * Update a work order with a message
      * @description Adds a message to the specified work order.
@@ -3015,49 +3086,49 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be updated. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The message to be added to the work order. */
-            message?: string;
-          };
-        };
-      };
+            message?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully added the message to the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message added to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message is missing from the request body */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to add the message to the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to add message to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/close": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/close': {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -3066,32 +3137,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       responses: {
         /** @description Successfully closed the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order with ID {workOrderId} updated successfully */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to close the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-sms": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-sms': {
     /**
      * Send SMS for a work order
      * @description Sends an SMS message to the specified phone number for a work order.
@@ -3099,46 +3170,46 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The phone number to send the SMS to. */
-            phoneNumber?: string;
+            phoneNumber?: string
             /** @description The message to be sent via SMS. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the SMS. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Sms sent to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: phoneNumber and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the SMS. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Unexpected error sending sms to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-email": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-email': {
     /**
      * Send email for a work order
      * @description Sends an email to the specified recipient for a work order.
@@ -3146,48 +3217,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The email address of the recipient. */
-            to?: string;
+            to?: string
             /** @description The subject of the email. */
-            subject?: string;
+            subject?: string
             /** @description The message to be sent in the email. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the email. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Email sent to {to} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: to, subject, and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the email. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to send email to {to}, status: {statusCode} */
-              text?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/by-room/{roomId}": {
+              text?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/by-room/{roomId}': {
     /**
      * Get components by room ID
      * @description Returns all components currently installed in a specific space via their installation records.
@@ -3197,40 +3268,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the room */
-          roomId: string;
-        };
-      };
+          roomId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the components list */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component'][]
+            }
+          }
+        }
         /** @description Room not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Room not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories': {
     /**
      * Get all component categories
      * @description Top-level groupings for building components (e.g., Ventilation, VVS, Vitvaror, Tak). Use categoryId to filter component types.
@@ -3238,21 +3309,21 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?: number;
-          limit?: number;
-        };
-      };
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component categories */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component category
      * @description Creates a new top-level category for organizing component types.
@@ -3260,22 +3331,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories/{id}': {
     /**
      * Get component category by ID
      * @description Returns a single category with its name and metadata.
@@ -3283,24 +3354,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
         /** @description Component category not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component category
      * @description Updates category name or metadata.
@@ -3308,25 +3379,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component category
      * @description Removes a category. Will fail if category has associated types.
@@ -3334,18 +3405,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-types': {
     /**
      * Get all component types
      * @description Specific kinds of components within a category (e.g., Diskmaskin, Värmepump, Takbeläggning). Filter by categoryId to get types for a specific category.
@@ -3354,22 +3425,22 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter types by category ID */
-          categoryId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          categoryId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component types */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component type
      * @description Creates a new type within a category. Requires categoryId.
@@ -3377,22 +3448,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-types/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-types/{id}': {
     /**
      * Get component type by ID
      * @description Returns a single type with its category relationship.
@@ -3400,24 +3471,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
         /** @description Component type not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component type
      * @description Updates type name or category assignment.
@@ -3425,25 +3496,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component type
      * @description Removes a type. Will fail if type has associated subtypes.
@@ -3451,18 +3522,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-subtypes": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-subtypes': {
     /**
      * Get all component subtypes
      * @description Variants of a type with lifecycle data including depreciation price, technical/economic lifespan, and replacement interval. Filter by typeId or subtypeName.
@@ -3471,30 +3542,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter subtypes by type ID */
-          typeId?: string;
+          typeId?: string
           /** @description Search subtypes by name (case-insensitive) */
-          subtypeName?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          subtypeName?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component subtypes */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"][];
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component subtype
      * @description Creates a subtype with lifecycle parameters. Requires typeId.
@@ -3502,22 +3573,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-subtypes/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-subtypes/{id}': {
     /**
      * Get component subtype by ID
      * @description Returns subtype with full lifecycle and cost planning data.
@@ -3525,24 +3596,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component subtype
      * @description Updates subtype specifications or lifecycle data.
@@ -3550,29 +3621,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component subtype
      * @description Removes a subtype. Will fail if subtype has associated models.
@@ -3580,22 +3651,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models': {
     /**
      * Get all component models
      * @description Specific manufacturer products with pricing, warranty, specifications, and dimensions. Filter by subtypeId, manufacturer, or modelName.
@@ -3604,32 +3675,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter models by component type ID */
-          componentTypeId?: string;
+          componentTypeId?: string
           /** @description Filter models by subtype ID */
-          subtypeId?: string;
+          subtypeId?: string
           /** @description Filter models by manufacturer name */
-          manufacturer?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          manufacturer?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component models */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"][];
+            'application/json': {
+              content?: components['schemas']['ComponentModel'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component model
      * @description Creates a manufacturer product entry. Requires subtypeId.
@@ -3637,49 +3708,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/documents/component-models/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/documents/component-models/{id}': {
     /** Get all documents for a component model */
     get: {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}': {
     /**
      * Get component model by ID
      * @description Returns full model details including specs and current pricing.
@@ -3687,24 +3758,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component model
      * @description Updates model pricing, specs, or warranty info.
@@ -3712,29 +3783,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component model
      * @description Removes a model. Will fail if model has associated components.
@@ -3742,22 +3813,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/surface": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/surface': {
     /**
      * Get surface component models (Ytskikt hierarchy)
      * @description Returns all ComponentModels under the Ytskikt category with full Subtype → Type → Category hierarchy populated. Subtypes whose name starts with "Ospecificera" sort first within each Type.
@@ -3767,19 +3838,19 @@ export interface paths {
         /** @description List of surface component models */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components': {
     /**
      * Get all components
      * @description Physical units with serial numbers and status. Filter by modelId, status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED), or serialNumber.
@@ -3787,31 +3858,31 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          modelId?: string;
-          status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+          modelId?: string
+          status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
           /** @description Search by serial number (case-insensitive partial match) */
-          serialNumber?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          serialNumber?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of components */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
+            'application/json': {
+              content?: components['schemas']['Component'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component
      * @description Registers a new physical unit. Requires modelId and serialNumber.
@@ -3819,22 +3890,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/{id}": {
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/{id}': {
     /**
      * Get component by ID
      * @description Returns full component details including purchase info, warranty dates, and current status.
@@ -3842,24 +3913,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component
      * @description Updates component status, warranty dates, or other attributes.
@@ -3868,29 +3939,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component
      * @description Removes a component record. Automatically deletes associated installation records.
@@ -3898,22 +3969,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/{id}/inspection-state": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/{id}/inspection-state': {
     /**
      * Update component inspection state
      * @description Updates component condition and last inspection date
@@ -3922,40 +3993,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component instance ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @enum {string} */
-            condition: "GOOD" | "FAIR" | "DAMAGED";
+            condition: 'GOOD' | 'FAIR' | 'DAMAGED'
             /** Format: date-time */
-            lastInspectionDate: string;
-          };
-        };
-      };
+            lastInspectionDate: string
+          }
+        }
+      }
       responses: {
         /** @description Component inspection state updated */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-installations": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-installations': {
     /**
      * Get all component installations
      * @description Placement records linking components to property locations (spaceId). A component can be moved between locations over time. Filter by componentId, spaceId, or buildingPartId.
@@ -3963,30 +4034,30 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          componentId?: string;
-          spaceId?: string;
-          buildingPartId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          componentId?: string
+          spaceId?: string
+          buildingPartId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component installations */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"][];
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component installation
      * @description Records a component being installed at a location. Requires componentId and spaceId.
@@ -3994,22 +4065,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-installations/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-installations/{id}': {
     /**
      * Get component installation by ID
      * @description Returns installation record with dates, location, order number, and cost.
@@ -4017,24 +4088,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component installation
      * @description Updates installation details or records deinstallation date.
@@ -4043,29 +4114,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component installation ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component installation
      * @description Removes an installation record.
@@ -4073,22 +4144,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/{id}/upload': {
     /**
      * Upload a file to a component
      * @description Attach photos or documents to a specific component (e.g., installation photos, receipts).
@@ -4097,92 +4168,92 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
+            contentType: string
             /** @description Optional caption for the file */
-            caption?: string;
-          };
-        };
-      };
+            caption?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/component-instances/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/component-instances/{id}': {
     /** Get all documents for a component */
     get: {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/{id}': {
     /** Delete a document by ID */
     delete: {
       parameters: {
         path: {
           /** @description Document ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Document deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Document not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}/upload': {
     /**
      * Upload a document to a component model
      * @description Attach product documentation, manuals, or spec sheets to a model for reference.
@@ -4191,38 +4262,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
-          };
-        };
-      };
+            contentType: string
+          }
+        }
+      }
       responses: {
         /** @description Document uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/analyze-image": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/analyze-image': {
     /**
      * Analyze component image(s) using AI
      * @description Upload photos to identify component type, model, or condition using AI image analysis. Can accept a typeplate/label image, product photo, or both for improved accuracy.
@@ -4230,30 +4301,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["AnalyzeComponentImageRequest"];
-        };
-      };
+          'application/json': components['schemas']['AnalyzeComponentImageRequest']
+        }
+      }
       responses: {
         /** @description Component analysis successful */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["AIComponentAnalysis"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['AIComponentAnalysis']
+            }
+          }
+        }
         /** @description Invalid request (e.g., image too large, missing required fields) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description AI analysis failed */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/processes/add-component": {
+          content: never
+        }
+      }
+    }
+  }
+  '/processes/add-component': {
     /**
      * Add a component with model, instance, and installation
      * @description Unified process to add a component. This handles:
@@ -4269,99 +4340,99 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Model name (used to find existing model or create new one) */
-            modelName: string;
+            modelName: string
             /**
              * Format: uuid
              * @description Subtype ID (must exist)
              */
-            componentSubtypeId: string;
+            componentSubtypeId: string
             /** @description Required if model doesn't exist */
-            manufacturer?: string;
+            manufacturer?: string
             /** @description Required if model doesn't exist */
-            currentPrice?: number;
+            currentPrice?: number
             /** @description Required if model doesn't exist */
-            currentInstallPrice?: number;
+            currentInstallPrice?: number
             /** @description Required if model doesn't exist */
-            modelWarrantyMonths?: number;
-            technicalSpecification?: string;
-            dimensions?: string;
-            coclassCode?: string;
-            serialNumber: string;
-            specifications?: string;
-            additionalInformation?: string;
+            modelWarrantyMonths?: number
+            technicalSpecification?: string
+            dimensions?: string
+            coclassCode?: string
+            serialNumber: string
+            specifications?: string
+            additionalInformation?: string
             /**
              * Format: date-time
              * @description ISO-8601 DateTime format (e.g., 2026-01-01T00:00:00.000Z)
              */
-            warrantyStartDate?: string;
-            componentWarrantyMonths: number;
-            priceAtPurchase: number;
-            depreciationPriceAtPurchase: number;
-            economicLifespan: number;
+            warrantyStartDate?: string
+            componentWarrantyMonths: number
+            priceAtPurchase: number
+            depreciationPriceAtPurchase: number
+            economicLifespan: number
             /** @default 1 */
-            quantity?: number;
+            quantity?: number
             /** @description NCS color code */
-            ncsCode?: string;
+            ncsCode?: string
             /**
              * @default ACTIVE
              * @enum {string}
              */
-            status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+            status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
             /**
              * @description Physical condition of the component (optional)
              * @enum {string|null}
              */
-            condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+            condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
             /** @description Where to install the component */
-            spaceId: string;
+            spaceId: string
             /** @enum {string} */
-            spaceType: "OBJECT" | "PropertyObject";
-            installationDate: string;
-            orderNumber?: string;
-            installationCost: number;
-          };
-        };
-      };
+            spaceType: 'OBJECT' | 'PropertyObject'
+            installationDate: string
+            orderNumber?: string
+            installationCost: number
+          }
+        }
+      }
       responses: {
         /** @description Component added successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                modelCreated?: boolean;
+                modelCreated?: boolean
                 model?: {
-                  id?: string;
-                  modelName?: string;
-                  manufacturer?: string;
-                };
+                  id?: string
+                  modelName?: string
+                  manufacturer?: string
+                }
                 component?: {
-                  id?: string;
-                  serialNumber?: string;
-                  status?: string;
-                };
+                  id?: string
+                  serialNumber?: string
+                  status?: string
+                }
                 installation?: {
-                  id?: string;
-                  spaceId?: string;
-                  installationDate?: string;
-                };
-              };
-            };
-          };
-        };
+                  id?: string
+                  spaceId?: string
+                  installationDate?: string
+                }
+              }
+            }
+          }
+        }
         /** @description Validation error or missing required model fields */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings': {
     /**
      * Get all buildings for a specific property
      * @description Retrieves all buildings associated with a given property code.
@@ -4372,30 +4443,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the property. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the buildings. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings/{id}': {
     /**
      * Get detailed information about a specific building
      * @description Retrieves comprehensive information about a building using its unique building id.
@@ -4406,40 +4477,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique id of the building */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-building-code/{buildingCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-building-code/{buildingCode}': {
     /**
      * Get building by building code
      * @description Retrieves building data by building code
@@ -4448,40 +4519,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-property-code/{propertyCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-property-code/{propertyCode}': {
     /**
      * Get buildings by property code
      * @description Retrieves buildings by property code
@@ -4490,31 +4561,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property to fetch buildings for */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved buildings */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies': {
     /**
      * Get all companies
      * @description Retrieves companies from property base
@@ -4524,24 +4595,24 @@ export interface paths {
         /** @description Successfully retrieved companies */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Company"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Company'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies/{organizationNumber}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies/{organizationNumber}': {
     /**
      * Get detailed information about a specific company
      * @description Retrieves comprehensive information about a company using its organization number.
@@ -4550,40 +4621,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The organization number of the company. */
-          organizationNumber: string;
-        };
-      };
+          organizationNumber: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved company information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CompanyDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['CompanyDetails']
+            }
+          }
+        }
         /** @description Company not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Company not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences': {
     /**
      * Get residences by building code and (optional) staircase code
      * @description Retrieves residences by building code and (optional) staircase code
@@ -4592,41 +4663,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch residences from */
-          buildingCode: string;
+          buildingCode: string
           /** @description Code for the staircase to fetch residences from */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Residence"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Residence'][]
+            }
+          }
+        }
         /** @description Missing building code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties': {
     /**
      * Get properties by company code and (optional) tract
      * @description Retrieves properties by company code and (optional) tract
@@ -4635,41 +4706,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the company that owns the properties. */
-          companyCode: string;
+          companyCode: string
           /** @description Optional filter to get properties in a specific tract. */
-          tract?: string;
-        };
-      };
+          tract?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved properties */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Missing company code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties/search": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties/search': {
     /**
      * Search properties
      * @description Retrieves a list of all real estate properties by name.
@@ -4678,30 +4749,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The search query. */
-          q?: string;
-        };
-      };
+          q?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved list of properties. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/properties/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/properties/{propertyCode}': {
     /**
      * Get property by property code
      * @description Retrieves property by property code
@@ -4710,40 +4781,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved property */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property']
+            }
+          }
+        }
         /** @description Property not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Property not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/by-rental-id/{rentalId}': {
     /**
      * Get residence data by residence rental id
      * @description Retrieves residence data by residence rental id
@@ -4752,40 +4823,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id for the residence to fetch */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residence. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceDetails']
+            }
+          }
+        }
         /** @description Residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Residence not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve residence data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/by-rental-id/{rentalId}': {
     /**
      * Get rental blocks by rental ID
      * @description Retrieves rental blocks by rental ID
@@ -4794,44 +4865,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
-        };
+          active?: boolean
+        }
         path: {
           /** @description Rental id to fetch rental blocks for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlock"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['RentalBlock'][]
+            }
+          }
+        }
         /** @description Rental ID not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental ID not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve rental blocks. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/export": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/export': {
     /**
      * Export rental blocks to Excel
      * @description Generates and downloads an Excel file with all rental blocks matching the filters
@@ -4840,36 +4911,36 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term */
-          q?: string;
+          q?: string
           /** @description Filter by category (supports multiple values) */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter by start date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter by end date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-        };
-      };
+          active?: boolean
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/search': {
     /**
      * Search rental blocks with server-side filtering
      * @description Search and filter rental blocks. Searches by rentalId and address.
@@ -4878,55 +4949,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term (searches rentalId, address) */
-          q?: string;
+          q?: string
           /** @description Comma-separated fields to search (default rentalId,address,propertyName,blockReason) */
-          fields?: string;
+          fields?: string
           /** @description Filter by category (Bostad, Bilplats, Lokal, Förråd) - supports multiple values */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property code/name (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter blocks starting on or after this date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter blocks ending on or before this date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-          page?: number;
-          limit?: number;
-        };
-      };
+          active?: boolean
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully searched rental blocks */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/all": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/all': {
     /**
      * Get all rental blocks (paginated)
      * @description Retrieves all rental blocks for residences across the system with pagination support
@@ -4935,46 +5006,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
+          active?: boolean
           /** @description Page number (1-indexed) */
-          page?: number;
+          page?: number
           /** @description Number of items per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved all rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/block-reasons": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/block-reasons': {
     /**
      * Get all block reasons
      * @description Returns all available block reasons for rental blocks. Used for filtering dropdowns.
@@ -4984,22 +5055,22 @@ export interface paths {
         /** @description Successfully retrieved block reasons */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  id?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                id?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/search': {
     /**
      * Search residences
      * @description Searches for residences by rental object id.
@@ -5008,30 +5079,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental object id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/summary/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/summary/by-building-code/{buildingCode}': {
     /**
      * Get residences by building code, optionally filtered by staircase code.
      * @description Returns all residences belonging to a specific building, optionally filtered by staircase code.
@@ -5040,34 +5111,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
+          staircaseCode?: string
+        }
         path: {
           /** @description The building code of the building. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the residences. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSummary"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSummary'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/staircases": {
+          content: never
+        }
+      }
+    }
+  }
+  '/staircases': {
     /**
      * Get staircases for a building
      * @description Retrieves staircases for a building
@@ -5076,42 +5147,42 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch staircases for */
-          buildingCode: string;
+          buildingCode: string
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved staircases. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Staircase"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Staircase'][]
+            }
+          }
+        }
         /** @description Missing buildingCode */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Missing buildingCode */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rooms": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rooms': {
     /**
      * Get rooms by rental id.
      * @description Returns all rooms belonging to a residence.
@@ -5120,30 +5191,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The rental id of the residence. */
-          rentalId: string;
+          rentalId: string
           /** @description The code of the room (optional). */
-          roomCode?: string;
-        };
-      };
+          roomCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Create a room for a residence.
      * @description Forwards to property-base-service which performs a transactional
@@ -5153,34 +5224,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateRoomRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateRoomRequest']
+        }
+      }
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Residence not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rooms/by-facility-id/{facilityId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rooms/by-facility-id/{facilityId}': {
     /**
      * Get rooms by facility id.
      * @description Returns all rooms belonging to a facility.
@@ -5189,26 +5260,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The id of the facility. */
-          facilityId: string;
-        };
-      };
+          facilityId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/by-rental-id/{rentalId}': {
     /**
      * Get parking space data by rentalId
      * @description Retrieves parking space data by rentalId
@@ -5217,40 +5288,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id to fetch parking space for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking space. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpace"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpace']
+            }
+          }
+        }
         /** @description Parking space not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve parking space data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-id/{rentalId}': {
     /**
      * Get maintenance units by rental id.
      * @description Returns all maintenance units belonging to a rental property.
@@ -5259,30 +5330,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property for which to retrieve maintenance units. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-building-code/{buildingCode}': {
     /**
      * Get maintenance units by building code.
      * @description Returns all maintenance units belonging to a building.
@@ -5291,30 +5362,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve maintenance units. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-rental-id/{rentalId}': {
     /**
      * Get facility by rental id.
      * @description Returns facility.
@@ -5323,30 +5394,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental id of the facility. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facility. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilityDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilityDetails']
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-property-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-property-code/{code}': {
     /**
      * Get maintenance units by property code.
      * @description Returns all maintenance units belonging to a property.
@@ -5355,30 +5426,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve maintenance units. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-code/{code}': {
     /**
      * Get a maintenance unit by its code
      * @description Returns a single maintenance unit by its unique code.
@@ -5387,30 +5458,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the maintenance unit to retrieve. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance unit. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit']
+            }
+          }
+        }
         /** @description Maintenance unit not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/search': {
     /**
      * Search maintenance units
      * @description Searches for maintenance units by code.
@@ -5419,30 +5490,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (maintenance unit code). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved maintenance units matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-property-code/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-property-code/{propertyCode}': {
     /**
      * Get facilities by property code.
      * @description Returns all facilities belonging to a property.
@@ -5451,30 +5522,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve facilities. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-building-code/{buildingCode}': {
     /**
      * Get facilities by building code.
      * @description Returns all facilities belonging to a building.
@@ -5483,30 +5554,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve facilities. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/search': {
     /**
      * Search facilities
      * @description Searches for facilities by rental id.
@@ -5515,30 +5586,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved facilities matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilitySearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilitySearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/search': {
     /**
      * Search parking spaces
      * @description Searches for parking spaces by rental id.
@@ -5547,30 +5618,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking spaces matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpaceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpaceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/apartments/{objectNumber}/temperatures": {
+          content: never
+        }
+      }
+    }
+  }
+  '/apartments/{objectNumber}/temperatures': {
     /**
      * Get indoor temperatures for an apartment
      * @description Fetches indoor temperature time series for an apartment by its object
@@ -5583,42 +5654,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Unix timestamp (seconds) for range start. Defaults to `to - 86400`. */
-          from?: number;
+          from?: number
           /** @description Unix timestamp (seconds) for range end. Defaults to now. */
-          to?: number;
+          to?: number
           /** @description Aggregation bucket size. Defaults to "H" (hourly). */
-          interval?: "H" | "D";
-        };
+          interval?: 'H' | 'D'
+        }
         path: {
           /** @description Apartment object number (e.g. "806-032-01-0101"). */
-          objectNumber: string;
-        };
-      };
+          objectNumber: string
+        }
+      }
       responses: {
         /** @description Temperature series successfully retrieved. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ApartmentTemperaturesResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ApartmentTemperaturesResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description No apartment node found for the given object number. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/search': {
     /**
      * Omni-search for different entities
      * @description Search for properties, buildings, residences, parking spaces, and maintenance units.
@@ -5635,30 +5706,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query string */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description A list of search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SearchResult'][]
+            }
+          }
+        }
         /** @description Bad request - invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/inspections": {
+          content: never
+        }
+      }
+    }
+  }
+  '/inspections': {
     /**
      * Retrieve inspections from all sources
      * @description Retrieves inspections from both the local database and Xpand, merged with a source indicator per item.
@@ -5667,58 +5738,58 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections from all sources. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["InspectionWithSource"][];
+            'application/json': {
+              content?: components['schemas']['InspectionWithSource'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new inspection
      * @description Creates a new inspection in the local inspection database
@@ -5726,40 +5797,40 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateInspectionRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateInspectionRequest']
+        }
+      }
       responses: {
         /** @description Inspection created successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["DetailedInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['DetailedInspection']
+              }
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/residence/{residenceId}": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from all sources
      * @description Retrieves inspections associated with a specific residence ID from both the local database and Xpand.
@@ -5768,37 +5839,37 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["InspectionWithSource"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['InspectionWithSource'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand': {
     /**
      * Retrieve inspections from Xpand
      * @description Retrieves inspections from Xpand with pagination and status filtering support.
@@ -5807,60 +5878,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Inspection"][];
+            'application/json': {
+              content?: components['schemas']['Inspection'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/residence/{residenceId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from Xpand
      * @description Retrieves inspections associated with a specific residence ID from Xpand.
@@ -5869,46 +5940,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["Inspection"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['Inspection'][]
+              }
+            }
+          }
+        }
         /** @description No inspections found for the specified residence ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}': {
     /**
      * Retrieve an inspection by ID from Xpand
      * @description Retrieves a specific inspection by its ID from Xpand.
@@ -5917,40 +5988,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["DetailedInspection"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['DetailedInspection']
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve the inspection. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}/pdf": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}/pdf': {
     /**
      * Generate PDF protocol for an inspection
      * @description Generates and returns a PDF protocol for a specific inspection by its ID.
@@ -5959,47 +6030,47 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean;
-        };
+          includeCosts?: boolean
+        }
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string;
-              };
-            };
-          };
-        };
+                pdfBase64?: string
+              }
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to generate PDF. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/details": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/details': {
     /**
      * Retrieve an enriched internal inspection by ID
      * @description Retrieves a specific internal inspection by its ID, normalized into the same shape as Xpand inspections (with lease, residence, and flattened room remarks) so it can be rendered by the protocol UI without source-specific branching.
@@ -6008,38 +6079,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["DetailedInspection"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['DetailedInspection']
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/pdf": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/pdf': {
     /**
      * Generate PDF protocol for an internal inspection
      * @description Generates and returns a PDF protocol for a specific internal inspection by its ID.
@@ -6048,45 +6119,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean;
-        };
+          includeCosts?: boolean
+        }
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string;
-              };
-            };
-          };
-        };
+                pdfBase64?: string
+              }
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/tenant-contacts": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/tenant-contacts': {
     /**
      * Get tenant contacts for an internal inspection
      * @description Retrieves contact information for new and previous tenants associated with an internal inspection's residence.
@@ -6094,38 +6165,38 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant contacts. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["TenantContactsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['TenantContactsResponse']
+            }
+          }
+        }
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/send-protocol": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/send-protocol': {
     /**
      * Send inspection protocol to tenant for an internal inspection
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous) for an internal inspection.
@@ -6133,51 +6204,51 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SendProtocolRequest"];
-        };
-      };
+          'application/json': components['schemas']['SendProtocolRequest']
+        }
+      }
       responses: {
         /** @description Protocol sent successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SendProtocolResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SendProtocolResponse']
+            }
+          }
+        }
         /** @description Invalid request or no contract found. */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/tenant-contacts": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/tenant-contacts': {
     /**
      * Get tenant contacts for inspection protocol modal
      * @description Retrieves contact information for new and previous tenants to display in confirmation modal before sending protocol
@@ -6186,40 +6257,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant contacts */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["TenantContactsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['TenantContactsResponse']
+            }
+          }
+        }
         /** @description Inspection or residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/send-protocol": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/send-protocol': {
     /**
      * Send inspection protocol to tenant
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous)
@@ -6228,90 +6299,90 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SendProtocolRequest"];
-        };
-      };
+          'application/json': components['schemas']['SendProtocolRequest']
+        }
+      }
       responses: {
         /** @description Protocol sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SendProtocolResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SendProtocolResponse']
+            }
+          }
+        }
         /** @description Invalid request or no contract found */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid request body */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}': {
     /** Get internal inspection by ID including draft room data */
     get: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Internal inspection with draft room data */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["InternalInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['InternalInspection']
+              }
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Update internal inspection
      * @description Updates an internal inspection. Supports updating status (with valid transitions Registrerad → Påbörjad → Genomförd) and/or inspector. At least one field must be provided.
@@ -6320,100 +6391,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to update */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateInspectionStatusRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateInspectionStatusRequest']
+        }
+      }
       responses: {
         /** @description Inspection updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["InternalInspection"];
+                inspection?: components['schemas']['InternalInspection']
                 /** @description Per-component write-back errors recorded when transitioning to "Genomförd". Empty for other status transitions. */
-                componentWriteBackErrors?: components["schemas"]["ComponentWriteBackError"][];
-              };
-            };
-          };
-        };
+                componentWriteBackErrors?: components['schemas']['ComponentWriteBackError'][]
+              }
+            }
+          }
+        }
         /** @description Invalid request body or invalid status transition */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/draft": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/draft': {
     /** Save inspection draft data (rooms and inspector name) */
     patch: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SaveInspectionDraftRequest"];
-        };
-      };
+          'application/json': components['schemas']['SaveInspectionDraftRequest']
+        }
+      }
       responses: {
         /** @description Draft saved successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/rooms": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/rooms': {
     /**
      * Add a room to a residence during an inspection.
      * @description Creates a new room in Xpand (via property-base) for the residence
@@ -6429,53 +6500,53 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["AddInspectionRoomRequest"];
-        };
-      };
+          'application/json': components['schemas']['AddInspectionRoomRequest']
+        }
+      }
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                room?: components["schemas"]["Room"];
-              };
-            };
-          };
-        };
+                room?: components['schemas']['Room']
+              }
+            }
+          }
+        }
         /** @description Invalid request body or no residence linked to the inspection. */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/rooms/{roomId}": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/rooms/{roomId}': {
     /**
      * Remove a room that was added during the current inspection.
      * @description Symmetric to POST /inspections/internal/{inspectionId}/rooms.
@@ -6491,206 +6562,206 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          inspectionId: string;
-          roomId: string;
-        };
-      };
+          inspectionId: string
+          roomId: string
+        }
+      }
       responses: {
         /** @description Room removed. */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /**
          * @description Inspection not found, room not found in Xpand, or the room was
          * not added during this inspection.
          */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Room has installed components and cannot be removed. */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files': {
     /** List files with optional prefix */
     get: {
       parameters: {
         query?: {
-          prefix?: string;
-        };
-      };
+          prefix?: string
+        }
+      }
       responses: {
         /** @description List of files with metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListFilesResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListFilesResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/upload': {
     /** Upload a file */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["FileUploadRequest"];
-        };
-      };
+          'application/json': components['schemas']['FileUploadRequest']
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUploadResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUploadResponse']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/url": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/url': {
     /** Get presigned URL for file download */
     get: {
       parameters: {
         query?: {
           /** @description URL expiry time in seconds */
-          expirySeconds?: number;
-        };
+          expirySeconds?: number
+        }
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description Presigned URL generated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUrlResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUrlResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/metadata": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/metadata': {
     /** Get file metadata */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileMetadata"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileMetadata']
+            }
+          }
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}': {
     /** Delete a file */
     delete: {
       parameters: {
         path: {
           /** @description Name of the file to delete */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/exists": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/exists': {
     /** Check if file exists */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File existence status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileExistsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileExistsResponse']
+            }
+          }
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/dax/card-owners": {
+          content: never
+        }
+      }
+    }
+  }
+  '/dax/card-owners': {
     /**
      * Search card owners from DAX
      * @description Search for card owners in the DAX access control system
@@ -6699,44 +6770,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by name (rental object ID / object code) */
-          nameFilter?: string;
+          nameFilter?: string
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
+          expand?: string
           /** @description Filter by ID */
-          idfilter?: string;
+          idfilter?: string
           /** @description Filter by attribute */
-          attributeFilter?: string;
+          attributeFilter?: string
           /** @description Select specific attributes to return */
-          selectedAttributes?: string;
+          selectedAttributes?: string
           /** @description Filter by folder */
-          folderFilter?: string;
+          folderFilter?: string
           /** @description Filter by organisation */
-          organisationFilter?: string;
+          organisationFilter?: string
           /** @description Pagination offset */
-          offset?: number;
+          offset?: number
           /** @description Maximum number of results */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Card owners retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwners?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              cardOwners?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Failed to fetch card owners */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/card-owners/{cardOwnerId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/card-owners/{cardOwnerId}': {
     /**
      * Get a specific card owner from DAX
      * @description Retrieve a card owner by ID from the DAX access control system
@@ -6745,38 +6816,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card owner ID */
-          cardOwnerId: string;
-        };
-      };
+          cardOwnerId: string
+        }
+      }
       responses: {
         /** @description Card owner retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwner?: components["schemas"]["CardOwner"];
-            };
-          };
-        };
+            'application/json': {
+              cardOwner?: components['schemas']['CardOwner']
+            }
+          }
+        }
         /** @description Card owner not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card owner */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/cards/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/cards/{cardId}': {
     /**
      * Get a specific card from DAX
      * @description Retrieve a card by ID from the DAX access control system
@@ -6785,38 +6856,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "codes") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card ID */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              card?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              card?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-bundles": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-bundles': {
     /**
      * List key bundles with pagination
      * @description Fetches a paginated list of all key bundles ordered by name.
@@ -6825,28 +6896,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description A paginated list of key bundles. */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key bundle
      * @description Create a new key bundle record.
@@ -6854,30 +6925,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while creating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/search': {
     /**
      * Search key bundles with pagination
      * @description Search key bundles with flexible filtering and pagination.
@@ -6886,35 +6957,35 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. */
-          fields?: string;
-        };
-      };
+          fields?: string
+        }
+      }
       responses: {
         /** @description Paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Invalid search parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-key/{keyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-key/{keyId}': {
     /**
      * Get all bundles containing a specific key
      * @description Returns all bundle records containing the specified key ID
@@ -6923,26 +6994,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to search for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of bundles containing this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}': {
     /**
      * Get key bundle by ID
      * @description Fetch a specific key bundle by its ID.
@@ -6951,28 +7022,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key bundle object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while fetching the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a key bundle
      * @description Delete a key bundle by ID.
@@ -6981,24 +7052,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key bundle deleted successfully. */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while deleting the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a key bundle
      * @description Partially update an existing key bundle.
@@ -7007,39 +7078,39 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while updating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}/keys-with-loan-status": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}/keys-with-loan-status': {
     /**
      * Get keys in bundle with maintenance loan status
      * @description Fetches all keys in a key bundle along with their active maintenance loan information
@@ -7053,38 +7124,38 @@ export interface paths {
            * Soft fails — if the contacts service errors, the response is
            * returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The key bundle ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Bundle information and keys with loan status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundleDetailsResponse"];
+            'application/json': {
+              content?: components['schemas']['KeyBundleDetailsResponse']
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Key bundle not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-contact/{contactCode}/with-loaned-keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-contact/{contactCode}/with-loaned-keys': {
     /**
      * Get key bundles with keys loaned to a contact
      * @description Fetches all key bundles that have keys currently loaned to a specific contact.
@@ -7093,28 +7164,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code (F-number) to find bundles for */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description A list of bundles with loaned keys info. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BundleWithLoanedKeysInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BundleWithLoanedKeysInfo'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events': {
     /**
      * Get all key events
      * @description Returns all key events ordered by creation date.
@@ -7124,19 +7195,19 @@ export interface paths {
         /** @description List of key events. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a key event
      * @description Create a new key event record. Will fail with 409 if any of the keys have an incomplete event (status not COMPLETED).
@@ -7144,43 +7215,43 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Conflict - one or more keys have incomplete events. */
         409: {
           content: {
-            "application/json": {
-              reason?: string;
-              conflictingKeys?: string[];
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+              conflictingKeys?: string[]
+            }
+          }
+        }
         /** @description An error occurred while creating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/by-key/{keyId}': {
     /**
      * Get all key events for a specific key
      * @description Returns all key events associated with a specific key ID. Optionally limit results to get only the latest event(s).
@@ -7189,32 +7260,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional limit on number of results (e.g., 1 for latest event only). */
-          limit?: number;
-        };
+          limit?: number
+        }
         path: {
           /** @description The key ID to filter events by. */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description List of key events for the key. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/{id}': {
     /**
      * Get key event by ID
      * @description Fetch a specific key event by its ID.
@@ -7223,32 +7294,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key event object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key event
      * @description Update an existing key event.
@@ -7257,45 +7328,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans': {
     /**
      * List all key loans
      * @description Fetches a list of all key loans ordered by creation date.
@@ -7305,19 +7376,19 @@ export interface paths {
         /** @description A list of key loans. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key loans. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key loan
      * @description Create a new key loan record.
@@ -7325,34 +7396,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description An error occurred while creating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/search': {
     /**
      * Search key loans
      * @description Search key loans with flexible filtering.
@@ -7365,69 +7436,69 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to contact and contact2. */
-          fields?: string;
+          fields?: string
           /** @description Search by key name or rental object code (requires JOIN with keys table) */
-          keyNameOrObjectCode?: string;
+          keyNameOrObjectCode?: string
           /** @description Minimum number of keys in loan */
-          minKeys?: number;
+          minKeys?: number
           /** @description Maximum number of keys in loan */
-          maxKeys?: number;
+          maxKeys?: number
           /** @description Filter by pickedUpAt null status (true = NOT NULL, false = NULL) */
-          hasPickedUp?: boolean;
+          hasPickedUp?: boolean
           /** @description Filter by returnedAt null status (true = NOT NULL, false = NULL) */
-          hasReturned?: boolean;
-          id?: string;
-          keys?: string;
-          contact?: string;
-          contact2?: string;
-          loanType?: "TENANT" | "MAINTENANCE";
+          hasReturned?: boolean
+          id?: string
+          keys?: string
+          contact?: string
+          contact2?: string
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          returnedAt?: string;
-          availableToNextTenantFrom?: string;
+          returnedAt?: string
+          availableToNextTenantFrom?: string
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          pickedUpAt?: string;
-          createdAt?: string;
-          updatedAt?: string;
+          pickedUpAt?: string
+          createdAt?: string
+          updatedAt?: string
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Successfully retrieved search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-key/{keyId}': {
     /**
      * Get all loans for a specific key
      * @description Returns all loan records for the specified key ID, ordered by creation date DESC
@@ -7441,36 +7512,36 @@ export interface paths {
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The key ID to fetch loans for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-card/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-card/{cardId}': {
     /**
      * Get all loans for a specific card
      * @description Returns all loan records for the specified card ID, ordered by creation date DESC
@@ -7479,23 +7550,23 @@ export interface paths {
       parameters: {
         path: {
           /** @description The card ID to fetch loans for */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this card */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
-        500: components["responses"]["InternalServerError"];
-      };
-    };
-  };
-  "/key-loans/by-rental-object/{rentalObjectCode}": {
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
+        500: components['responses']['InternalServerError']
+      }
+    }
+  }
+  '/key-loans/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key loans by rental object code
      * @description Returns all key loans for a specific rental object with keys and optional receipts
@@ -7504,43 +7575,43 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by contact code */
-          contact?: string;
+          contact?: string
           /** @description Filter by second contact code */
-          contact2?: string;
+          contact2?: string
           /** @description Include receipts in the response */
-          includeReceipts?: boolean;
+          includeReceipts?: boolean
           /**
            * @description Filter by return status:
            * - true: Only returned loans (returnedAt IS NOT NULL)
            * - false: Only active loans (returnedAt IS NULL)
            * - omitted: All loans (no filter)
            */
-          returned?: boolean;
-        };
+          returned?: boolean
+        }
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description A list of key loans with details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-contact/{contact}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-contact/{contact}/with-keys': {
     /**
      * Get key loans by contact with keys
      * @description Returns all key loans for a specific contact with full key details, optionally filtered by loan type and return status
@@ -7549,45 +7620,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
+          returned?: boolean
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The contact identifier to search for */
-          contact: string;
-        };
-      };
+          contact: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-bundle/{bundleId}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-bundle/{bundleId}/with-keys': {
     /**
      * Get key loans by bundle with keys
      * @description Returns all key loans for a specific bundle with full key details, optionally filtered by loan type and return status
@@ -7596,45 +7667,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
+          returned?: boolean
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The bundle ID to search for */
-          bundleId: string;
-        };
-      };
+          bundleId: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/{id}': {
     /**
      * Get key loan by ID
      * @description Fetch a specific key loan by its ID.
@@ -7647,42 +7718,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description When true, includes keysArray with keySystem data attached to each key. */
-          includeKeySystem?: boolean;
+          includeKeySystem?: boolean
           /** @description When true, includes keyCardsArray with card data from DAX. Auto-implies key fetching. */
-          includeCards?: boolean;
+          includeCards?: boolean
           /** @description When true, includes loan history attached to each key in keysArray. */
-          includeLoans?: boolean;
+          includeLoans?: boolean
           /** @description When true, includes event history attached to each key in keysArray. */
-          includeEvents?: boolean;
-        };
+          includeEvents?: boolean
+        }
         path: {
           /** @description The unique ID of the key loan to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key loan object. Returns KeyLoanWithDetails if includeKeySystem or includeCards is true. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"] | components["schemas"]["KeyLoanWithDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?:
+                | components['schemas']['KeyLoan']
+                | components['schemas']['KeyLoanWithDetails']
+            }
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key loan
      * @description Delete an existing key loan by ID.
@@ -7691,28 +7764,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key loan deleted successfully. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while deleting the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key loan
      * @description Partially update an existing key loan.
@@ -7721,45 +7794,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/{id}': {
     /**
      * Get key note by ID
      * @description Retrieve a specific key note by its ID
@@ -7768,32 +7841,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key note
      * @description Update the description of an existing key note
@@ -7802,45 +7875,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key note by rental object code
      * @description Retrieve the key note for a specific rental object
@@ -7849,34 +7922,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes': {
     /**
      * Create a new key note
      * @description Create a new key note for a rental object
@@ -7884,34 +7957,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems': {
     /**
      * List all key systems with pagination
      * @description Retrieve a paginated list of all key systems
@@ -7920,28 +7993,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated key systems */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key system
      * @description Create a new key system
@@ -7949,34 +8022,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/search': {
     /**
      * Search key systems
      * @description Search key systems with flexible filtering.
@@ -7993,54 +8066,54 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Search query for OR search across fields specified in 'fields' parameter */
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search (e.g., "systemCode,manufacturer"). Defaults to systemCode. */
-          fields?: string;
-          id?: string;
-          systemCode?: string;
-          name?: string;
-          manufacturer?: string;
-          managingSupplier?: string;
-          type?: string;
-          propertyIds?: string;
-          installationDate?: string;
-          isActive?: string;
-          notes?: string;
-          createdAt?: string;
-          updatedAt?: string;
-          createdBy?: string;
-          updatedBy?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          systemCode?: string
+          name?: string
+          manufacturer?: string
+          managingSupplier?: string
+          type?: string
+          propertyIds?: string
+          installationDate?: string
+          isActive?: string
+          notes?: string
+          createdAt?: string
+          updatedAt?: string
+          createdBy?: string
+          updatedBy?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Bad request. Invalid parameters or field names */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}': {
     /**
      * Get key system by ID
      * @description Retrieve a specific key system by its ID
@@ -8049,32 +8122,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key system */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key system
      * @description Delete a key system by ID
@@ -8083,28 +8156,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key system deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key system
      * @description Partially update a key system
@@ -8113,139 +8186,139 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/upload-schema": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/upload-schema': {
     /** Upload a schema file for a key system */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-            fileName?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+            fileName?: string
+          }
+        }
+      }
       responses: {
         /** @description Schema file uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/download-schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/download-schema': {
     /** Get presigned download URL for a key system schema file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": components["schemas"]["SchemaDownloadUrlResponse"];
-          };
-        };
+            'application/json': components['schemas']['SchemaDownloadUrlResponse']
+          }
+        }
         /** @description Key system or schema file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/schema': {
     /** Delete the schema file for a key system */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Schema deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/keys': {
     /**
      * List keys with pagination
      * @description Returns paginated keys ordered by createdAt (desc).
@@ -8254,71 +8327,71 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Paginated list of keys */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a key */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/search': {
     /**
      * Search keys
      * @description Search keys with flexible filtering.
@@ -8331,59 +8404,59 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to keyName. */
-          fields?: string;
-          id?: string;
-          keyName?: string;
-          keySequenceNumber?: string;
-          flexNumber?: string;
-          rentalObjectCode?: string;
-          keyType?: string;
-          keySystemId?: string;
-          createdAt?: string;
-          updatedAt?: string;
+          fields?: string
+          id?: string
+          keyName?: string
+          keySequenceNumber?: string
+          flexNumber?: string
+          rentalObjectCode?: string
+          keyType?: string
+          keySystemId?: string
+          createdAt?: string
+          updatedAt?: string
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/by-rental-object/{rentalObjectCode}': {
     /**
      * Get all keys by rental object code
      * @description Returns all keys associated with a specific rental object code without pagination
@@ -8392,182 +8465,182 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to filter keys by */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved keys */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/cards/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/cards/by-rental-object/{rentalObjectCode}': {
     /** Get cards by rental object code */
     get: {
       parameters: {
         query?: {
-          includeLoans?: boolean;
-        };
+          includeLoans?: boolean
+        }
         path: {
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Cards for the rental object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CardDetails"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/cards/{cardId}": {
+            'application/json': {
+              content?: components['schemas']['CardDetails'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/cards/{cardId}': {
     /** Get card by ID */
     get: {
       parameters: {
         path: {
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/{id}': {
     /** Get key by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Delete a key */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Deleted */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Update a key (partial) */
     patch: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyRequest']
+        }
+      }
       responses: {
         /** @description Updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update': {
     /**
      * Bulk update keys
      * @description Update multiple keys with the same values. Maximum 100 keys per request.
@@ -8575,35 +8648,35 @@ export interface paths {
     patch: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateKeysRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateKeysRequest']
+        }
+      }
       responses: {
         /** @description Keys updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update-flex": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update-flex': {
     /**
      * Bulk update flex number for all keys on a rental object
      * @description Update the flex number for all keys associated with a specific rental object code. Flex numbers range from 1-3.
@@ -8611,35 +8684,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateFlexRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateFlexRequest']
+        }
+      }
       responses: {
         /** @description Flex numbers updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-delete": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-delete': {
     /**
      * Bulk delete keys
      * @description Delete multiple keys by their IDs. Maximum 100 keys per request.
@@ -8647,37 +8720,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            keyIds: string[];
-          };
-        };
-      };
+          'application/json': {
+            keyIds: string[]
+          }
+        }
+      }
       responses: {
         /** @description Keys deleted successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys deleted */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs': {
     /**
      * List logs with pagination
      * @description Returns paginated logs (most recent per objectId) ordered by eventTime (desc).
@@ -8686,60 +8759,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Paginated list of logs */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a log */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateLogRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateLogRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Invalid or missing fields */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/search': {
     /**
      * Search logs with pagination
      * @description Search logs with flexible filtering and pagination.
@@ -8752,46 +8825,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to objectId. */
-          fields?: string;
-          id?: string;
-          userName?: string;
-          eventType?: string;
-          eventTime?: string;
-          objectType?: string;
-          objectId?: string;
-          description?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          userName?: string
+          eventType?: string
+          eventTime?: string
+          objectType?: string
+          objectId?: string
+          description?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/object/{objectId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/object/{objectId}': {
     /**
      * Get all logs for a specific objectId
      * @description Returns all log entries for a given objectId, ordered by most recent first
@@ -8799,60 +8872,60 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          objectId: string;
-        };
-      };
+          objectId: string
+        }
+      }
       responses: {
         /** @description List of logs for the objectId */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/{id}': {
     /** Get log by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Log found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/rental-object/{rentalObjectCode}': {
     /**
      * Get all logs for a specific rental object
      * @description Returns all log entries for a given rental object code by JOINing across multiple tables.
@@ -8869,40 +8942,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The rental object code (e.g., "705-011-03-0102") */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the rental object */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/contact/{contactId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/contact/{contactId}': {
     /**
      * Get all logs for a specific contact
      * @description Returns all log entries for a given contact code by JOINing across keyLoans and receipts.
@@ -8919,40 +8992,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The contact code (e.g., "P079586", "F123456") */
-          contactId: string;
-        };
-      };
+          contactId: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the contact */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts': {
     /**
      * Create a receipt
      * @description Create a new receipt record for a key loan
@@ -8960,34 +9033,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/{id}': {
     /**
      * Get a receipt by ID
      * @description Retrieve a specific receipt by its ID
@@ -8996,32 +9069,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The receipt ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved receipt */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a receipt
      * @description Delete a receipt by ID (and associated file from MinIO)
@@ -9030,28 +9103,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Receipt deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a receipt
      * @description Update a receipt (e.g., set fileId after upload)
@@ -9060,144 +9133,144 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Receipt updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/by-key-loan/{keyLoanId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/by-key-loan/{keyLoanId}': {
     /** Get receipts by key loan ID */
     get: {
       parameters: {
         path: {
-          keyLoanId: string;
-        };
-      };
+          keyLoanId: string
+        }
+      }
       responses: {
         /** @description Receipts for the key loan */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/upload': {
     /** Upload a file for a receipt */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/download": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/download': {
     /** Get presigned download URL for a receipt file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                url?: string;
-                expiresIn?: number;
-                fileId?: string;
-              };
-            };
-          };
-        };
+                url?: string
+                expiresIn?: number
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Receipt or file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/signatures/send": {
+          content: never
+        }
+      }
+    }
+  }
+  '/signatures/send': {
     /**
      * Send a document for digital signature via SimpleSign
      * @description Send a PDF document to SimpleSign for digital signature
@@ -9205,49 +9278,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @enum {string} */
-            resourceType: "receipt";
+            resourceType: 'receipt'
             /** Format: uuid */
-            resourceId: string;
+            resourceId: string
             /** Format: email */
-            recipientEmail: string;
-            recipientName?: string;
-            pdfBase64: string;
-          };
-        };
-      };
+            recipientEmail: string
+            recipientName?: string
+            pdfBase64: string
+          }
+        }
+      }
       responses: {
         /** @description Signature request sent successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Resource not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/{id}': {
     /**
      * Get a signature by ID
      * @description Retrieve a specific signature by its ID
@@ -9255,34 +9328,34 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Signature details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Signature not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/resource/{resourceType}/{resourceId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/resource/{resourceType}/{resourceId}': {
     /**
      * Get all signatures for a resource
      * @description Retrieve all signatures associated with a specific resource
@@ -9290,29 +9363,29 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          resourceType: "receipt";
-          resourceId: string;
-        };
-      };
+          resourceType: 'receipt'
+          resourceId: string
+        }
+      }
       responses: {
         /** @description List of signatures */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/webhooks/simplesign": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/webhooks/simplesign': {
     /**
      * Webhook endpoint for SimpleSign status updates
      * @description Receives webhook notifications from SimpleSign when document status changes (e.g., signed, declined)
@@ -9320,26 +9393,26 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SimpleSignWebhookPayload"];
-        };
-      };
+          'application/json': components['schemas']['SimpleSignWebhookPayload']
+        }
+      }
       responses: {
         /** @description Webhook processed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Signature not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/v1/contacts": {
+          content: never
+        }
+      }
+    }
+  }
+  '/v1/contacts': {
     /**
      * List and filter(search) for contact information
      * @description Filtering can be done by wildcard search
@@ -9348,55 +9421,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Wildcard search string */
-          q?: string[];
+          q?: string[]
           /** @description Filter on contact type */
-          type?: "individual" | "organisation";
+          type?: 'individual' | 'organisation'
           /** @description Page number for paginated results (1-based) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              content: components["schemas"]["ContactV1"][];
+            'application/json': {
+              content: components['schemas']['ContactV1'][]
               _meta: {
-                totalRecords: number;
-                page: number;
-                limit: number;
-                count: number;
-              };
-              _links: ({
-                  href: string;
-                  /** @enum {string} */
-                  rel: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords: number
+                page: number
+                limit: number
+                count: number
+              }
+              _links: {
+                href: string
+                /** @enum {string} */
+                rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
         /** @description Internal Server Error */
         500: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/batch": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/batch': {
     /**
      * Batch lookup of contacts by contact code
      * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, or `includeAddress` to include those joins. Missing contact codes are simply absent from the response.
@@ -9405,2848 +9478,3014 @@ export interface paths {
       parameters: {
         query: {
           /** @description Contact code(s) to look up. Repeat the parameter for multiple codes, e.g. ?code=P123&code=P456. */
-          code: string[];
+          code: string[]
           /** @description Include phone numbers in the response. */
-          includePhone?: boolean;
+          includePhone?: boolean
           /** @description Include email addresses in the response. */
-          includeEmail?: boolean;
+          includeEmail?: boolean
           /** @description Include addresses in the response. */
-          includeAddress?: boolean;
-        };
-      };
+          includeAddress?: boolean
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"][];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1'][]
+            }
+          }
+        }
         /** @description Internal Server Error */
         500: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}': {
     /** Get a single contact by canonical id (contact code) */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}/trustee": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}/trustee': {
     /** Get the trustee of a contact */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-phone-number/{phoneNumber}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-phone-number/{phoneNumber}': {
     /** List contacts by phone number */
     get: {
       parameters: {
         path: {
           /** @description Phone Number */
-          phoneNumber: string;
-        };
-      };
+          phoneNumber: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-email-address/{emailAddress}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-email-address/{emailAddress}': {
     /** List contacts by email address */
     get: {
       parameters: {
         path: {
           /** @description Email Address */
-          emailAddress: string;
-        };
-      };
+          emailAddress: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-national-id/{nid}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-national-id/{nid}': {
     /** List contacts by national id (Personnummer / Org.nr) */
     get: {
       parameters: {
         path: {
           /** @description National ID */
-          nid: string;
-        };
-      };
+          nid: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
     Lease: {
-      leaseId: string;
-      leaseNumber: string;
+      leaseId: string
+      leaseNumber: string
       /** Format: date-time */
-      leaseStartDate: string;
+      leaseStartDate: string
       /** Format: date-time */
-      leaseEndDate?: string;
+      leaseEndDate?: string
       /** @enum {string} */
-      status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-      tenantContactIds?: string[];
-      rentalPropertyId: string;
+      status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+      tenantContactIds?: string[]
+      rentalPropertyId: string
       rentalProperty?: {
-        rentalPropertyId: string;
-        apartmentNumber: number;
-        size: number;
-        type: string;
+        rentalPropertyId: string
+        apartmentNumber: number
+        size: number
+        type: string
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        rentalPropertyType: string;
-        additionsIncludedInRent: string;
-        otherInfo?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        rentalPropertyType: string
+        additionsIncludedInRent: string
+        otherInfo?: string
         roomTypes?: {
-            roomTypeId: string;
-            name: string;
-          }[];
+          roomTypeId: string
+          name: string
+        }[]
         /** Format: date-time */
-        lastUpdated?: string;
-      };
-      type: string;
+        lastUpdated?: string
+      }
+      type: string
       rentInfo?: {
         currentRent: {
-          rentId?: string;
-          leaseId?: string;
-          currentRent: number;
-          vat: number;
-          additionalChargeDescription?: string;
-          additionalChargeAmount?: number;
+          rentId?: string
+          leaseId?: string
+          currentRent: number
+          vat: number
+          additionalChargeDescription?: string
+          additionalChargeAmount?: number
           /** Format: date-time */
-          rentStartDate?: string;
+          rentStartDate?: string
           /** Format: date-time */
-          rentEndDate?: string;
-        };
-      };
+          rentEndDate?: string
+        }
+      }
       address?: {
-        street?: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      };
-      noticeGivenBy?: string;
+        street?: string
+        number: string
+        postalCode: string
+        city: string
+      }
+      noticeGivenBy?: string
       /** Format: date-time */
-      noticeDate?: string;
-      noticeTimeTenant?: string | number;
+      noticeDate?: string
+      noticeTimeTenant?: string | number
       /** Format: date-time */
-      preferredMoveOutDate?: string;
+      preferredMoveOutDate?: string
       /** Format: date-time */
-      terminationDate?: string;
+      terminationDate?: string
       /** Format: date-time */
-      contractDate?: string;
+      contractDate?: string
       /** Format: date-time */
-      lastDebitDate?: string;
+      lastDebitDate?: string
       /** Format: date-time */
-      approvalDate?: string;
+      approvalDate?: string
       residentialArea?: {
-        code: string;
-        caption: string;
-      };
+        code: string
+        caption: string
+      }
       tenants?: {
-          contactCode: string;
-          contactKey: string;
-          leaseIds?: string[];
-          firstName: string;
-          lastName: string;
-          fullName: string;
-          nationalRegistrationNumber: string;
+        contactCode: string
+        contactKey: string
+        leaseIds?: string[]
+        firstName: string
+        lastName: string
+        fullName: string
+        nationalRegistrationNumber: string
+        /** Format: date-time */
+        birthDate: string
+        address?: {
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        phoneNumbers?: {
+          phoneNumber: string
+          type: string
+          isMainNumber: boolean
+        }[]
+        emailAddress?: string
+        isTenant: boolean
+        parkingSpaceWaitingList?: {
           /** Format: date-time */
-          birthDate: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          phoneNumbers?: {
-              phoneNumber: string;
-              type: string;
-              isMainNumber: boolean;
-            }[];
-          emailAddress?: string;
-          isTenant: boolean;
-          parkingSpaceWaitingList?: {
-            /** Format: date-time */
-            queueTime: string;
-            queuePoints: number;
-            type: number;
-          };
-          specialAttention?: boolean;
-          leaseContactType?: string;
-        }[];
-    };
+          queueTime: string
+          queuePoints: number
+          type: number
+        }
+        specialAttention?: boolean
+        leaseContactType?: string
+      }[]
+    }
     IdentityCheckContact: {
-      contactCode: string;
-      nationalRegistrationNumber: string;
-    };
+      contactCode: string
+      nationalRegistrationNumber: string
+    }
     LeaseSearchResult: {
-      leaseId: string;
-      objectTypeCode: string;
-      leaseType: string;
-      contacts: ({
-          name: string;
-          contactCode: string;
-          email: string | null;
-          phone: string | null;
-        })[];
-      address: string | null;
+      leaseId: string
+      objectTypeCode: string
+      leaseType: string
+      contacts: {
+        name: string
+        contactCode: string
+        email: string | null
+        phone: string | null
+      }[]
+      address: string | null
       /** Format: date-time */
-      startDate: string | null;
+      startDate: string | null
       /** Format: date-time */
-      lastDebitDate: string | null;
+      lastDebitDate: string | null
       /** @enum {number} */
-      status: 0 | 1 | 2 | 3;
-      rentalObjectCode: string | null;
-      property?: string | null;
-      buildingCode?: string | null;
-      area?: string | null;
-      buildingManager?: string | null;
-      districtName?: string | null;
-      parkingSpaceType?: string | null;
-    };
+      status: 0 | 1 | 2 | 3
+      rentalObjectCode: string | null
+      property?: string | null
+      buildingCode?: string | null
+      area?: string | null
+      buildingManager?: string | null
+      districtName?: string | null
+      parkingSpaceType?: string | null
+    }
     ContactInfo: {
-      name: string;
-      contactCode: string;
-      email: string | null;
-      phone: string | null;
-    };
+      name: string
+      contactCode: string
+      email: string | null
+      phone: string | null
+    }
     PaginationMeta: {
-      totalRecords: number;
-      page: number;
-      limit: number;
-      count: number;
-    };
+      totalRecords: number
+      page: number
+      limit: number
+      count: number
+    }
     PaginationLinks: {
-      href: string;
+      href: string
       /** @enum {string} */
-      rel: "self" | "first" | "last" | "prev" | "next";
-    };
+      rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+    }
     Contact: {
-      contactCode: string;
-      contactKey: string;
-      leaseIds?: string[];
-      firstName: string | null;
-      lastName: string | null;
-      fullName: string | null;
-      nationalRegistrationNumber: string;
+      contactCode: string
+      contactKey: string
+      leaseIds?: string[]
+      firstName: string | null
+      lastName: string | null
+      fullName: string | null
+      nationalRegistrationNumber: string
       /** Format: date-time */
-      birthDate: string | null;
+      birthDate: string | null
       address: {
-        street: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      } | null;
+        street: string
+        number: string
+        postalCode: string
+        city: string
+      } | null
       phoneNumbers: {
-          phoneNumber: string;
-          type: string;
-          isMainNumber: boolean;
-        }[];
-      emailAddress: string | null;
-      isTenant: boolean;
-      specialAttention?: boolean;
-    };
+        phoneNumber: string
+        type: string
+        isMainNumber: boolean
+      }[]
+      emailAddress: string | null
+      isTenant: boolean
+      specialAttention?: boolean
+    }
     ListingTextContent: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
+      id: string
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     CreateListingTextContentRequest: {
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     UpdateListingTextContentRequest: {
-      contentBlocks?: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      contentBlocks?: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     WorkOrder: {
-      accessCaption: string;
-      caption: string;
-      code: string;
-      contactCode: string;
-      description: string;
-      detailsCaption: string;
-      externalResource: boolean;
-      id: string;
+      accessCaption: string
+      caption: string
+      code: string
+      contactCode: string
+      description: string
+      detailsCaption: string
+      externalResource: boolean
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string;
+      lastChanged: string
+      priority: string
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-      hiddenFromMyPages?: boolean;
-      workOrderRows: ({
-          description: string | null;
-          locationCode: string | null;
-          equipmentCode: string | null;
-        })[];
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+      hiddenFromMyPages?: boolean
+      workOrderRows: {
+        description: string | null
+        locationCode: string | null
+        equipmentCode: string | null
+      }[]
       messages?: {
-          id: number;
-          body: string;
-          messageType: string;
-          author: string;
-          /** Format: date-time */
-          createDate: string;
-        }[];
-      url?: string;
-    };
+        id: number
+        body: string
+        messageType: string
+        author: string
+        /** Format: date-time */
+        createDate: string
+      }[]
+      url?: string
+    }
     XpandWorkOrder: {
-      accessCaption: string;
-      caption: string | null;
-      code: string;
-      contactCode: string | null;
-      id: string;
+      accessCaption: string
+      caption: string | null
+      code: string
+      contactCode: string | null
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string | null;
+      lastChanged: string
+      priority: string | null
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-    };
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+    }
+    MaintenanceTeam: {
+      id: number
+      name: string
+    }
+    CreateInspectionWorkOrdersRequest: {
+      rentalObjectCode: string
+      groups: {
+        maintenanceTeamId: number
+        maintenanceTeamName: string
+        descriptionHtml: string
+      }[]
+    }
+    CreateInspectionWorkOrdersResponse: {
+      results: {
+        maintenanceTeamId: number
+        ok: boolean
+        workOrderId?: number
+        err?: string
+      }[]
+    }
     Building: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       buildingType: {
-        id: string | null;
-        code: string | null;
-        name: string | null;
-      };
+        id: string | null
+        code: string | null
+        name: string | null
+      }
       construction: {
-        constructionYear: number | null;
-        renovationYear: number | null;
-        valueYear: number | null;
-      };
+        constructionYear: number | null
+        renovationYear: number | null
+        valueYear: number | null
+      }
       features: {
-        heating?: string | null;
-        fireRating?: string | null;
-      };
+        heating?: string | null
+        fireRating?: string | null
+      }
       insurance: {
-        class: string | null;
-        value: number | null;
-      };
-      quantityValues?: ({
-          id: string;
-          value: number;
-          name: string;
-          unitId: string | null;
-        })[];
-      deleted: boolean;
-      property?: ({
-        name: string | null;
-        code: string;
-        id: string;
-      }) | null;
-    };
+        class: string | null
+        value: number | null
+      }
+      quantityValues?: {
+        id: string
+        value: number
+        name: string
+        unitId: string | null
+      }[]
+      deleted: boolean
+      property?: {
+        name: string | null
+        code: string
+        id: string
+      } | null
+    }
     Company: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+    }
     CompanyDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-      phone: string | null;
-      fax: string | null;
-      vatNumber?: string | null;
-      internalExternal: number;
-      fTax: number;
-      cooperativeHousingAssociation: number;
-      differentiatedAdditionalCapital: number;
-      rentAdministered: number;
-      blocked: number;
-      rentDaysPerMonth: number;
-      economicPlanApproved: number;
-      vatObligationPercent: number;
-      vatRegistered: number;
-      energyOptimization: number;
-      ownedCompany: number;
-      interestInvoice: number;
-      errorReportAdministration: number;
-      mediaBilling: number;
-      ownResponsibilityForInternalMaintenance: number;
-      subletPercentage: number;
-      subletFeeAmount: number;
-      disableQuantitiesBelowCompany: number;
-      timestamp: string;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+      phone: string | null
+      fax: string | null
+      vatNumber?: string | null
+      internalExternal: number
+      fTax: number
+      cooperativeHousingAssociation: number
+      differentiatedAdditionalCapital: number
+      rentAdministered: number
+      blocked: number
+      rentDaysPerMonth: number
+      economicPlanApproved: number
+      vatObligationPercent: number
+      vatRegistered: number
+      energyOptimization: number
+      ownedCompany: number
+      interestInvoice: number
+      errorReportAdministration: number
+      mediaBilling: number
+      ownResponsibilityForInternalMaintenance: number
+      subletPercentage: number
+      subletFeeAmount: number
+      disableQuantitiesBelowCompany: number
+      timestamp: string
+    }
     Property: {
-      id: string;
-      propertyObjectId: string;
-      marketAreaId: string | null;
-      districtId: string | null;
-      propertyDesignationId: string | null;
-      valueAreaId: string | null;
-      code: string;
-      designation: string;
-      municipality: string;
-      tract: string;
-      block: string;
-      sector: string | null;
-      propertyIndexNumber: string | null;
-      congregation: string | null;
-      builtStatus: number;
-      separateAssessmentUnit: number;
-      consolidationNumber: string | null;
-      ownershipType: string;
-      registrationDate: string | null;
-      acquisitionDate: string | null;
-      isLeasehold: number;
-      leaseholdTerminationDate: string | null;
-      area: string | null;
-      purpose: string | null;
-      buildingType: string | null;
-      propertyTaxNumber: string | null;
-      mainPartAssessedValue: number;
-      includeInAssessedValue: number;
-      grading: number;
-      deleteMark: number;
+      id: string
+      propertyObjectId: string
+      marketAreaId: string | null
+      districtId: string | null
+      propertyDesignationId: string | null
+      valueAreaId: string | null
+      code: string
+      designation: string
+      municipality: string
+      tract: string
+      block: string
+      sector: string | null
+      propertyIndexNumber: string | null
+      congregation: string | null
+      builtStatus: number
+      separateAssessmentUnit: number
+      consolidationNumber: string | null
+      ownershipType: string
+      registrationDate: string | null
+      acquisitionDate: string | null
+      isLeasehold: number
+      leaseholdTerminationDate: string | null
+      area: string | null
+      purpose: string | null
+      buildingType: string | null
+      propertyTaxNumber: string | null
+      mainPartAssessedValue: number
+      includeInAssessedValue: number
+      grading: number
+      deleteMark: number
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string;
-      timestamp: string;
-    };
+      toDate: string
+      timestamp: string
+    }
     Residence: {
-      id: string;
-      code: string;
-      name: string;
-      deleted: boolean;
+      id: string
+      code: string
+      name: string
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
-    };
+        toDate: string
+      }
+    }
     ResidenceDetails: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       /** @enum {string|null} */
-      status: "VACANT" | "LEASED" | null;
-      entrance: string | null;
-      location: string | null;
-      floor: string | null;
-      partNo: number | null;
-      part: string | null;
-      deleted: boolean;
+      status: 'VACANT' | 'LEASED' | null
+      entrance: string | null
+      location: string | null
+      floor: string | null
+      partNo: number | null
+      part: string | null
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
+        toDate: string
+      }
       accessibility: {
-        wheelchairAccessible: boolean;
-        elevator: boolean;
-        residenceAdapted: boolean;
-      };
+        wheelchairAccessible: boolean
+        elevator: boolean
+        residenceAdapted: boolean
+      }
       features: {
-        hygieneFacility: string | null;
+        hygieneFacility: string | null
         balcony1?: {
-          location: string;
-          type: string;
-        };
+          location: string
+          type: string
+        }
         balcony2?: {
-          location: string;
-          type: string;
-        };
-        patioLocation: string | null;
-        sauna: boolean;
-        extraToilet: boolean;
-        sharedKitchen: boolean;
-        petAllergyFree: boolean;
+          location: string
+          type: string
+        }
+        patioLocation: string | null
+        sauna: boolean
+        extraToilet: boolean
+        sharedKitchen: boolean
+        petAllergyFree: boolean
         /** @description Is the apartment checked for electric allergy intolerance? */
-        electricAllergyIntolerance: boolean;
-        smokeFree: boolean;
-        asbestos: boolean;
-      };
+        electricAllergyIntolerance: boolean
+        smokeFree: boolean
+        asbestos: boolean
+      }
       type: {
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-      };
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+      }
       residenceType: {
-        residenceTypeId: string;
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-        systemStandard: number;
-        checklistId: string | null;
-        componentTypeActionId: string | null;
-        statisticsGroupSCBId: string | null;
-        statisticsGroup2Id: string | null;
-        statisticsGroup3Id: string | null;
-        statisticsGroup4Id: string | null;
-        timestamp: string;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        residenceTypeId: string
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+        systemStandard: number
+        checklistId: string | null
+        componentTypeActionId: string | null
+        statisticsGroupSCBId: string | null
+        statisticsGroup2Id: string | null
+        statisticsGroup3Id: string | null
+        statisticsGroup4Id: string | null
+        timestamp: string
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       propertyObject: {
         energy: {
-          energyClass: number;
+          energyClass: number
           /** Format: date-time */
-          energyRegistered?: string;
+          energyRegistered?: string
           /** Format: date-time */
-          energyReceived?: string;
-          energyIndex?: number;
-        };
-        rentalId: string | null;
-        rentalInformation: ({
+          energyReceived?: string
+          energyIndex?: number
+        }
+        rentalId: string | null
+        rentalInformation: {
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
-        rentalBlocks: ({
-            id: string;
-            blockReasonId: string | null;
-            blockReason: string | null;
-            /** Format: date-time */
-            fromDate: string;
-            /** Format: date-time */
-            toDate: string | null;
-            amount: number | null;
-          })[];
-      };
+            code: string
+            name: string | null
+          }
+        } | null
+        rentalBlocks: {
+          id: string
+          blockReasonId: string | null
+          blockReason: string | null
+          /** Format: date-time */
+          fromDate: string
+          /** Format: date-time */
+          toDate: string | null
+          amount: number | null
+        }[]
+      }
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      staircase: ({
-        id: string;
-        code: string;
-        name: string | null;
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      staircase: {
+        id: string
+        code: string
+        name: string | null
         features: {
-          floorPlan: string | null;
-          accessibleByElevator: boolean;
-        };
+          floorPlan: string | null
+          accessibleByElevator: boolean
+        }
         dates: {
           /** Format: date-time */
-          from: string;
+          from: string
           /** Format: date-time */
-          to: string;
-        };
+          to: string
+        }
         property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
+          propertyId: string | null
+          propertyName: string | null
+          propertyCode: string | null
+        }
         building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
-        deleted: boolean;
-        timestamp: string;
-      }) | null;
-      areaSize: number | null;
-      malarEnergiFacilityId: string | null;
-    };
+          buildingId: string | null
+          buildingName: string | null
+          buildingCode: string | null
+        }
+        deleted: boolean
+        timestamp: string
+      } | null
+      areaSize: number | null
+      malarEnergiFacilityId: string | null
+    }
     ResidenceSummary: {
-      id: string;
-      code: string;
-      name: string | null;
-      deleted: boolean;
-      rentalId: string;
-      buildingCode: string;
-      buildingName: string;
-      staircaseCode: string;
-      staircaseName: string;
-      elevator: number | null;
-      floor: string;
-      hygieneFacility: string | null;
-      wheelchairAccessible: number;
+      id: string
+      code: string
+      name: string | null
+      deleted: boolean
+      rentalId: string
+      buildingCode: string
+      buildingName: string
+      staircaseCode: string
+      staircaseName: string
+      elevator: number | null
+      floor: string
+      hygieneFacility: string | null
+      wheelchairAccessible: number
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string | null;
+        fromDate: string | null
         /** Format: date-time */
-        toDate: string | null;
-      };
+        toDate: string | null
+      }
       residenceType: {
-        code: string;
-        name: string;
-        roomCount: number;
-        kitchen: number;
-      };
-      quantityValues: ({
-          value: number;
-          quantityTypeId: string;
-          quantityType: {
-            name: string;
-            unitId: string | null;
-          };
-        })[];
-    };
+        code: string
+        name: string
+        roomCount: number
+        kitchen: number
+      }
+      quantityValues: {
+        value: number
+        quantityTypeId: string
+        quantityType: {
+          name: string
+          unitId: string | null
+        }
+      }[]
+    }
     Staircase: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       features: {
-        floorPlan: string | null;
-        accessibleByElevator: boolean;
-      };
+        floorPlan: string | null
+        accessibleByElevator: boolean
+      }
       dates: {
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
-      };
+        to: string
+      }
       property?: {
-        propertyId: string | null;
-        propertyName: string | null;
-        propertyCode: string | null;
-      };
+        propertyId: string | null
+        propertyName: string | null
+        propertyCode: string | null
+      }
       building?: {
-        buildingId: string | null;
-        buildingName: string | null;
-        buildingCode: string | null;
-      };
-      deleted: boolean;
-      timestamp: string;
-    };
+        buildingId: string | null
+        buildingName: string | null
+        buildingCode: string | null
+      }
+      deleted: boolean
+      timestamp: string
+    }
     Room: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
       usage: {
-        shared: boolean;
-        allowPeriodicWorks: boolean;
-        spaceType: number;
-      };
+        shared: boolean
+        allowPeriodicWorks: boolean
+        spaceType: number
+      }
       features: {
-        hasToilet: boolean;
-        isHeated: boolean;
-        hasThermostatValve: boolean;
-        orientation: number;
-      };
+        hasToilet: boolean
+        isHeated: boolean
+        hasThermostatValve: boolean
+        orientation: number
+      }
       dates: {
         /** Format: date-time */
-        installation: string | null;
+        installation: string | null
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
+        to: string
         /** Format: date-time */
-        availableFrom: string | null;
+        availableFrom: string | null
         /** Format: date-time */
-        availableTo: string | null;
-      };
-      sortingOrder: number;
-      deleted: boolean;
-      timestamp: string;
-      roomType: ({
-        id: string;
-        code: string;
-        name: string | null;
-        use: number;
-        optionAllowed: number;
-        isSystemStandard: number;
-        allowSmallRoomsInValuation: number;
-        timestamp: string;
-      }) | null;
-      area?: number;
-    };
+        availableTo: string | null
+      }
+      sortingOrder: number
+      deleted: boolean
+      timestamp: string
+      roomType: {
+        id: string
+        code: string
+        name: string | null
+        use: number
+        optionAllowed: number
+        isSystemStandard: number
+        allowSmallRoomsInValuation: number
+        timestamp: string
+      } | null
+      area?: number
+    }
     CreateRoomRequest: {
-      rentalId: string;
+      rentalId: string
       /** @enum {string} */
-      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
-      code?: string;
-      caption?: string;
+      roomTypeCode:
+        | 'BAD'
+        | 'BAL'
+        | 'BRS'
+        | 'DUSCH'
+        | 'FÖR'
+        | 'GROV'
+        | 'HALL'
+        | 'KLÄD'
+        | 'KÖK'
+        | 'KOV'
+        | 'KV'
+        | 'MAT'
+        | 'PA'
+        | 'RUM'
+        | 'TRAPP'
+        | 'UP'
+        | 'VARD'
+        | 'WC'
+        | 'WC/DU1'
+      code?: string
+      caption?: string
       features?: {
-        hasToilet?: boolean;
-        isHeated?: boolean;
-        hasThermostatValve?: boolean;
-        orientation?: number;
-      };
+        hasToilet?: boolean
+        isHeated?: boolean
+        hasThermostatValve?: boolean
+        orientation?: number
+      }
       usage?: {
-        shared?: boolean;
-        allowPeriodicWorks?: boolean;
-        spaceType?: number;
-      };
-    };
+        shared?: boolean
+        allowPeriodicWorks?: boolean
+        spaceType?: number
+      }
+    }
     ParkingSpace: {
-      rentalId: string;
-      companyCode: string;
-      companyName: string;
-      managementUnitCode: string;
-      managementUnitName: string;
-      propertyCode: string;
-      propertyName: string;
-      buildingCode: string | null;
-      buildingName: string | null;
+      rentalId: string
+      companyCode: string
+      companyName: string
+      managementUnitCode: string
+      managementUnitName: string
+      propertyCode: string
+      propertyName: string
+      buildingCode: string | null
+      buildingName: string | null
       parkingSpace: {
-        propertyObjectId: string;
-        code: string;
-        name: string;
-        parkingNumber: string;
+        propertyObjectId: string
+        code: string
+        name: string
+        parkingNumber: string
         parkingSpaceType: {
-          code: string;
-          name: string;
-        };
-      };
+          code: string
+          name: string
+        }
+      }
       address: {
-        streetAddress: string | null;
-        streetAddress2: string | null;
-        postalCode: string | null;
-        city: string | null;
-      };
-    };
+        streetAddress: string | null
+        streetAddress2: string | null
+        postalCode: string | null
+        city: string | null
+      }
+    }
     MaintenanceUnit: {
-      id: string;
-      propertyObjectId: string;
-      rentalPropertyId?: string;
-      code: string;
-      caption: string | null;
-      type?: string | null;
-      estateCode: string | null;
-      estate: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      rentalPropertyId?: string
+      code: string
+      caption: string | null
+      type?: string | null
+      estateCode: string | null
+      estate: string | null
+    }
     FacilityDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
-      entrance: string | null;
-      deleted: boolean;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
+      entrance: string | null
+      deleted: boolean
       type: {
-        code: string;
-        name: string | null;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        code: string
+        name: string | null
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      areaSize: number | null;
-    };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      areaSize: number | null
+    }
     RentalBlock: {
-      id: string;
-      blockReasonId: string;
-      blockReason: string;
+      id: string
+      blockReasonId: string
+      blockReason: string
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-    };
+      toDate: string | null
+      amount: number | null
+    }
     RentalBlockWithRentalObject: {
-      id: string;
-      blockReasonId: string | null;
-      blockReason: string | null;
+      id: string
+      blockReasonId: string | null
+      blockReason: string | null
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-      distrikt: string | null;
+      toDate: string | null
+      amount: number | null
+      distrikt: string | null
       rentalObject: {
-        code: string | null;
-        name: string | null;
+        code: string | null
+        name: string | null
         /** @enum {string} */
-        category: "Bostad" | "Bilplats" | "Lokal" | "Förråd" | "Övrigt";
-        address: string | null;
-        rentalId: string | null;
-        residenceId: string | null;
-        yearlyRent: number;
-        type: string | null;
-      };
+        category: 'Bostad' | 'Bilplats' | 'Lokal' | 'Förråd' | 'Övrigt'
+        address: string | null
+        rentalId: string | null
+        residenceId: string | null
+        yearlyRent: number
+        type: string | null
+      }
       building: {
-        code: string | null;
-        name: string | null;
-      };
+        code: string | null
+        name: string | null
+      }
       property: {
-        code: string | null;
-        name: string | null;
-      };
-    };
+        code: string | null
+        name: string | null
+      }
+    }
     FacilitySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a facility result
        * @enum {string}
        */
-      type: "facility";
+      type: 'facility'
       /** @description Name of the facility */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the facility */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the facility */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the facility */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ResidenceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a residence result
        * @enum {string}
        */
-      type: "residence";
+      type: 'residence'
       /** @description Name of the residence */
-      name: string | null;
+      name: string | null
       /** @description Rental object ID of the residence */
-      rentalId: string | null;
+      rentalId: string | null
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the residence */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ParkingSpaceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a parking space result
        * @enum {string}
        */
-      type: "parking-space";
+      type: 'parking-space'
       /** @description Name of the parking space */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the parking space */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the parking space */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     Component: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      modelId: string;
-      serialNumber: string | null;
-      specifications?: string | null;
-      additionalInformation?: string | null;
-      warrantyStartDate: string | null;
-      warrantyMonths: number;
-      priceAtPurchase: number;
-      depreciationPriceAtPurchase: number;
-      ncsCode?: string | null;
+      modelId: string
+      serialNumber: string | null
+      specifications?: string | null
+      additionalInformation?: string | null
+      warrantyStartDate: string | null
+      warrantyMonths: number
+      priceAtPurchase: number
+      depreciationPriceAtPurchase: number
+      ncsCode?: string | null
       /** @enum {string} */
-      status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      lastInspectionDate?: string | null;
-      quantity: number;
-      economicLifespan: number;
-      createdAt: string;
-      updatedAt: string;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      lastInspectionDate?: string | null
+      quantity: number
+      economicLifespan: number
+      createdAt: string
+      updatedAt: string
       model?: {
         /** Format: uuid */
-        id: string;
-        modelName: string;
+        id: string
+        modelName: string
         /** Format: uuid */
-        componentSubtypeId: string;
-        currentPrice: number;
-        currentInstallPrice: number;
-        warrantyMonths: number;
-        manufacturer: string;
-        technicalSpecification: string | null;
-        installationInstructions: string | null;
-        dimensions: string | null;
-        coclassCode: string | null;
-        createdAt: string;
-        updatedAt: string;
+        componentSubtypeId: string
+        currentPrice: number
+        currentInstallPrice: number
+        warrantyMonths: number
+        manufacturer: string
+        technicalSpecification: string | null
+        installationInstructions: string | null
+        dimensions: string | null
+        coclassCode: string | null
+        createdAt: string
+        updatedAt: string
         subtype?: {
           /** Format: uuid */
-          id: string;
-          subTypeName: string;
+          id: string
+          subTypeName: string
           /** Format: uuid */
-          typeId: string;
-          xpandCode: string | null;
-          depreciationPrice: number;
-          technicalLifespan: number;
-          economicLifespan: number;
-          replacementIntervalMonths: number;
+          typeId: string
+          xpandCode: string | null
+          depreciationPrice: number
+          technicalLifespan: number
+          economicLifespan: number
+          replacementIntervalMonths: number
           /** @enum {string} */
-          quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-          createdAt: string;
-          updatedAt: string;
+          quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+          createdAt: string
+          updatedAt: string
           componentType?: {
             /** Format: uuid */
-            id: string;
-            typeName: string;
+            id: string
+            typeName: string
             /** Format: uuid */
-            categoryId: string;
-            description: string | null;
-            createdAt: string;
-            updatedAt: string;
+            categoryId: string
+            description: string | null
+            createdAt: string
+            updatedAt: string
             category?: {
               /** Format: uuid */
-              id: string;
-              categoryName: string;
-              description: string;
-              createdAt: string;
-              updatedAt: string;
-            };
-          };
-        };
-      };
-      componentInstallations?: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          componentId: string;
-          spaceId: string | null;
-          /** @enum {string} */
-          spaceType: "OBJECT" | "PropertyObject";
-          installationDate: string | null;
-          deinstallationDate: string | null;
-          orderNumber?: string | null;
-          cost: number;
-          createdAt: string;
-          updatedAt: string;
-          propertyObject?: ({
-            id: string;
-            propertyStructures?: ({
-                roomId?: string | null;
-                roomCode?: string | null;
-                roomName?: string | null;
-                residenceId?: string | null;
-                residenceCode?: string | null;
-                residenceName?: string | null;
-                rentalId?: string | null;
-                buildingCode?: string | null;
-                buildingName?: string | null;
-                residence?: {
-                  id: string;
-                } | null;
-              })[];
-          }) | null;
-        })[];
-    };
+              id: string
+              categoryName: string
+              description: string
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      componentInstallations?: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        componentId: string
+        spaceId: string | null
+        /** @enum {string} */
+        spaceType: 'OBJECT' | 'PropertyObject'
+        installationDate: string | null
+        deinstallationDate: string | null
+        orderNumber?: string | null
+        cost: number
+        createdAt: string
+        updatedAt: string
+        propertyObject?: {
+          id: string
+          propertyStructures?: {
+            roomId?: string | null
+            roomCode?: string | null
+            roomName?: string | null
+            residenceId?: string | null
+            residenceCode?: string | null
+            residenceName?: string | null
+            rentalId?: string | null
+            buildingCode?: string | null
+            buildingName?: string | null
+            residence?: {
+              id: string
+            } | null
+          }[]
+        } | null
+      }[]
+    }
     ComponentCategory: {
       /** Format: uuid */
-      id: string;
-      categoryName: string;
-      description: string;
-      createdAt: string;
-      updatedAt: string;
-    };
+      id: string
+      categoryName: string
+      description: string
+      createdAt: string
+      updatedAt: string
+    }
     ComponentType: {
       /** Format: uuid */
-      id: string;
-      typeName: string;
+      id: string
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description: string | null;
-      createdAt: string;
-      updatedAt: string;
+      categoryId: string
+      description: string | null
+      createdAt: string
+      updatedAt: string
       category?: {
         /** Format: uuid */
-        id: string;
-        categoryName: string;
-        description: string;
-        createdAt: string;
-        updatedAt: string;
-      };
-    };
+        id: string
+        categoryName: string
+        description: string
+        createdAt: string
+        updatedAt: string
+      }
+    }
     ComponentSubtype: {
       /** Format: uuid */
-      id: string;
-      subTypeName: string;
+      id: string
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode: string | null;
-      depreciationPrice: number;
-      technicalLifespan: number;
-      economicLifespan: number;
-      replacementIntervalMonths: number;
+      typeId: string
+      xpandCode: string | null
+      depreciationPrice: number
+      technicalLifespan: number
+      economicLifespan: number
+      replacementIntervalMonths: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-      createdAt: string;
-      updatedAt: string;
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+      createdAt: string
+      updatedAt: string
       componentType?: {
         /** Format: uuid */
-        id: string;
-        typeName: string;
+        id: string
+        typeName: string
         /** Format: uuid */
-        categoryId: string;
-        description: string | null;
-        createdAt: string;
-        updatedAt: string;
+        categoryId: string
+        description: string | null
+        createdAt: string
+        updatedAt: string
         category?: {
           /** Format: uuid */
-          id: string;
-          categoryName: string;
-          description: string;
-          createdAt: string;
-          updatedAt: string;
-        };
-      };
-    };
+          id: string
+          categoryName: string
+          description: string
+          createdAt: string
+          updatedAt: string
+        }
+      }
+    }
     ComponentModel: {
       /** Format: uuid */
-      id: string;
-      modelName: string;
+      id: string
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
-      currentPrice: number;
-      currentInstallPrice: number;
-      warrantyMonths: number;
-      manufacturer: string;
-      technicalSpecification: string | null;
-      installationInstructions: string | null;
-      dimensions: string | null;
-      coclassCode: string | null;
-      createdAt: string;
-      updatedAt: string;
+      componentSubtypeId: string
+      currentPrice: number
+      currentInstallPrice: number
+      warrantyMonths: number
+      manufacturer: string
+      technicalSpecification: string | null
+      installationInstructions: string | null
+      dimensions: string | null
+      coclassCode: string | null
+      createdAt: string
+      updatedAt: string
       subtype?: {
         /** Format: uuid */
-        id: string;
-        subTypeName: string;
+        id: string
+        subTypeName: string
         /** Format: uuid */
-        typeId: string;
-        xpandCode: string | null;
-        depreciationPrice: number;
-        technicalLifespan: number;
-        economicLifespan: number;
-        replacementIntervalMonths: number;
+        typeId: string
+        xpandCode: string | null
+        depreciationPrice: number
+        technicalLifespan: number
+        economicLifespan: number
+        replacementIntervalMonths: number
         /** @enum {string} */
-        quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-        createdAt: string;
-        updatedAt: string;
+        quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+        createdAt: string
+        updatedAt: string
         componentType?: {
           /** Format: uuid */
-          id: string;
-          typeName: string;
+          id: string
+          typeName: string
           /** Format: uuid */
-          categoryId: string;
-          description: string | null;
-          createdAt: string;
-          updatedAt: string;
+          categoryId: string
+          description: string | null
+          createdAt: string
+          updatedAt: string
           category?: {
             /** Format: uuid */
-            id: string;
-            categoryName: string;
-            description: string;
-            createdAt: string;
-            updatedAt: string;
-          };
-        };
-      };
-    };
+            id: string
+            categoryName: string
+            description: string
+            createdAt: string
+            updatedAt: string
+          }
+        }
+      }
+    }
     ComponentInstallation: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      componentId: string;
-      spaceId: string | null;
+      componentId: string
+      spaceId: string | null
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
-      installationDate: string | null;
-      deinstallationDate: string | null;
-      orderNumber?: string | null;
-      cost: number;
-      createdAt: string;
-      updatedAt: string;
+      spaceType: 'OBJECT' | 'PropertyObject'
+      installationDate: string | null
+      deinstallationDate: string | null
+      orderNumber?: string | null
+      cost: number
+      createdAt: string
+      updatedAt: string
       component?: {
         /** Format: uuid */
-        id: string;
+        id: string
         /** Format: uuid */
-        modelId: string;
-        serialNumber: string | null;
-        specifications?: string | null;
-        additionalInformation?: string | null;
-        warrantyStartDate: string | null;
-        warrantyMonths: number;
-        priceAtPurchase: number;
-        depreciationPriceAtPurchase: number;
-        ncsCode?: string | null;
+        modelId: string
+        serialNumber: string | null
+        specifications?: string | null
+        additionalInformation?: string | null
+        warrantyStartDate: string | null
+        warrantyMonths: number
+        priceAtPurchase: number
+        depreciationPriceAtPurchase: number
+        ncsCode?: string | null
         /** @enum {string} */
-        status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+        status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
         /** @enum {string|null} */
-        condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-        lastInspectionDate?: string | null;
-        quantity: number;
-        economicLifespan: number;
-        createdAt: string;
-        updatedAt: string;
+        condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+        lastInspectionDate?: string | null
+        quantity: number
+        economicLifespan: number
+        createdAt: string
+        updatedAt: string
         model?: {
           /** Format: uuid */
-          id: string;
-          modelName: string;
+          id: string
+          modelName: string
           /** Format: uuid */
-          componentSubtypeId: string;
-          currentPrice: number;
-          currentInstallPrice: number;
-          warrantyMonths: number;
-          manufacturer: string;
-          technicalSpecification: string | null;
-          installationInstructions: string | null;
-          dimensions: string | null;
-          coclassCode: string | null;
-          createdAt: string;
-          updatedAt: string;
+          componentSubtypeId: string
+          currentPrice: number
+          currentInstallPrice: number
+          warrantyMonths: number
+          manufacturer: string
+          technicalSpecification: string | null
+          installationInstructions: string | null
+          dimensions: string | null
+          coclassCode: string | null
+          createdAt: string
+          updatedAt: string
           subtype?: {
             /** Format: uuid */
-            id: string;
-            subTypeName: string;
+            id: string
+            subTypeName: string
             /** Format: uuid */
-            typeId: string;
-            xpandCode: string | null;
-            depreciationPrice: number;
-            technicalLifespan: number;
-            economicLifespan: number;
-            replacementIntervalMonths: number;
+            typeId: string
+            xpandCode: string | null
+            depreciationPrice: number
+            technicalLifespan: number
+            economicLifespan: number
+            replacementIntervalMonths: number
             /** @enum {string} */
-            quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-            createdAt: string;
-            updatedAt: string;
+            quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+            createdAt: string
+            updatedAt: string
             componentType?: {
               /** Format: uuid */
-              id: string;
-              typeName: string;
+              id: string
+              typeName: string
               /** Format: uuid */
-              categoryId: string;
-              description: string | null;
-              createdAt: string;
-              updatedAt: string;
+              categoryId: string
+              description: string | null
+              createdAt: string
+              updatedAt: string
               category?: {
                 /** Format: uuid */
-                id: string;
-                categoryName: string;
-                description: string;
-                createdAt: string;
-                updatedAt: string;
-              };
-            };
-          };
-        };
-        componentInstallations?: ({
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            componentId: string;
-            spaceId: string | null;
-            spaceType: components["schemas"]["ComponentInstallation"]["spaceType"];
-            installationDate: string | null;
-            deinstallationDate: string | null;
-            orderNumber?: string | null;
-            cost: number;
-            createdAt: string;
-            updatedAt: string;
-            propertyObject?: ({
-              id: string;
-              propertyStructures?: ({
-                  roomId?: string | null;
-                  roomCode?: string | null;
-                  roomName?: string | null;
-                  residenceId?: string | null;
-                  residenceCode?: string | null;
-                  residenceName?: string | null;
-                  rentalId?: string | null;
-                  buildingCode?: string | null;
-                  buildingName?: string | null;
-                  residence?: {
-                    id: string;
-                  } | null;
-                })[];
-            }) | null;
-          })[];
-      };
-    };
+                id: string
+                categoryName: string
+                description: string
+                createdAt: string
+                updatedAt: string
+              }
+            }
+          }
+        }
+        componentInstallations?: {
+          /** Format: uuid */
+          id: string
+          /** Format: uuid */
+          componentId: string
+          spaceId: string | null
+          spaceType: components['schemas']['ComponentInstallation']['spaceType']
+          installationDate: string | null
+          deinstallationDate: string | null
+          orderNumber?: string | null
+          cost: number
+          createdAt: string
+          updatedAt: string
+          propertyObject?: {
+            id: string
+            propertyStructures?: {
+              roomId?: string | null
+              roomCode?: string | null
+              roomName?: string | null
+              residenceId?: string | null
+              residenceCode?: string | null
+              residenceName?: string | null
+              rentalId?: string | null
+              buildingCode?: string | null
+              buildingName?: string | null
+              residence?: {
+                id: string
+              } | null
+            }[]
+          } | null
+        }[]
+      }
+    }
     CreateComponentCategoryRequest: {
-      categoryName: string;
-      description: string;
-    };
+      categoryName: string
+      description: string
+    }
     UpdateComponentCategoryRequest: {
-      categoryName?: string;
-      description?: string;
-    };
+      categoryName?: string
+      description?: string
+    }
     CreateComponentTypeRequest: {
-      typeName: string;
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description?: string;
-    };
+      categoryId: string
+      description?: string
+    }
     UpdateComponentTypeRequest: {
-      typeName?: string;
+      typeName?: string
       /** Format: uuid */
-      categoryId?: string;
-      description?: string;
-    };
+      categoryId?: string
+      description?: string
+    }
     CreateComponentSubtypeRequest: {
-      subTypeName: string;
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode?: string;
+      typeId: string
+      xpandCode?: string
       /** @default 0 */
-      depreciationPrice?: number;
+      depreciationPrice?: number
       /** @default 0 */
-      technicalLifespan?: number;
+      technicalLifespan?: number
       /** @default 0 */
-      economicLifespan?: number;
+      economicLifespan?: number
       /** @default 0 */
-      replacementIntervalMonths?: number;
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     UpdateComponentSubtypeRequest: {
-      subTypeName?: string;
+      subTypeName?: string
       /** Format: uuid */
-      typeId?: string;
-      xpandCode?: string;
-      depreciationPrice?: number;
-      technicalLifespan?: number;
-      economicLifespan?: number;
-      replacementIntervalMonths?: number;
+      typeId?: string
+      xpandCode?: string
+      depreciationPrice?: number
+      technicalLifespan?: number
+      economicLifespan?: number
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType?: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType?: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     CreateComponentModelRequest: {
-      modelName: string;
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
+      componentSubtypeId: string
       /** @default 0 */
-      currentPrice?: number;
+      currentPrice?: number
       /** @default 0 */
-      currentInstallPrice?: number;
+      currentInstallPrice?: number
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default */
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     UpdateComponentModelRequest: {
-      modelName?: string;
+      modelName?: string
       /** Format: uuid */
-      componentSubtypeId?: string;
-      currentPrice?: number;
-      currentInstallPrice?: number;
-      warrantyMonths?: number;
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      componentSubtypeId?: string
+      currentPrice?: number
+      currentInstallPrice?: number
+      warrantyMonths?: number
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     CreateComponentRequest: {
       /** Format: uuid */
-      modelId: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
+      warrantyStartDate?: string
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default 0 */
-      priceAtPurchase?: number;
+      priceAtPurchase?: number
       /** @default 0 */
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /**
        * @default ACTIVE
        * @enum {string}
        */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
       /** @default 1 */
-      quantity?: number;
+      quantity?: number
       /** @default 0 */
-      economicLifespan?: number;
-      files?: string;
-    };
+      economicLifespan?: number
+      files?: string
+    }
     UpdateComponentRequest: {
       /** Format: uuid */
-      modelId?: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId?: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
-      warrantyMonths?: number;
-      priceAtPurchase?: number;
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      warrantyStartDate?: string
+      warrantyMonths?: number
+      priceAtPurchase?: number
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /** @enum {string} */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      quantity?: number;
-      economicLifespan?: number;
-      files?: string;
-    };
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      quantity?: number
+      economicLifespan?: number
+      files?: string
+    }
     CreateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId: string;
-      spaceId?: string;
+      componentId: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
+      spaceType: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string | null;
+      installationDate?: string | null
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost: number
+    }
     UpdateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId?: string;
-      spaceId?: string;
+      componentId?: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType?: "OBJECT" | "PropertyObject";
+      spaceType?: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string;
+      installationDate?: string
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost?: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost?: number
+    }
     DocumentWithUrl: {
-      id: string;
-      fileId: string;
-      originalName: string;
-      mimeType: string;
-      size: number;
-      createdAt: string;
-      url: string;
-      uploadedAt?: string;
-      caption?: string;
-    };
+      id: string
+      fileId: string
+      originalName: string
+      mimeType: string
+      size: number
+      createdAt: string
+      url: string
+      uploadedAt?: string
+      caption?: string
+    }
     AnalyzeComponentImageRequest: {
-      image: string;
-      additionalImage?: string;
-    };
+      image: string
+      additionalImage?: string
+    }
     AIComponentAnalysis: {
-      componentType: string | null;
-      componentSubtype: string | null;
-      manufacturer: string | null;
-      model: string | null;
-      serialNumber: string | null;
-      estimatedAge: string | null;
-      condition: string | null;
-      specifications: string | null;
-      dimensions: string | null;
-      warrantyMonths: number | null;
-      ncsCode: string | null;
-      additionalInformation: string | null;
-      confidence: number;
-    };
+      componentType: string | null
+      componentSubtype: string | null
+      manufacturer: string | null
+      model: string | null
+      serialNumber: string | null
+      estimatedAge: string | null
+      condition: string | null
+      specifications: string | null
+      dimensions: string | null
+      warrantyMonths: number | null
+      ncsCode: string | null
+      additionalInformation: string | null
+      confidence: number
+    }
     ApartmentTemperaturePoint: {
-      time: number;
-      avg: number | null;
-      min: number | null;
-      max: number | null;
-    };
+      time: number
+      avg: number | null
+      min: number | null
+      max: number | null
+    }
     ApartmentTemperatureSeries: {
-      subNodeId: number;
-      subNodeName: string;
-      points: ({
-          time: number;
-          avg: number | null;
-          min: number | null;
-          max: number | null;
-        })[];
-    };
+      subNodeId: number
+      subNodeName: string
+      points: {
+        time: number
+        avg: number | null
+        min: number | null
+        max: number | null
+      }[]
+    }
     ApartmentTemperaturesResponse: {
-      objectNumber: string;
-      nodeId: number;
-      from: number;
-      to: number;
+      objectNumber: string
+      nodeId: number
+      from: number
+      to: number
       /** @enum {string} */
-      interval: "H" | "D";
-      unit: string;
-      series: ({
-          subNodeId: number;
-          subNodeName: string;
-          points: ({
-              time: number;
-              avg: number | null;
-              min: number | null;
-              max: number | null;
-            })[];
-        })[];
-    };
+      interval: 'H' | 'D'
+      unit: string
+      series: {
+        subNodeId: number
+        subNodeName: string
+        points: {
+          time: number
+          avg: number | null
+          min: number | null
+          max: number | null
+        }[]
+      }[]
+    }
     Key: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeySystem: {
       /** Format: uuid */
-      id: string;
-      systemCode: string;
-      name: string;
-      manufacturer: string;
-      managingSupplier?: string | null;
+      id: string
+      systemCode: string
+      name: string
+      manufacturer: string
+      managingSupplier?: string | null
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+    }
     KeyLoan: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+    }
     KeyDetails: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      keySystem?: components["schemas"]["KeySystem"] | null;
-      loans?: components["schemas"]["KeyLoan"][] | null;
-      events?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
-          /** @enum {string} */
-          status: "ORDERED" | "RECEIVED" | "COMPLETED";
-          /** Format: uuid */
-          workOrderId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[]) | null;
-      activeLoanContact?: string | null;
-    };
+      updatedAt: string
+      keySystem?: components['schemas']['KeySystem'] | null
+      loans?: components['schemas']['KeyLoan'][] | null
+      events?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+            /** @enum {string} */
+            status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+            /** Format: uuid */
+            workOrderId?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+          }[]
+        | null
+      activeLoanContact?: string | null
+    }
     KeyLoanWithDetails: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-      keysArray: ({
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+      keysArray: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: {
-              id: components["schemas"]["KeyLoanWithDetails"]["id"];
-              loanType: components["schemas"]["KeyLoanWithDetails"]["loanType"];
-              contact?: components["schemas"]["KeyLoanWithDetails"]["contact"];
-              contact2?: components["schemas"]["KeyLoanWithDetails"]["contact2"];
-              contactPerson?: components["schemas"]["KeyLoanWithDetails"]["contactPerson"];
-              notes?: components["schemas"]["KeyLoanWithDetails"]["notes"];
-              returnedAt?: components["schemas"]["KeyLoanWithDetails"]["returnedAt"];
-              availableToNextTenantFrom?: components["schemas"]["KeyLoanWithDetails"]["availableToNextTenantFrom"];
-              pickedUpAt?: components["schemas"]["KeyLoanWithDetails"]["pickedUpAt"];
-              createdAt: components["schemas"]["KeyLoanWithDetails"]["createdAt"];
-              updatedAt: components["schemas"]["KeyLoanWithDetails"]["updatedAt"];
-              createdBy?: components["schemas"]["KeyLoanWithDetails"]["createdBy"];
-              updatedBy?: components["schemas"]["KeyLoanWithDetails"]["updatedBy"];
-              keyCount?: components["schemas"]["KeyLoanWithDetails"]["keyCount"];
-              cardCount?: components["schemas"]["KeyLoanWithDetails"]["cardCount"];
-            }[] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?:
+          | {
+              id: components['schemas']['KeyLoanWithDetails']['id']
+              loanType: components['schemas']['KeyLoanWithDetails']['loanType']
+              contact?: components['schemas']['KeyLoanWithDetails']['contact']
+              contact2?: components['schemas']['KeyLoanWithDetails']['contact2']
+              contactPerson?: components['schemas']['KeyLoanWithDetails']['contactPerson']
+              notes?: components['schemas']['KeyLoanWithDetails']['notes']
+              returnedAt?: components['schemas']['KeyLoanWithDetails']['returnedAt']
+              availableToNextTenantFrom?: components['schemas']['KeyLoanWithDetails']['availableToNextTenantFrom']
+              pickedUpAt?: components['schemas']['KeyLoanWithDetails']['pickedUpAt']
+              createdAt: components['schemas']['KeyLoanWithDetails']['createdAt']
+              updatedAt: components['schemas']['KeyLoanWithDetails']['updatedAt']
+              createdBy?: components['schemas']['KeyLoanWithDetails']['createdBy']
+              updatedBy?: components['schemas']['KeyLoanWithDetails']['updatedBy']
+              keyCount?: components['schemas']['KeyLoanWithDetails']['keyCount']
+              cardCount?: components['schemas']['KeyLoanWithDetails']['cardCount']
+            }[]
+          | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-      keyCardsArray: ({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[];
-      receipts: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          keyLoanId: string;
-          /** @enum {string} */
-          receiptType: "LOAN" | "RETURN";
-          /** @enum {string} */
-          type: "DIGITAL" | "PHYSICAL";
-          fileId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+      keyCardsArray: {
+        cardId: string
+        name?: string | null
+        owner?: unknown
+        appearanceCode?: string | null
+        classification?: string | null
+        disabled?: boolean
+        startTime?: string | null
+        stopTime?: string | null
+        createTime: string
+        pinCode?: string | null
+        state?: string | null
+        archivedAt?: string | null
+        codes?: unknown[] | null
+      }[]
+      receipts: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        keyLoanId: string
+        /** @enum {string} */
+        receiptType: 'LOAN' | 'RETURN'
+        /** @enum {string} */
+        type: 'DIGITAL' | 'PHYSICAL'
+        fileId?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+      }[]
+    }
     Log: {
       /** Format: uuid */
-      id: string;
-      userName: string;
+      id: string
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
+      objectId?: string | null
       /** Format: date-time */
-      eventTime: string;
-      description?: string | null;
-      eventTypeLabel?: string;
-      objectTypeLabel?: string;
-    };
+      eventTime: string
+      description?: string | null
+      eventTypeLabel?: string
+      objectTypeLabel?: string
+    }
     KeyNote: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      description: string;
-    };
+      id: string
+      rentalObjectCode: string
+      description: string
+    }
     Receipt: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type: "DIGITAL" | "PHYSICAL";
-      fileId?: string | null;
+      type: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeyEvent: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
+      workOrderId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     Signature: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
-      status: string;
+      recipientEmail: string
+      recipientName?: string | null
+      status: string
       /** Format: date-time */
-      sentAt: string;
+      sentAt: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     CreateKeyRequest: {
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      notes?: string | null
+    }
     UpdateKeyRequest: {
-      keyName?: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName?: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType?: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType?:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      disposed?: boolean;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      disposed?: boolean
+      notes?: string | null
+    }
     BulkUpdateFlexRequest: {
-      rentalObjectCode: string;
-      flexNumber: number;
-    };
+      rentalObjectCode: string
+      flexNumber: number
+    }
     BulkUpdateKeysRequest: {
-      keyIds: string[];
+      keyIds: string[]
       updates: {
-        keyName?: string;
-        flexNumber?: number | null;
+        keyName?: string
+        flexNumber?: number | null
         /** Format: uuid */
-        keySystemId?: string | null;
-        rentalObjectCode?: string;
-        disposed?: boolean;
-        notes?: string | null;
-        clearNotes?: boolean;
-      };
-    };
+        keySystemId?: string | null
+        rentalObjectCode?: string
+        disposed?: boolean
+        notes?: string | null
+        clearNotes?: boolean
+      }
+    }
     CreateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
-      createdBy?: string | null;
-    };
+      availableToNextTenantFrom?: string | null
+      createdBy?: string | null
+    }
     UpdateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType?: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType?: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
-      updatedBy?: string | null;
-    };
+      pickedUpAt?: string | null
+      updatedBy?: string | null
+    }
     CreateKeySystemRequest: {
-      systemCode: string;
-      name: string;
-      manufacturer: string;
+      systemCode: string
+      name: string
+      manufacturer: string
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+    }
     UpdateKeySystemRequest: {
-      systemCode?: string;
-      name?: string;
-      manufacturer?: string;
+      systemCode?: string
+      name?: string
+      manufacturer?: string
       /** @enum {string} */
-      type?: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type?: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
+    }
     CreateLogRequest: {
-      userName: string;
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
-      description?: string | null;
-      autoGenerateDescription?: boolean;
-      entityData?: unknown;
+      objectId?: string | null
+      description?: string | null
+      autoGenerateDescription?: boolean
+      entityData?: unknown
       /** @enum {string} */
-      action?: "Skapad" | "Uppdaterad" | "Kasserad" | "Raderad";
+      action?: 'Skapad' | 'Uppdaterad' | 'Kasserad' | 'Raderad'
       /** Format: date-time */
-      eventTime?: string;
-    };
+      eventTime?: string
+    }
     CreateKeyNoteRequest: {
-      rentalObjectCode: string;
-      description: string;
-    };
+      rentalObjectCode: string
+      description: string
+    }
     UpdateKeyNoteRequest: {
-      rentalObjectCode?: string;
-      description?: string;
-    };
+      rentalObjectCode?: string
+      description?: string
+    }
     KeyBundle: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description?: string | null;
-      keyCount?: number;
-    };
+      id: string
+      name: string
+      description?: string | null
+      keyCount?: number
+    }
     BundleWithLoanedKeysInfo: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description: string | null;
-      loanedKeyCount: number;
-      totalKeyCount: number;
-    };
+      id: string
+      name: string
+      description: string | null
+      loanedKeyCount: number
+      totalKeyCount: number
+    }
     CreateKeyBundleRequest: {
-      name: string;
-      keys: string[];
-      description?: string | null;
-    };
+      name: string
+      keys: string[]
+      description?: string | null
+    }
     UpdateKeyBundleRequest: {
-      name?: string;
-      keys?: string[];
-      description?: string | null;
-    };
+      name?: string
+      keys?: string[]
+      description?: string | null
+    }
     KeyBundleDetailsResponse: {
       bundle: {
         /** Format: uuid */
-        id: string;
-        name: string;
-        description?: string | null;
-        keyCount?: number;
-      };
-      keys: ({
+        id: string
+        name: string
+        description?: string | null
+        keyCount?: number
+      }
+      keys: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: components["schemas"]["KeyLoan"][] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?: components['schemas']['KeyLoan'][] | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+    }
     CreateKeyEventRequest: {
-      keys: string[];
+      keys: string[]
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     UpdateKeyEventRequest: {
-      keys?: string[];
+      keys?: string[]
       /** @enum {string} */
-      type?: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type?: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status?: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status?: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     CreateSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
+      recipientEmail: string
+      recipientName?: string | null
       /** @default sent */
-      status?: string;
-    };
+      status?: string
+    }
     UpdateSignatureRequest: {
-      status?: string;
+      status?: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     SendSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
+      resourceId: string
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string;
-      pdfBase64: string;
-    };
+      recipientEmail: string
+      recipientName?: string
+      pdfBase64: string
+    }
     SimpleSignWebhookPayload: {
-      id: number;
-      status: string;
-      status_updated_at: string;
-    };
+      id: number
+      status: string
+      status_updated_at: string
+    }
     CreateReceiptRequest: {
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type?: "DIGITAL" | "PHYSICAL";
-      fileId?: string;
-      fileData?: string;
-      fileContentType?: string;
-    };
+      type?: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string
+      fileData?: string
+      fileContentType?: string
+    }
     UpdateReceiptRequest: {
-      fileId?: string;
-    };
+      fileId?: string
+    }
     /** @enum {string} */
-    ReceiptType: "LOAN" | "RETURN";
+    ReceiptType: 'LOAN' | 'RETURN'
     /** @enum {string} */
-    ReceiptFormat: "DIGITAL" | "PHYSICAL";
+    ReceiptFormat: 'DIGITAL' | 'PHYSICAL'
     ErrorResponse: {
       /** @example Internal server error */
-      error?: string;
-      reason?: string;
-    };
+      error?: string
+      reason?: string
+    }
     NotFoundResponse: {
       /** @example Resource not found */
-      reason: string;
-    };
+      reason: string
+    }
     BadRequestResponse: {
-      reason: string;
-    };
+      reason: string
+    }
     SchemaDownloadUrlResponse: {
-      url: string;
-      expiresIn: number;
-    };
+      url: string
+      expiresIn: number
+    }
     CardOwner: {
-      cardOwnerId: string;
-      cardOwnerType?: string | null;
-      familyName?: string | null;
-      specificName?: string | null;
-      primaryOrganization?: unknown;
-      cards?: (({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[]) | null;
-      comment?: string | null;
-      folderId?: number | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      pinCode?: string | null;
+      cardOwnerId: string
+      cardOwnerType?: string | null
+      familyName?: string | null
+      specificName?: string | null
+      primaryOrganization?: unknown
+      cards?:
+        | {
+            cardId: string
+            name?: string | null
+            owner?: unknown
+            appearanceCode?: string | null
+            classification?: string | null
+            disabled?: boolean
+            startTime?: string | null
+            stopTime?: string | null
+            createTime: string
+            pinCode?: string | null
+            state?: string | null
+            archivedAt?: string | null
+            codes?: unknown[] | null
+          }[]
+        | null
+      comment?: string | null
+      folderId?: number | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      pinCode?: string | null
       attributes?: {
-        [key: string]: string;
-      } | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      createTime?: string;
-    };
+        [key: string]: string
+      } | null
+      state?: string | null
+      archivedAt?: string | null
+      createTime?: string
+    }
     Card: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+    }
     CardDetails: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-      loans?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          loanType: "TENANT" | "MAINTENANCE";
-          contact?: string | null;
-          contact2?: string | null;
-          contactPerson?: string | null;
-          notes?: string | null;
-          /** Format: date-time */
-          returnedAt?: string | null;
-          /** Format: date-time */
-          availableToNextTenantFrom?: string | null;
-          /** Format: date-time */
-          pickedUpAt?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-          createdBy?: string | null;
-          updatedBy?: string | null;
-          keyCount?: number;
-          cardCount?: number;
-        })[]) | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+      loans?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            loanType: 'TENANT' | 'MAINTENANCE'
+            contact?: string | null
+            contact2?: string | null
+            contactPerson?: string | null
+            notes?: string | null
+            /** Format: date-time */
+            returnedAt?: string | null
+            /** Format: date-time */
+            availableToNextTenantFrom?: string | null
+            /** Format: date-time */
+            pickedUpAt?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+            createdBy?: string | null
+            updatedBy?: string | null
+            keyCount?: number
+            cardCount?: number
+          }[]
+        | null
+    }
     QueryCardOwnersParams: {
-      nameFilter?: string;
-      expand?: string;
-      idfilter?: string;
-      attributeFilter?: string;
-      selectedAttributes?: string;
-      folderFilter?: string;
-      organisationFilter?: string;
-      offset?: number;
-      limit?: number;
-    };
+      nameFilter?: string
+      expand?: string
+      idfilter?: string
+      attributeFilter?: string
+      selectedAttributes?: string
+      folderFilter?: string
+      organisationFilter?: string
+      offset?: number
+      limit?: number
+    }
     PaginatedResponse: {
-      content: unknown[];
+      content: unknown[]
       _meta: {
-        totalRecords: number;
-        page: number;
-        limit: number;
-        count: number;
-      };
-      _links: ({
-          href: string;
-          /** @enum {string} */
-          rel: "self" | "first" | "last" | "prev" | "next";
-        })[];
-    };
+        totalRecords: number
+        page: number
+        limit: number
+        count: number
+      }
+      _links: {
+        href: string
+        /** @enum {string} */
+        rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+      }[]
+    }
     SearchQueryParams: {
       /** @description The search query string used to find properties, buildings and residences */
-      q: string;
-    };
+      q: string
+    }
     PropertySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a property result
        * @enum {string}
        */
-      type: "property";
+      type: 'property'
       /** @description Property code */
-      code: string;
+      code: string
       /** @description Name or designation of the property */
-      name: string;
-    };
+      name: string
+    }
     BuildingSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a building result
        * @enum {string}
        */
-      type: "building";
+      type: 'building'
       /** @description Building code */
-      code: string;
+      code: string
       /** @description Name of the building */
-      name: string | null;
-      property?: ({
+      name: string | null
+      property?: {
         /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    };
+        name: string | null
+        id: string
+        code: string
+      } | null
+    }
     MaintenanceUnitSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a maintenance unit result
        * @enum {string}
        */
-      type: "maintenance-unit";
+      type: 'maintenance-unit'
       /** @description Code of the maintenance unit */
-      code: string;
+      code: string
       /** @description Caption/name of the maintenance unit */
-      caption: string | null;
+      caption: string | null
       /** @description Type of maintenance unit */
-      maintenanceType: string | null;
+      maintenanceType: string | null
       /** @description Property code */
-      estateCode: string | null;
+      estateCode: string | null
       /** @description Property name */
-      estate: string | null;
-    };
+      estate: string | null
+    }
     StaircaseSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a staircase result
        * @enum {string}
        */
-      type: "staircase";
+      type: 'staircase'
       /** @description Code of the staircase */
-      code: string;
+      code: string
       /** @description Name (caption) of the staircase */
-      name: string | null;
+      name: string | null
       property: {
-        code: string;
+        code: string
         /** @description Name of property associated with the staircase */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string;
+        code: string
         /** @description Name of building associated with the staircase */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
-    SearchResult: {
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a property result
-       * @enum {string}
-       */
-      type: "property";
-      /** @description Property code */
-      code: string;
-      /** @description Name or designation of the property */
-      name: string;
-    } | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a building result
-       * @enum {string}
-       */
-      type: "building";
-      /** @description Building code */
-      code: string;
-      /** @description Name of the building */
-      name: string | null;
-      property?: ({
-        /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a residence result
-       * @enum {string}
-       */
-      type: "residence";
-      /** @description Name of the residence */
-      name: string | null;
-      /** @description Rental object ID of the residence */
-      rentalId: string | null;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the residence */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a parking space result
-       * @enum {string}
-       */
-      type: "parking-space";
-      /** @description Name of the parking space */
-      name: string | null;
-      /** @description Rental ID of the parking space */
-      rentalId: string;
-      /** @description Code of the parking space */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a maintenance unit result
-       * @enum {string}
-       */
-      type: "maintenance-unit";
-      /** @description Code of the maintenance unit */
-      code: string;
-      /** @description Caption/name of the maintenance unit */
-      caption: string | null;
-      /** @description Type of maintenance unit */
-      maintenanceType: string | null;
-      /** @description Property code */
-      estateCode: string | null;
-      /** @description Property name */
-      estate: string | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a facility result
-       * @enum {string}
-       */
-      type: "facility";
-      /** @description Name of the facility */
-      name: string | null;
-      /** @description Rental ID of the facility */
-      rentalId: string;
-      /** @description Code of the facility */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the facility */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a staircase result
-       * @enum {string}
-       */
-      type: "staircase";
-      /** @description Code of the staircase */
-      code: string;
-      /** @description Name (caption) of the staircase */
-      name: string | null;
-      property: {
-        code: string;
-        /** @description Name of property associated with the staircase */
-        name: string | null;
-      };
-      building: {
-        code: string;
-        /** @description Name of building associated with the staircase */
-        name: string | null;
-      };
-    });
+    SearchResult:
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a property result
+           * @enum {string}
+           */
+          type: 'property'
+          /** @description Property code */
+          code: string
+          /** @description Name or designation of the property */
+          name: string
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a building result
+           * @enum {string}
+           */
+          type: 'building'
+          /** @description Building code */
+          code: string
+          /** @description Name of the building */
+          name: string | null
+          property?: {
+            /** @description Property associated with the building */
+            name: string | null
+            id: string
+            code: string
+          } | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a residence result
+           * @enum {string}
+           */
+          type: 'residence'
+          /** @description Name of the residence */
+          name: string | null
+          /** @description Rental object ID of the residence */
+          rentalId: string | null
+          property: {
+            code: string | null
+            /** @description Name of property associated with the residence */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the residence */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a parking space result
+           * @enum {string}
+           */
+          type: 'parking-space'
+          /** @description Name of the parking space */
+          name: string | null
+          /** @description Rental ID of the parking space */
+          rentalId: string
+          /** @description Code of the parking space */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the parking space */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the parking space */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a maintenance unit result
+           * @enum {string}
+           */
+          type: 'maintenance-unit'
+          /** @description Code of the maintenance unit */
+          code: string
+          /** @description Caption/name of the maintenance unit */
+          caption: string | null
+          /** @description Type of maintenance unit */
+          maintenanceType: string | null
+          /** @description Property code */
+          estateCode: string | null
+          /** @description Property name */
+          estate: string | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a facility result
+           * @enum {string}
+           */
+          type: 'facility'
+          /** @description Name of the facility */
+          name: string | null
+          /** @description Rental ID of the facility */
+          rentalId: string
+          /** @description Code of the facility */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the facility */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the facility */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a staircase result
+           * @enum {string}
+           */
+          type: 'staircase'
+          /** @description Code of the staircase */
+          code: string
+          /** @description Name (caption) of the staircase */
+          name: string | null
+          property: {
+            code: string
+            /** @description Name of property associated with the staircase */
+            name: string | null
+          }
+          building: {
+            code: string
+            /** @description Name of building associated with the staircase */
+            name: string | null
+          }
+        }
     Inspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              details: string
+            }
+            actions: {
+              details: string[]
+            }
+            componentNotes: {
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
               /** @default */
-              condition?: string;
-              cost?: number;
+              condition?: string
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[]) | null;
-    };
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default false */
+            isAddedInThisInspection?: boolean
+          }[]
+        | null
+    }
     InspectionComponent: {
-      componentId: string;
-      label: string;
-      condition: string;
-      action: string[];
-      note: string;
-      photos: string[];
-      cost?: number;
+      componentId: string
+      label: string
+      condition: string
+      action: string[]
+      note: string
+      photos: string[]
+      cost?: number
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: "tenant" | "landlord" | null;
-    };
+      costResponsibility?: 'tenant' | 'landlord' | null
+    }
     InspectionRoom: {
-      roomId: string;
-      name?: string;
+      roomId: string
+      name?: string
       conditions: {
-        details: string;
-      };
+        details: string
+      }
       actions: {
-        details: string[];
-      };
+        details: string[]
+      }
       componentNotes: {
-        details: string;
-      };
+        details: string
+      }
       componentCosts: {
         /** @default 0 */
-        details?: number;
-      };
+        details?: number
+      }
       componentPhotos: {
-        details: string[];
-      };
+        details: string[]
+      }
       componentCostResponsibilities: {
         /**
          * @default null
          * @enum {string|null}
          */
-        details?: "tenant" | "landlord" | null;
-      };
-      photos: string[];
-      isApproved: boolean;
-      isHandled: boolean;
+        details?: 'tenant' | 'landlord' | null
+      }
+      photos: string[]
+      isApproved: boolean
+      isHandled: boolean
       /** @default [] */
-      detailComponents?: ({
-          id: string;
-          type: string;
-          label: string;
-          note: string;
-          /** @default */
-          condition?: string;
-          cost?: number;
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: "tenant" | "landlord" | null;
-        })[];
+      detailComponents?: {
+        id: string
+        type: string
+        label: string
+        note: string
+        /** @default */
+        condition?: string
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+      }[]
       /** @default [] */
-      components?: ({
-          componentId: string;
-          label: string;
-          condition: string;
-          action: string[];
-          note: string;
-          photos: string[];
-          cost?: number;
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: "tenant" | "landlord" | null;
-        })[];
+      components?: {
+        componentId: string
+        label: string
+        condition: string
+        action: string[]
+        note: string
+        photos: string[]
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+      }[]
       /** @default false */
-      isAddedInThisInspection?: boolean;
-    };
+      isAddedInThisInspection?: boolean
+    }
     DetailedInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12257,379 +12496,379 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
-        /** Format: date-time */
-        leaseStartDate: string;
-        /** Format: date-time */
-        leaseEndDate?: string;
-        /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
-        rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
-          roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
-          /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
-        rentInfo?: {
-          currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
-            /** Format: date-time */
-            rentStartDate?: string;
-            /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
-        address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
-        /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
-        /** Format: date-time */
-        preferredMoveOutDate?: string;
-        /** Format: date-time */
-        terminationDate?: string;
-        /** Format: date-time */
-        contractDate?: string;
-        /** Format: date-time */
-        lastDebitDate?: string;
-        /** Format: date-time */
-        approvalDate?: string;
-        residentialArea?: {
-          code: string;
-          caption: string;
-        };
-        tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
-            /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      residence: ({
-        id: string;
-        code: string;
-        name: string | null;
-        /** @enum {string|null} */
-        status: "VACANT" | "LEASED" | null;
-        entrance: string | null;
-        location: string | null;
-        floor: string | null;
-        partNo: number | null;
-        part: string | null;
-        deleted: boolean;
-        validityPeriod: {
-          /** Format: date-time */
-          fromDate: string;
-          /** Format: date-time */
-          toDate: string;
-        };
-        accessibility: {
-          wheelchairAccessible: boolean;
-          elevator: boolean;
-          residenceAdapted: boolean;
-        };
-        features: {
-          hygieneFacility: string | null;
-          balcony1?: {
-            location: string;
-            type: string;
-          };
-          balcony2?: {
-            location: string;
-            type: string;
-          };
-          patioLocation: string | null;
-          sauna: boolean;
-          extraToilet: boolean;
-          sharedKitchen: boolean;
-          petAllergyFree: boolean;
-          /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean;
-          smokeFree: boolean;
-          asbestos: boolean;
-        };
-        type: {
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-        };
-        residenceType: {
-          residenceTypeId: string;
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-          systemStandard: number;
-          checklistId: string | null;
-          componentTypeActionId: string | null;
-          statisticsGroupSCBId: string | null;
-          statisticsGroup2Id: string | null;
-          statisticsGroup3Id: string | null;
-          statisticsGroup4Id: string | null;
-          timestamp: string;
-        };
-        rentalInformation: ({
-          apartmentNumber: string | null;
-          rentalId: string | null;
-          type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
-        propertyObject: {
-          energy: {
-            energyClass: number;
-            /** Format: date-time */
-            energyRegistered?: string;
-            /** Format: date-time */
-            energyReceived?: string;
-            energyIndex?: number;
-          };
-          rentalId: string | null;
-          rentalInformation: ({
-            type: {
-              code: string;
-              name: string | null;
-            };
-          }) | null;
-          rentalBlocks: ({
-              id: string;
-              blockReasonId: string | null;
-              blockReason: string | null;
-              /** Format: date-time */
-              fromDate: string;
-              /** Format: date-time */
-              toDate: string | null;
-              amount: number | null;
-            })[];
-        };
-        property: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        building: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        staircase: ({
-          id: string;
-          code: string;
-          name: string | null;
-          features: {
-            floorPlan: string | null;
-            accessibleByElevator: boolean;
-          };
-          dates: {
-            /** Format: date-time */
-            from: string;
-            /** Format: date-time */
-            to: string;
-          };
-          property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
-          building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
-          };
-          deleted: boolean;
-          timestamp: string;
-        }) | null;
-        areaSize: number | null;
-        malarEnergiFacilityId: string | null;
-      }) | null;
-    };
-    DetailedInspectionRoom: {
-      room: string;
-      remarks: ({
-          remarkId: string;
-          location: string | null;
-          buildingComponent: string | null;
-          notes: string | null;
-          remarkGrade: number;
-          remarkStatus: string | null;
-          cost: number;
+        electricalSystem?: boolean
+      }
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
           /**
            * @default null
            * @enum {string|null}
            */
-          costResponsibility?: "tenant" | "landlord" | null;
-          invoice: boolean;
-          quantity: number;
-          isMissing: boolean;
+          costResponsibility?: 'tenant' | 'landlord' | null
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
           /** Format: date-time */
-          fixedDate: string | null;
-          workOrderCreated: boolean;
-          workOrderStatus: number | null;
-        })[];
-    };
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+      lease: {
+        leaseId: string
+        leaseNumber: string
+        /** Format: date-time */
+        leaseStartDate: string
+        /** Format: date-time */
+        leaseEndDate?: string
+        /** @enum {string} */
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
+        rentalProperty?: {
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
+          roomTypes?: {
+            roomTypeId: string
+            name: string
+          }[]
+          /** Format: date-time */
+          lastUpdated?: string
+        }
+        type: string
+        rentInfo?: {
+          currentRent: {
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
+            /** Format: date-time */
+            rentStartDate?: string
+            /** Format: date-time */
+            rentEndDate?: string
+          }
+        }
+        address?: {
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
+        /** Format: date-time */
+        noticeDate?: string
+        noticeTimeTenant?: string | number
+        /** Format: date-time */
+        preferredMoveOutDate?: string
+        /** Format: date-time */
+        terminationDate?: string
+        /** Format: date-time */
+        contractDate?: string
+        /** Format: date-time */
+        lastDebitDate?: string
+        /** Format: date-time */
+        approvalDate?: string
+        residentialArea?: {
+          code: string
+          caption: string
+        }
+        tenants?: {
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
+            /** Format: date-time */
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      residence: {
+        id: string
+        code: string
+        name: string | null
+        /** @enum {string|null} */
+        status: 'VACANT' | 'LEASED' | null
+        entrance: string | null
+        location: string | null
+        floor: string | null
+        partNo: number | null
+        part: string | null
+        deleted: boolean
+        validityPeriod: {
+          /** Format: date-time */
+          fromDate: string
+          /** Format: date-time */
+          toDate: string
+        }
+        accessibility: {
+          wheelchairAccessible: boolean
+          elevator: boolean
+          residenceAdapted: boolean
+        }
+        features: {
+          hygieneFacility: string | null
+          balcony1?: {
+            location: string
+            type: string
+          }
+          balcony2?: {
+            location: string
+            type: string
+          }
+          patioLocation: string | null
+          sauna: boolean
+          extraToilet: boolean
+          sharedKitchen: boolean
+          petAllergyFree: boolean
+          /** @description Is the apartment checked for electric allergy intolerance? */
+          electricAllergyIntolerance: boolean
+          smokeFree: boolean
+          asbestos: boolean
+        }
+        type: {
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+        }
+        residenceType: {
+          residenceTypeId: string
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+          systemStandard: number
+          checklistId: string | null
+          componentTypeActionId: string | null
+          statisticsGroupSCBId: string | null
+          statisticsGroup2Id: string | null
+          statisticsGroup3Id: string | null
+          statisticsGroup4Id: string | null
+          timestamp: string
+        }
+        rentalInformation: {
+          apartmentNumber: string | null
+          rentalId: string | null
+          type: {
+            code: string
+            name: string | null
+          }
+        } | null
+        propertyObject: {
+          energy: {
+            energyClass: number
+            /** Format: date-time */
+            energyRegistered?: string
+            /** Format: date-time */
+            energyReceived?: string
+            energyIndex?: number
+          }
+          rentalId: string | null
+          rentalInformation: {
+            type: {
+              code: string
+              name: string | null
+            }
+          } | null
+          rentalBlocks: {
+            id: string
+            blockReasonId: string | null
+            blockReason: string | null
+            /** Format: date-time */
+            fromDate: string
+            /** Format: date-time */
+            toDate: string | null
+            amount: number | null
+          }[]
+        }
+        property: {
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        building: {
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        staircase: {
+          id: string
+          code: string
+          name: string | null
+          features: {
+            floorPlan: string | null
+            accessibleByElevator: boolean
+          }
+          dates: {
+            /** Format: date-time */
+            from: string
+            /** Format: date-time */
+            to: string
+          }
+          property?: {
+            propertyId: string | null
+            propertyName: string | null
+            propertyCode: string | null
+          }
+          building?: {
+            buildingId: string | null
+            buildingName: string | null
+            buildingCode: string | null
+          }
+          deleted: boolean
+          timestamp: string
+        } | null
+        areaSize: number | null
+        malarEnergiFacilityId: string | null
+      } | null
+    }
+    DetailedInspectionRoom: {
+      room: string
+      remarks: {
+        remarkId: string
+        location: string | null
+        buildingComponent: string | null
+        notes: string | null
+        remarkGrade: number
+        remarkStatus: string | null
+        cost: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+        invoice: boolean
+        quantity: number
+        isMissing: boolean
+        /** Format: date-time */
+        fixedDate: string | null
+        workOrderCreated: boolean
+        workOrderStatus: number | null
+      }[]
+    }
     DetailedInspectionRemark: {
-      remarkId: string;
-      location: string | null;
-      buildingComponent: string | null;
-      notes: string | null;
-      remarkGrade: number;
-      remarkStatus: string | null;
-      cost: number;
+      remarkId: string
+      location: string | null
+      buildingComponent: string | null
+      notes: string | null
+      remarkGrade: number
+      remarkStatus: string | null
+      cost: number
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: "tenant" | "landlord" | null;
-      invoice: boolean;
-      quantity: number;
-      isMissing: boolean;
+      costResponsibility?: 'tenant' | 'landlord' | null
+      invoice: boolean
+      quantity: number
+      isMissing: boolean
       /** Format: date-time */
-      fixedDate: string | null;
-      workOrderCreated: boolean;
-      workOrderStatus: number | null;
-    };
+      fixedDate: string | null
+      workOrderCreated: boolean
+      workOrderStatus: number | null
+    }
     TenantContactsResponse: {
       inspection: {
-        id: string;
-        address: string;
-        apartmentCode: string | null;
-      };
+        id: string
+        address: string
+        apartmentCode: string | null
+      }
       new_tenant?: {
         contacts: {
-            fullName: string;
-            emailAddress: string;
-            contactCode: string;
-          }[];
-        contractId: string;
-      };
-      tenant?: components["schemas"]["TenantContactsResponse"]["new_tenant"];
-    };
+          fullName: string
+          emailAddress: string
+          contactCode: string
+        }[]
+        contractId: string
+      }
+      tenant?: components['schemas']['TenantContactsResponse']['new_tenant']
+    }
     SendProtocolRequest: {
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
-    };
+      recipient: 'tenant' | 'new-tenant'
+    }
     SendProtocolResponse: {
-      success: boolean;
+      success: boolean
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
+      recipient: 'tenant' | 'new-tenant'
       sentTo: {
-        emails: string[];
-        contactNames: string[];
-        contractId: string;
-      };
-      error?: string;
-    };
+        emails: string[]
+        contactNames: string[]
+        contractId: string
+      }
+      error?: string
+    }
     CreateInspectionRequest: {
-      status: string;
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12640,185 +12879,185 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-    };
+        electricalSystem?: boolean
+      }
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
+          /** Format: date-time */
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+    }
     UpdateInspectionStatusRequest: {
       /** @enum {string} */
-      status?: "Registrerad" | "Påbörjad" | "Genomförd";
-      inspector?: string;
-    };
+      status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
+      inspector?: string
+    }
     InspectionWithSource: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
       /** @enum {string} */
-      source: "xpand" | "internal";
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      source: 'xpand' | 'internal'
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-    };
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+    }
     InternalInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      residenceId: string;
-      isFurnished: boolean;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      residenceId: string
+      isFurnished: boolean
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
+      endedAt: string | null
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12829,388 +13068,425 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
+        electricalSystem?: boolean
+      }
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              details: string
+            }
+            actions: {
+              details: string[]
+            }
+            componentNotes: {
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
               /** @default */
-              condition?: string;
-              cost?: number;
+              condition?: string
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[]) | null;
-    };
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default false */
+            isAddedInThisInspection?: boolean
+          }[]
+        | null
+    }
     SaveInspectionDraftRequest: {
-      inspectorName: string;
-      rooms: ({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
-              /** @default */
-              condition?: string;
-              cost?: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[];
-      isFurnished: boolean;
-      isTenantPresent?: boolean;
-      isNewTenantPresent?: boolean;
+      inspectorName: string
+      rooms: {
+        roomId: string
+        name?: string
+        conditions: {
+          details: string
+        }
+        actions: {
+          details: string[]
+        }
+        componentNotes: {
+          details: string
+        }
+        componentCosts: {
+          /** @default 0 */
+          details?: number
+        }
+        componentPhotos: {
+          details: string[]
+        }
+        componentCostResponsibilities: {
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          details?: 'tenant' | 'landlord' | null
+        }
+        photos: string[]
+        isApproved: boolean
+        isHandled: boolean
+        /** @default [] */
+        detailComponents?: {
+          id: string
+          type: string
+          label: string
+          note: string
+          /** @default */
+          condition?: string
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+        }[]
+        /** @default [] */
+        components?: {
+          componentId: string
+          label: string
+          condition: string
+          action: string[]
+          note: string
+          photos: string[]
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+        }[]
+        /** @default false */
+        isAddedInThisInspection?: boolean
+      }[]
+      isFurnished: boolean
+      isTenantPresent?: boolean
+      isNewTenantPresent?: boolean
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
+        electricalSystem?: boolean
+      }
       /** Format: date-time */
-      date?: string;
-      type?: string;
-    };
+      date?: string
+      type?: string
+    }
     ComponentWriteBackError: {
-      componentId: string;
-      componentLabel: string;
-      message: string;
-    };
+      componentId: string
+      componentLabel: string
+      message: string
+    }
     AddInspectionRoomRequest: {
       /** @enum {string} */
-      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
-      caption?: string;
-    };
+      roomTypeCode:
+        | 'BAD'
+        | 'BAL'
+        | 'BRS'
+        | 'DUSCH'
+        | 'FÖR'
+        | 'GROV'
+        | 'HALL'
+        | 'KLÄD'
+        | 'KÖK'
+        | 'KOV'
+        | 'KV'
+        | 'MAT'
+        | 'PA'
+        | 'RUM'
+        | 'TRAPP'
+        | 'UP'
+        | 'VARD'
+        | 'WC'
+        | 'WC/DU1'
+      caption?: string
+    }
     FileListItem: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
-    };
+      size: number
+    }
     FileMetadata: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
+      size: number
       /** @description Custom metadata key-value pairs */
       metaData?: {
-        [key: string]: string;
-      };
-    };
+        [key: string]: string
+      }
+    }
     FileUploadRequest: {
       /** @description Target file name/path */
-      fileName: string;
+      fileName: string
       /** @description Base64 encoded file content */
-      fileData: string;
+      fileData: string
       /** @description MIME type of the file */
-      contentType: string;
-    };
+      contentType: string
+    }
     FileUploadResponse: {
       /** @description Stored file name/path */
-      fileName: string;
+      fileName: string
       /** @description Success message */
-      message: string;
-    };
+      message: string
+    }
     FileUrlResponse: {
       /**
        * Format: uri
        * @description Presigned download URL
        */
-      url: string;
+      url: string
       /** @description URL expiry time in seconds */
-      expiresIn: number;
-    };
+      expiresIn: number
+    }
     FileExistsResponse: {
       /** @description Whether the file exists */
-      exists: boolean;
-    };
+      exists: boolean
+    }
     ListFilesResponse: {
       /** @description Array of file metadata objects */
       files: {
-          /** @description Full file path/name */
-          name: string;
-          /**
-           * Format: date-time
-           * @description ISO 8601 timestamp
-           */
-          lastModified: string;
-          /** @description ETag for file version */
-          etag: string;
-          /** @description File size in bytes */
-          size: number;
-        }[];
-    };
+        /** @description Full file path/name */
+        name: string
+        /**
+         * Format: date-time
+         * @description ISO 8601 timestamp
+         */
+        lastModified: string
+        /** @description ETag for file version */
+        etag: string
+        /** @description File size in bytes */
+        size: number
+      }[]
+    }
     ListFilesQuery: {
       /** @description Filter files by prefix */
-      prefix?: string;
-    };
+      prefix?: string
+    }
     FileUrlQuery: {
       /**
        * @description URL expiry time
        * @default 3600
        */
-      expirySeconds?: number;
-    };
+      expirySeconds?: number
+    }
     BulkSmsResult: {
       /** @description Phone numbers that received SMS */
-      successful: string[];
+      successful: string[]
       /** @description Invalid phone numbers */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     BulkEmailResult: {
       /** @description Email addresses that received email */
-      successful: string[];
+      successful: string[]
       /** @description Invalid email addresses */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     KeycloakUser: {
-      id?: string;
-      username?: string;
-      firstName?: string;
-      lastName?: string;
-      email?: string;
-    };
+      id?: string
+      username?: string
+      firstName?: string
+      lastName?: string
+      email?: string
+    }
     RentalPropertyResponse: {
       content?: {
-        id?: string;
-        type?: string;
+        id?: string
+        type?: string
         property?: {
-          rentalTypeCode?: string;
-          rentalType?: string;
-          address?: string;
-          code?: string;
-          number?: string;
-          type?: string;
-          roomTypeCode?: string;
-          entrance?: string;
-          floor?: string;
-          hasElevator?: boolean;
-          washSpace?: string;
-          area?: number;
-          estateCode?: string;
-          estate?: string;
-          buildingCode?: string;
-          building?: string;
-        };
-      };
+          rentalTypeCode?: string
+          rentalType?: string
+          address?: string
+          code?: string
+          number?: string
+          type?: string
+          roomTypeCode?: string
+          entrance?: string
+          floor?: string
+          hasElevator?: boolean
+          washSpace?: string
+          area?: number
+          estateCode?: string
+          estate?: string
+          buildingCode?: string
+          building?: string
+        }
+      }
       _links?: {
         self?: {
-          href?: string;
-        };
+          href?: string
+        }
         link?: {
-          href?: string;
-          templated?: boolean;
-        };
-      };
-    };
-    ContactV1: ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "individual";
-      personal: {
-        nationalRegistrationNumber: string | null;
-        birthDate: string | null;
-        firstName: string | null;
-        lastName: string | null;
-        fullName: string;
-      };
-      trustee?: {
-        contactCode: string;
-        fullName?: string;
-      };
-    }) | ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "organisation";
-      organisation: {
-        organisationNumber: string;
-        name: string;
-      };
-    });
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+          href?: string
+          templated?: boolean
+        }
+      }
+    }
+    ContactV1:
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'individual'
+          personal: {
+            nationalRegistrationNumber: string | null
+            birthDate: string | null
+            firstName: string | null
+            lastName: string | null
+            fullName: string
+          }
+          trustee?: {
+            contactCode: string
+            fullName?: string
+          }
+        }
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'organisation'
+          organisation: {
+            organisationNumber: string
+            name: string
+          }
+        }
+  }
+  responses: never
+  parameters: never
+  requestBodies: never
+  headers: never
+  pathItems: never
 }
 
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 
-export type external = Record<string, never>;
+export type external = Record<string, never>
 
-export type operations = Record<string, never>;
+export type operations = Record<string, never>

--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -3,8 +3,9 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-  '/auth/generatehash': {
+  "/auth/generatehash": {
     /**
      * Generates a salt and hashes the given password using that salt.
      * @description Generates a salt and hashes the given password using that salt. Pass cleartext password as query parameter.
@@ -13,18 +14,18 @@ export interface paths {
       parameters: {
         query: {
           /** @description The cleartext password that should be hashed */
-          password: string
-        }
-      }
+          password: string;
+        };
+      };
       responses: {
         /** @description Hashed password and salt */
         200: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/generatetoken': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/generatetoken": {
     /**
      * Generates a JWT token
      * @description Validates username and password from request body and returns a JWT token.
@@ -32,41 +33,41 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/x-www-form-urlencoded': {
-            username?: string
-            password?: string
-          }
-        }
-      }
+          "application/x-www-form-urlencoded": {
+            username?: string;
+            password?: string;
+          };
+        };
+      };
       responses: {
         /** @description A valid JWT token */
         200: {
           content: {
-            'application/json': {
-              token?: string
-            }
-          }
-        }
+            "application/json": {
+              token?: string;
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
-              errorMessage?: string
-            }
-          }
-        }
+            "application/json": {
+              errorMessage?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/auth/login': {
+            "application/json": {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/auth/login": {
     /**
      * Redirects to Keycloak login
      * @description Redirects the user to the Keycloak login page
@@ -75,12 +76,12 @@ export interface paths {
       responses: {
         /** @description Redirect to Keycloak login */
         302: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/callback': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/callback": {
     /**
      * OAuth callback endpoint
      * @description Handles the OAuth callback from Keycloak
@@ -88,21 +89,21 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            code?: string
-            redirectUri?: string
-          }
-        }
-      }
+          "application/json": {
+            code?: string;
+            redirectUri?: string;
+          };
+        };
+      };
       responses: {
         /** @description User profile information */
         200: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/logout': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/logout": {
     /**
      * Logout endpoint
      * @description Clears authentication cookies and redirects to Keycloak logout
@@ -111,12 +112,12 @@ export interface paths {
       responses: {
         /** @description Redirect to login page */
         302: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/profile': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/profile": {
     /**
      * Get user profile
      * @description Returns the authenticated user's profile information
@@ -125,16 +126,16 @@ export interface paths {
       responses: {
         /** @description User profile information */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Unauthorized */
         401: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/refresh': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/refresh": {
     /**
      * Refresh access token
      * @description Uses refresh_token cookie to get new access_token
@@ -143,16 +144,16 @@ export interface paths {
       responses: {
         /** @description Token refreshed successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid or expired refresh token */
         401: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/roles/{roleName}/users': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/roles/{roleName}/users": {
     /**
      * Get users by realm role (via group membership)
      * @description Returns all users that belong to groups assigned the given Keycloak realm role. Users are deduplicated across groups.
@@ -161,44 +162,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The name of the Keycloak realm role */
-          roleName: string
-        }
-      }
+          roleName: string;
+        };
+      };
       responses: {
         /** @description List of users with the given role */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeycloakUser'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeycloakUser"][];
+            };
+          };
+        };
         /** @description Unauthorized */
         401: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Forbidden — insufficient permissions to query role members */
         403: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Role not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Keycloak unreachable */
         502: {
-          content: never
-        }
-      }
-    }
-  }
-  openapi: {}
-  security: {}
-  '/sendBulkSms': {
+          content: never;
+        };
+      };
+    };
+  };
+  "openapi": {
+  };
+  "security": {
+  };
+  "/sendBulkSms": {
     /**
      * Send SMS to multiple contacts
      * @description Send SMS messages to multiple phone numbers
@@ -206,35 +209,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Array of phone numbers */
-            phoneNumbers: string[]
+            phoneNumbers: string[];
             /** @description SMS message content */
-            text: string
-          }
-        }
-      }
+            text: string;
+          };
+        };
+      };
       responses: {
         /** @description SMS sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BulkSmsResult']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BulkSmsResult"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/sendBulkEmail': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/sendBulkEmail": {
     /**
      * Send email to multiple contacts
      * @description Send email messages to multiple email addresses
@@ -242,37 +245,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Array of email addresses */
-            emails: string[]
+            emails: string[];
             /** @description Email subject */
-            subject: string
+            subject: string;
             /** @description Email message content */
-            text: string
-          }
-        }
-      }
+            text: string;
+          };
+        };
+      };
       responses: {
         /** @description Email sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BulkEmailResult']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BulkEmailResult"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/getLinearTickets': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/getLinearTickets": {
     /**
      * Get Linear tickets with mimer-visible label
      * @description Fetch Linear issues that have the mimer-visible label
@@ -281,24 +284,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of tickets to fetch */
-          first?: number
+          first?: number;
           /** @description Cursor for pagination */
-          after?: string
-        }
-      }
+          after?: string;
+        };
+      };
       responses: {
         /** @description Linear tickets fetched successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/createLinearErrand': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/createLinearErrand": {
     /**
      * Create a new Linear errand
      * @description Create a new issue in Linear with specified team, project, and labels
@@ -306,33 +309,33 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Errand title */
-            title: string
+            title: string;
             /** @description Errand description */
-            description: string
+            description: string;
             /** @description Label ID for category (Bug, Improvement, etc.) */
-            categoryLabelId: string
-          }
-        }
-      }
+            categoryLabelId: string;
+          };
+        };
+      };
       responses: {
         /** @description Linear errand created successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/getLinearLabels': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/getLinearLabels": {
     /**
      * Get Linear category labels
      * @description Fetch available category labels (Bug, Improvement, new feature)
@@ -341,16 +344,16 @@ export interface paths {
       responses: {
         /** @description Linear labels fetched successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/health': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/health": {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -360,35 +363,35 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /**
                * @description Name of the system.
                * @example core
                */
-              name?: string
+              name?: string;
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string
-              subsystems?: {
-                /** @description Name of the subsystem. */
-                name?: string
-                /**
-                 * @description Status of the subsystem.
-                 * @enum {string}
-                 */
-                status?: 'active' | 'impaired' | 'failure' | 'unknown'
-                /** @description Additional details about the subsystem status. */
-                details?: string
-              }[]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/leases/search': {
+              status?: string;
+              subsystems?: ({
+                  /** @description Name of the subsystem. */
+                  name?: string;
+                  /**
+                   * @description Status of the subsystem.
+                   * @enum {string}
+                   */
+                  status?: "active" | "impaired" | "failure" | "unknown";
+                  /** @description Additional details about the subsystem status. */
+                  details?: string;
+                })[];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/leases/search": {
     /**
      * Search and filter leases
      * @description Search leases with comprehensive filtering options including text search, object type, status, date ranges, and property hierarchy filters.
@@ -397,70 +400,64 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking)) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
+          buildingManager?: string[];
           /** @description Page number */
-          page?: number
+          page?: number;
           /** @description Items per page */
-          limit?: number
+          limit?: number;
           /** @description Include Upphört (ended) contracts. Excluded by default for performance. */
-          includeEnded?: boolean
+          includeEnded?: boolean;
           /** @description Sort field */
-          sortBy?:
-            | 'leaseStartDate'
-            | 'lastDebitDate'
-            | 'leaseId'
-            | 'address'
-            | 'objectType'
-            | 'rentalObjectCode'
+          sortBy?: "leaseStartDate" | "lastDebitDate" | "leaseId" | "address" | "objectType" | "rentalObjectCode";
           /** @description Sort direction */
-          sortOrder?: 'asc' | 'desc'
-        }
-      }
+          sortOrder?: "asc" | "desc";
+        };
+      };
       responses: {
         /** @description Successfully retrieved lease search results with pagination */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['LeaseSearchResult'][]
-              _meta?: components['schemas']['PaginationMeta']
-              _links?: components['schemas']['PaginationLinks'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["LeaseSearchResult"][];
+              _meta?: components["schemas"]["PaginationMeta"];
+              _links?: components["schemas"]["PaginationLinks"][];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/building-managers': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/building-managers": {
     /**
      * Get all building managers
      * @description Returns a list of all building managers (Kvartersvärd) with their code, name and district.
@@ -470,23 +467,23 @@ export interface paths {
         /** @description List of building managers */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                code?: string
-                name?: string
-                district?: string
-              }[]
-            }
-          }
-        }
+                  code?: string;
+                  name?: string;
+                  district?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/parking-space-types': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/parking-space-types": {
     /**
      * Get all parking space types
      * @description Returns a list of all parking space types (P-platstyper).
@@ -496,22 +493,22 @@ export interface paths {
         /** @description List of parking space types */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                code?: string
-                caption?: string
-              }[]
-            }
-          }
-        }
+                  code?: string;
+                  caption?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/export': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/export": {
     /**
      * Export leases to Excel
      * @description Export lease search results to Excel file. Uses same filters as /leases/search but without pagination.
@@ -520,44 +517,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
-        }
-      }
+          buildingManager?: string[];
+        };
+      };
       responses: {
         /** @description Excel file download */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/from-lease-search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/from-lease-search": {
     /**
      * Get contacts matching lease search filters
      * @description Retrieves contact information for tenants matching the given lease search filters.
@@ -566,48 +563,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
-        }
-      }
+          buildingManager?: string[];
+        };
+      };
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ContactInfo'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ContactInfo"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/by-rental-property-id/{rentalPropertyId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get leases with related entities for a specific rental property id
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified rental property id.
@@ -616,38 +613,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
+          includeTerminatedLeases?: boolean;
           /** @description Whether to include contact information in the response */
-          includeContacts?: boolean
+          includeContacts?: boolean;
           /** @description Whether to include rent information in the response */
-          includeRentInfo?: boolean
-        }
+          includeRentInfo?: boolean;
+        };
         path: {
           /** @description Rental roperty id of the building/residence to fetch leases for. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/leases/by-pnr/{pnr}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/leases/by-pnr/{pnr}": {
     /**
      * Get leases with related entities for a specific Personal Number (PNR)
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
@@ -656,28 +653,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
-        }
+          includeTerminatedLeases?: boolean;
+        };
         path: {
           /** @description Personal Number (PNR) of the individual to fetch leases for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/leases/by-contact-code/{contactCode}': {
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/leases/by-contact-code/{contactCode}": {
     /**
      * Get leases with related entities for a specific contact code
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified contact code.
@@ -686,28 +683,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
-        }
+          includeTerminatedLeases?: boolean;
+        };
         path: {
           /** @description Contact code of the individual to fetch leases for. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/consumer-reports/by-pnr/{pnr}': {
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/consumer-reports/by-pnr/{pnr}": {
     /**
      * Get consumer report for a specific Personal Number (PNR)
      * @description Retrieves credit information and consumer report for the specified Personal Number (PNR).
@@ -716,20 +713,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch credit information for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with credit information and consumer report */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/contacts/by-pnr/{pnr}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/contacts/by-pnr/{pnr}": {
     /**
      * Get contact information for a specific Personal Number (PNR)
      * @description Retrieves contact information associated with the specified Personal Number (PNR).
@@ -738,20 +735,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch contact information for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/offers': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/offers": {
     /**
      * Get offers for a contact
      * @description Retrieves all offers associated with a specific contact based on the provided contact code.
@@ -760,28 +757,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique code identifying the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with a list of offers for the contact. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description The contact was not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve offers. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/comments': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/comments": {
     /**
      * Get comments for a contact
      * @description Retrieves all comments/notes for a contact from Xpand
@@ -790,57 +787,57 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by comment type. If omitted, returns all comment types. */
-          commentType?: 'Standard' | 'Sökande'
-        }
+          commentType?: "Standard" | "Sökande";
+        };
         path: {
           /**
            * @description The unique code identifying the contact.
            * @example P086890
            */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved comments */
         200: {
           content: {
-            'application/json': {
-              content?: {
-                contactKey?: string
-                contactCode?: string
-                commentKey?: string
-                id?: number
-                commentType?: string | null
-                /** @description Array of individual notes parsed from comment text */
-                notes?: {
-                  /**
-                   * Format: date
-                   * @description Date in YYYY-MM-DD format
-                   */
-                  date?: string | null
-                  /** @description Time in HH:MM format */
-                  time?: string | null
-                  /** @description Author initials (6 letters) or "Notering utan signatur" */
-                  author?: string
-                  /** @description Note content (plain text) */
-                  text?: string
-                }[]
-                priority?: number | null
-                kind?: number | null
-              }[]
-            }
-          }
-        }
+            "application/json": {
+              content?: ({
+                  contactKey?: string;
+                  contactCode?: string;
+                  commentKey?: string;
+                  id?: number;
+                  commentType?: string | null;
+                  /** @description Array of individual notes parsed from comment text */
+                  notes?: ({
+                      /**
+                       * Format: date
+                       * @description Date in YYYY-MM-DD format
+                       */
+                      date?: string | null;
+                      /** @description Time in HH:MM format */
+                      time?: string | null;
+                      /** @description Author initials (6 letters) or "Notering utan signatur" */
+                      author?: string;
+                      /** @description Note content (plain text) */
+                      text?: string;
+                    })[];
+                  priority?: number | null;
+                  kind?: number | null;
+                })[];
+            };
+          };
+        };
         /** @description Contact not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Create or append to contact comment
      * @description Creates a new comment if none exists for the contact, or appends to existing comment in Xpand
@@ -852,56 +849,56 @@ export interface paths {
            * @description The unique code identifying the contact
            * @example P086890
            */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /**
              * @description Plain text content of the note
              * @example Customer contacted regarding lease renewal
              */
-            content: string
+            content: string;
             /**
              * @description Author name or code (1-50 characters)
              * @example DAVLIN
              */
-            author: string
+            author: string;
             /**
              * @description Type of comment. Defaults to 'Standard' if not specified.
              * @default Standard
              * @enum {string}
              */
-            commentType?: 'Standard' | 'Sökande'
-          }
-        }
-      }
+            commentType?: "Standard" | "Sökande";
+          };
+        };
+      };
       responses: {
         /** @description Comment updated successfully (appended to existing comment) */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Comment created successfully (new comment) */
         201: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request body (validation failed) */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Contact not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/applicants/{contactCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/applicants/{contactCode}": {
     /**
      * Get a specific offer for an applicant
      * @description Retrieve details of a specific offer associated with an applicant using contact code and offer ID.
@@ -910,30 +907,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the offer. */
-          offerId: string
+          offerId: string;
           /** @description The unique code identifying the applicant. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Details of the specified offer. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Offer not found for the specified contact code and offer ID. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/by-listing-id/{listingId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/by-listing-id/{listingId}": {
     /**
      * Get offers for a specific listing
      * @description Get all offers for a listing.
@@ -942,24 +939,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description A list of offers. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/by-listing-id/{listingId}/active': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/by-listing-id/{listingId}/active": {
     /**
      * Gets active offer for a specific listing
      * @description Get an offer for a listing.
@@ -968,24 +965,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description The active offer. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/search": {
     /**
      * Search contacts by name, PNR, contact code, or email
      * @description Search contacts by contact code, personal registration number, name, or email. Supports searching by full name or partial name (e.g., "john smith" or "smith"). Multiple search terms are matched with AND logic. Email search is triggered when query contains "@".
@@ -994,30 +991,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description Search query - can be contact code, personal registration number, name, or email (if query contains "@"). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successful response with search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Contact'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Contact"][];
+            };
+          };
+        };
         /** @description Bad request. The query parameter 'q' must be a string. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve contacts. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/for-identity-check': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/for-identity-check": {
     /**
      * Get contacts for deceased/protected identity check
      * @description Returns paginated list of person contacts eligible for deceased/protected identity verification. Note - Results are validated using the personnummer package, so the actual count may be fewer than the requested limit if invalid personnummer are filtered out.
@@ -1026,38 +1023,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved contacts for identity check. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['IdentityCheckContact'][]
+            "application/json": {
+              content?: components["schemas"]["IdentityCheckContact"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}": {
     /**
      * Get contact by contact code
      * @description Retrieves a contact based on the provided contact code.
@@ -1066,22 +1063,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Contact']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/tenants/by-contact-code/{contactCode}': {
+            "application/json": {
+              content?: components["schemas"]["Contact"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/tenants/by-contact-code/{contactCode}": {
     /**
      * Get tenant by contact code
      * @description Retrieves a tenant based on the provided contact code.
@@ -1090,31 +1087,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant information. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The tenant data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve Tenant information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/by-phone-number/{pnr}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/by-phone-number/{pnr}": {
     /**
      * Get contact by phone number
      * @description Retrieves a contact based on the provided phone number.
@@ -1123,20 +1120,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The phone number used to identify the contact. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/leases/{id}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/leases/{id}": {
     /**
      * Get lease by ID
      * @description Retrieves lease details along with related entities based on the provided ID.
@@ -1145,22 +1142,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the lease to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested lease and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/accept': {
+            "application/json": {
+              content?: components["schemas"]["Lease"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/accept": {
     /**
      * Accept an offer
      * @description Accepts an offer for the contact of the contactCode provided
@@ -1169,22 +1166,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to accept */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer accepted successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to accept the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/deny': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/deny": {
     /**
      * Deny an offer
      * @description Denies an offer
@@ -1193,22 +1190,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to deny */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer denied successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to deny the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/expire': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/expire": {
     /**
      * Expire an offer
      * @description Expires an offer
@@ -1217,22 +1214,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to expire */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer expired successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to expire the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/applicants': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/applicants": {
     /**
      * Get applicants by contact code
      * @description Retrieves applicants based on the contact code.
@@ -1241,20 +1238,20 @@ export interface paths {
       parameters: {
         query: {
           /** @description The contact code used to fetch applicants. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of applicants. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}": {
     /**
      * Validate property rental rules for applicant
      * @description Validate property rental rules for an applicant based on contact code and listing ID.
@@ -1263,61 +1260,61 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The xpand rental object code of the property. */
-          rentalObjectCode: number
-        }
-      }
+          rentalObjectCode: number;
+        };
+      };
       responses: {
         /** @description No property rental rules apply to this property. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string
+              applicationType?: string;
               /** @example No property rental rules applies to this property. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Rental object code is not a parking space. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental object code entity is not a parking space. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Applicant is not eligible for the property based on property rental rules. */
         403: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description Listing, property info, or applicant not found. */
         404: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description An error occurred while validating property rental rules. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example An error occurred while validating property rental rules. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}": {
     /**
      * Validate residential area rental rules for applicant
      * @description Validate residential area rental rules for an applicant based on contact code and district code.
@@ -1326,52 +1323,52 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The xpand district code of the residential area to validate against. */
-          districtCode: string
-        }
-      }
+          districtCode: string;
+        };
+      };
       responses: {
         /** @description Either no residential area rental rules apply or applicant is eligible to apply for parking space. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string
-              reason?: string
-            }
-          }
-        }
+              applicationType?: string;
+              reason?: string;
+            };
+          };
+        };
         /** @description Applicant is not eligible for the listing based on residential area rental rules. */
         403: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant does not have any current or upcoming housing contracts in the residential area. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Listing or applicant not found. */
         404: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description An error occurred while validating residential area rental rules. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example An error occurred while validating residential area rental rules. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants-with-listings/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants-with-listings/by-contact-code/{contactCode}": {
     /**
      * Get applicants with listings by contact code
      * @description Retrieves applicants along with their listings based on the contact code.
@@ -1380,20 +1377,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch applicants and their associated listings. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of applicants with their listings. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{contactCode}/{listingId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{contactCode}/{listingId}": {
     /**
      * Get applicant by contact code and listing ID
      * @description Retrieves an applicant by their contact code and listing ID.
@@ -1402,22 +1399,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The ID of the listing associated with the applicant. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of the applicant. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{applicantId}/by-manager': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{applicantId}/by-manager": {
     /**
      * Withdraw applicant by manager
      * @description Withdraws an applicant by the manager using the applicant ID.
@@ -1426,32 +1423,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string
-        }
-      }
+          applicantId: string;
+        };
+      };
       responses: {
         /** @description Successful withdrawal of the applicant by manager. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant successfully withdrawn by manager. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Error message describing the issue. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{applicantId}/by-user/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{applicantId}/by-user/{contactCode}": {
     /**
      * Withdraw applicant by user
      * @description Withdraws an applicant by the user identified by contact code and applicant ID.
@@ -1460,34 +1457,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string
+          applicantId: string;
           /** @description The contact code of the user initiating the withdrawal. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful withdrawal of the applicant by user. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant successfully withdrawn by user. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Error message describing the issue. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile": {
     /**
      * Gets an application profile by contact code
      * @description Retrieve application profile information by contact code.
@@ -1496,31 +1493,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile/admin': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile/admin": {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1529,41 +1526,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Successfully created application profile. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile/client': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile/client": {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1572,41 +1569,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Successfully created application profile. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/{rentalObjectCode}/verify-application': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/{rentalObjectCode}/verify-application": {
     /**
      * Validate max num residents.
      * @description Checks if application is allowed based on current number of residents.
@@ -1615,32 +1612,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
+          contactCode: string;
           /** @description The rental object code associated with the rental property. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Application allowed. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Application not allowed. */
         403: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings": {
     /**
      * Get listings
      * @description Retrieves a list of listings.
@@ -1649,28 +1646,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The listing category, either PARKING_SPACE, APARTMENT or STORAGE. */
-          listingCategory?: string
+          listingCategory?: string;
           /** @description true for published listings, false for unpublished listings. */
-          published?: boolean
+          published?: boolean;
           /** @description The rental rule for the listings, either SCORED or NON_SCORED. */
-          rentalRule?: string
+          rentalRule?: string;
           /** @description A contact code to filter out listings that are not valid to rent for the contact. */
-          validToRentForContactCode?: string
+          validToRentForContactCode?: string;
           /** @description A Rental Object Code to filter the listings. */
-          rentalObjectCode?: string
-        }
-      }
+          rentalObjectCode?: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested list of listings. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}": {
     /**
      * Delete a Listing by ID
      * @description Deletes a listing by it's ID.
@@ -1679,31 +1676,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description Successfully deleted listing. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Conflict. */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/status': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/status": {
     /**
      * Update a listings status by ID
      * @description Updates a listing status by it's ID.
@@ -1712,36 +1709,36 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated listing. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/offers': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/offers": {
     /**
      * Create an offer for a listing
      * @description Creates an offer for the specified listing.
@@ -1750,22 +1747,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to create an offer for. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Offer creation successful. */
         201: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to create the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/applicants/details': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/applicants/details": {
     /**
      * Get listing by ID with detailed applicants
      * @description Retrieves a listing by ID along with detailed information about its applicants.
@@ -1774,20 +1771,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to fetch along with detailed applicant information. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of the listing with detailed applicant information. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings/{id}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings/{id}": {
     /**
      * Get listing by ID
      * @description Retrieves details of a listing based on the provided ID.
@@ -1796,20 +1793,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested listing details. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings-with-applicants': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings-with-applicants": {
     /**
      * Get listings with applicants
      * @description Retrieves a list of listings along with their associated applicants.
@@ -1818,24 +1815,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filters listings by one of the above types. Must be one of the specified values. */
-          type?: 'published' | 'ready-for-offer' | 'offered' | 'historical'
-        }
-      }
+          type?: "published" | "ready-for-offer" | "offered" | "historical";
+        };
+      };
       responses: {
         /** @description Successful response with listings and their applicants. */
         200: {
           content: {
-            'application/json': Record<string, never>[]
-          }
-        }
+            "application/json": Record<string, never>[];
+          };
+        };
         /** @description Internal server error. Failed to retrieve listings with applicants. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings/batch': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings/batch": {
     /**
      * Create multiple listings
      * @description Create multiple listings in a single request.
@@ -1843,54 +1840,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            listings: {
-              rentalObjectCode: string
-              /** Format: date-time */
-              publishedFrom: string
-              /** Format: date-time */
-              publishedTo: string
-              /** @enum {string} */
-              status:
-                | 'ACTIVE'
-                | 'INACTIVE'
-                | 'CLOSED'
-                | 'ASSIGNED'
-                | 'EXPIRED'
-                | 'NO_APPLICANTS'
-              /** @enum {string} */
-              rentalRule: 'SCORED' | 'NON_SCORED'
-              /** @enum {string} */
-              listingCategory: 'PARKING_SPACE' | 'APARTMENT' | 'STORAGE'
-            }[]
-          }
-        }
-      }
+          "application/json": {
+            listings: ({
+                rentalObjectCode: string;
+                /** Format: date-time */
+                publishedFrom: string;
+                /** Format: date-time */
+                publishedTo: string;
+                /** @enum {string} */
+                status: "ACTIVE" | "INACTIVE" | "CLOSED" | "ASSIGNED" | "EXPIRED" | "NO_APPLICANTS";
+                /** @enum {string} */
+                rentalRule: "SCORED" | "NON_SCORED";
+                /** @enum {string} */
+                listingCategory: "PARKING_SPACE" | "APARTMENT" | "STORAGE";
+              })[];
+          };
+        };
+      };
       responses: {
         /** @description All listings created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Partial success. Some listings created, some failed. */
         207: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request. Invalid input data. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to create listings. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/vacant-parkingspaces': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/vacant-parkingspaces": {
     /**
      * Get all vacant parking spaces
      * @description Retrieves a list of all vacant parking spaces.
@@ -1900,39 +1891,39 @@ export interface paths {
         /** @description A list of vacant parking spaces. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalObjectCode?: string
-                address?: string
-                monthlyRent?: number
-                propertyCaption?: string
-                propertyCode?: string
-                residentialAreaCode?: string
-                residentialAreaCaption?: string
-                objectTypeCaption?: string
-                objectTypeCode?: string
-                /** Format: date-time */
-                vacantFrom?: string
-                districtCaption?: string
-                districtCode?: string
-                braArea?: number
-              }[]
-            }
-          }
-        }
+                  rentalObjectCode?: string;
+                  address?: string;
+                  monthlyRent?: number;
+                  propertyCaption?: string;
+                  propertyCode?: string;
+                  residentialAreaCode?: string;
+                  residentialAreaCaption?: string;
+                  objectTypeCaption?: string;
+                  objectTypeCode?: string;
+                  /** Format: date-time */
+                  vacantFrom?: string;
+                  districtCaption?: string;
+                  districtCode?: string;
+                  braArea?: number;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve vacant parking spaces. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rental-objects/by-code/{rentalObjectCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rental-objects/by-code/{rentalObjectCode}": {
     /**
      * Get a rental object by code
      * @description Fetches a rental object by Rental Object Code.
@@ -1941,46 +1932,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the rental object to fetch. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rental object. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalObjectCode?: string
-                address?: string
-                monthlyRent?: number
-                propertyCaption?: string
-                propertyCode?: string
-                residentialAreaCode?: string
-                residentialAreaCaption?: string
-                objectTypeCaption?: string
-                objectTypeCode?: string
-                /** Format: date-time */
-                vacantFrom?: string
-                districtCaption?: string
-                districtCode?: string
-                braArea?: number
-              }[]
-            }
-          }
-        }
+                  rentalObjectCode?: string;
+                  address?: string;
+                  monthlyRent?: number;
+                  propertyCaption?: string;
+                  propertyCode?: string;
+                  residentialAreaCode?: string;
+                  residentialAreaCaption?: string;
+                  objectTypeCaption?: string;
+                  objectTypeCode?: string;
+                  /** Format: date-time */
+                  vacantFrom?: string;
+                  districtCaption?: string;
+                  districtCode?: string;
+                  braArea?: number;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. Failed to fetch rental object. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listing-text-content/{rentalObjectCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listing-text-content/{rentalObjectCode}": {
     /**
      * Get listing text content by rental object code
      * @description Fetch the listing text content for a specific rental object.
@@ -1989,28 +1980,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to fetch text content for. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Listing text content object */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update listing text content
      * @description Update existing listing text content.
@@ -2019,37 +2010,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to update. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateListingTextContentRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateListingTextContentRequest"];
+        };
+      };
       responses: {
         /** @description Listing text content updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete listing text content
      * @description Delete listing text content.
@@ -2058,26 +2049,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to delete. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Listing text content deleted successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listing-text-content': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listing-text-content": {
     /**
      * Create listing text content
      * @description Create new listing text content for a rental object.
@@ -2085,34 +2076,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateListingTextContentRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateListingTextContentRequest"];
+        };
+      };
       responses: {
         /** @description Listing text content created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content already exists for rental object code */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/floorplan': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/floorplan": {
     /**
      * Get floor plan for a rental property
      * @description Returns the floor plan image for the specified rental property.
@@ -2121,100 +2112,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved floor plan image */
         200: {
           content: {
-            'image/jpeg': string
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-options': {
+            "image/jpeg": string;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-options": {
     /** Get room types with material options by rental property ID */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch room types for */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with room types and their material options */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-options/{materialOptionId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-options/{materialOptionId}": {
     /** Get material option by ID for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material options from */
-          id: string
+          id: string;
           /** @description ID of the material option to fetch */
-          materialOptionId: string
-        }
-      }
+          materialOptionId: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material option */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{apartmentId}/contracts/{contractId}/material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{apartmentId}/contracts/{contractId}/material-choices": {
     /** Get material choices for a specific apartment and contract */
     get: {
       parameters: {
         path: {
           /** @description ID of the apartment to fetch material choices for */
-          apartmentId: string
+          apartmentId: string;
           /** @description ID of the contract to fetch material choices for */
-          contractId: string
-        }
-      }
+          contractId: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/rooms-with-material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/rooms-with-material-choices": {
     /** Get rooms with material choices for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch rooms with material choices for */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested rooms and their material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-choices": {
     /**
      * Get material choices for a specific rental property
      * @description Retrieve material choices associated with a rental property identified by {id}.
@@ -2223,18 +2214,18 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material choices for. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
     /**
      * Save material choices for a rental property
      * @description Saves material choices for a specific rental property.
@@ -2243,25 +2234,25 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to save material choices for. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Material choices successfully saved */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/material-choice-statuses': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/material-choice-statuses": {
     /**
      * Get material choice statuses for rental properties
      * @description Retrieves statuses of material choices associated with rental properties. Optionally includes rental property details if specified in query parameter.
@@ -2270,20 +2261,20 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional parameter to include rental property details in response. */
-          includeRentalProperties?: 'true'
-        }
-      }
+          includeRentalProperties?: "true";
+        };
+      };
       responses: {
         /** @description Successful response with material choice statuses */
         200: {
           content: {
-            'application/json': unknown[]
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}': {
+            "application/json": unknown[];
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}": {
     /**
      * Get rental property by ID
      * @description Retrieves details of a rental property based on the provided ID.
@@ -2292,22 +2283,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with rental property details */
         200: {
           content: {
-            'application/json': {
-              data?: Record<string, never>
-            }
-          }
-        }
-      }
-    }
-  }
-  '/parking-spaces/{parkingSpaceId}/leases': {
+            "application/json": {
+              data?: Record<string, never>;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/parking-spaces/{parkingSpaceId}/leases": {
     /**
      * Create lease for an external parking space
      * @description Creates a new lease for the specified external parking space.
@@ -2316,38 +2307,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the lease is being created. */
-          parkingSpaceId: string
-        }
-      }
+          parkingSpaceId: string;
+        };
+      };
       responses: {
         /** @description Lease successfully created */
         201: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Parking space id is missing. It needs to be passed in the url. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example A technical error has occured. */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/parking-spaces/{parkingSpaceId}/note-of-interests': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/parking-spaces/{parkingSpaceId}/note-of-interests": {
     /**
      * Create a note of interest for an internal parking space
      * @description Creates a new note of interest for the specified internal parking space.
@@ -2356,38 +2347,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the note of interest is being created. */
-          parkingSpaceId: string
-        }
-      }
+          parkingSpaceId: string;
+        };
+      };
       responses: {
         /** @description Note of interest successfully created */
         201: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Contact code is missing. It needs to be passed in the body (contactCode) */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example A technical error has occured. */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/by-rental-object-code/{rentalObjectCode}': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/by-rental-object-code/{rentalObjectCode}": {
     /**
      * Get rental property information from Xpand
      * @description Retrieves detailed information about a rental property from Xpand based on the provided rental object code.
@@ -2396,32 +2387,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental object code used to identify the specific rental property in Xpand. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved rental property information */
         200: {
           content: {
-            'application/json': components['schemas']['RentalPropertyResponse']
-          }
-        }
+            "application/json": components["schemas"]["RentalPropertyResponse"];
+          };
+        };
         /** @description Rental property not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}": {
     /**
      * Get maintenance units for a rental property
      * @description Retrieves maintenance units for a specific rental property, optionally filtered by type.
@@ -2430,22 +2421,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch maintenance units for. */
-          rentalPropertyId: string
+          rentalPropertyId: string;
           /** @description Optional type filter for maintenance units. */
-          type: string
-        }
-      }
+          type: string;
+        };
+      };
       responses: {
         /** @description Successful response with maintenance units */
         200: {
           content: {
-            'application/json': unknown[]
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-contact-code/{contactCode}': {
+            "application/json": unknown[];
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-contact-code/{contactCode}": {
     /**
      * Get maintenance units by contact code.
      * @description Returns all maintenance units belonging to a contact code.
@@ -2454,33 +2445,33 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code for which to retrieve maintenance units. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                ok?: boolean
-                data?: components['schemas']['MaintenanceUnit'][]
-              }[]
-            }
-          }
-        }
+                  ok?: boolean;
+                  data?: components["schemas"]["MaintenanceUnit"][];
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/data/{identifier}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/data/{identifier}": {
     /**
      * Get work order data by different identifiers
      * @description Retrieves work order data along with associated leases based on the provided identifier type.
@@ -2489,55 +2480,50 @@ export interface paths {
       parameters: {
         query: {
           /** @description The type of the identifier used to fetch work order data. */
-          handler:
-            | 'rentalObjectId'
-            | 'leaseId'
-            | 'pnr'
-            | 'phoneNumber'
-            | 'contactCode'
-        }
+          handler: "rentalObjectId" | "leaseId" | "pnr" | "phoneNumber" | "contactCode";
+        };
         path: {
           /** @description The identifier value for fetching work order data. */
-          identifier: string
-        }
-      }
+          identifier: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work order data. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalPropertyId?: string
-                leases?: {
-                  leaseId?: string
-                  rentalPropertyId?: string
-                }[]
-              }[]
-            }
-          }
-        }
+                  rentalPropertyId?: string;
+                  leases?: {
+                      leaseId?: string;
+                      rentalPropertyId?: string;
+                    }[];
+                }[];
+            };
+          };
+        };
         /** @description Invalid handler */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid handler */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work order data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-contact-code/{contactCode}": {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -2546,34 +2532,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-rental-property-id/{rentalPropertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get work orders by rental property id
      * @description Retrieves work orders based on the provided rental property id.
@@ -2582,34 +2568,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-property-id/{propertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-property-id/{propertyId}": {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -2618,34 +2604,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string
-        }
-      }
+          propertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-building-id/{buildingId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-building-id/{buildingId}": {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -2654,34 +2640,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string
-        }
-      }
+          buildingId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}": {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2690,34 +2676,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string
-        }
-      }
+          maintenanceUnitCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-contact-code/{contactCode}": {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -2726,42 +2712,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number
+          skip?: number;
           /** @description The number of work orders to fetch. */
-          limit?: number
+          limit?: number;
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean
-        }
+          sortAscending?: boolean;
+        };
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-rental-property-id/{rentalPropertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get work orders by rental property id from xpand
      * @description Retrieves work orders based on the provided rental property id.
@@ -2770,34 +2756,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-property-id/{propertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-property-id/{propertyId}": {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders based on the provided property id.
@@ -2806,34 +2792,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string
-        }
-      }
+          propertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-building-id/{buildingId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-building-id/{buildingId}": {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders based on the provided building id.
@@ -2842,34 +2828,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string
-        }
-      }
+          buildingId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}": {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2878,42 +2864,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number
+          skip?: number;
           /** @description The number of work orders to fetch. */
-          limit?: number
+          limit?: number;
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean
-        }
+          sortAscending?: boolean;
+        };
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string
-        }
-      }
+          maintenanceUnitCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/{code}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/{code}": {
     /**
      * Get work order details by rental property id from xpand
      * @description Retrieves work order details.
@@ -2922,40 +2908,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['XpandWorkOrder']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["XpandWorkOrder"];
+            };
+          };
+        };
         /** @description Work order not found. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders": {
     /**
      * Create a new work order
      * @description Creates a new work order.
@@ -2963,64 +2949,64 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The contact code of the tenant. */
-            ContactCode?: string
+            ContactCode?: string;
             /** @description The rental property ID. */
-            RentalObjectCode?: string
+            RentalObjectCode?: string;
             Rows?: {
-              /** @description The location code of the work order. */
-              LocationCode?: string
-            }[]
+                /** @description The location code of the work order. */
+                LocationCode?: string;
+              }[];
             /** @description Access options for the work order. */
-            AccessOptions?: Record<string, never>
+            AccessOptions?: Record<string, never>;
             /** @description Pet information for the work order. */
-            Pet?: Record<string, never>
-            Images?: string[]
-          }
-        }
-      }
+            Pet?: Record<string, never>;
+            Images?: string[];
+          };
+        };
+      };
       responses: {
         /** @description Successfully created the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order created */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example ContactCode is missing */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Not found. Rental property or active lease not found. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental property not found */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to create the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to create a new work order */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/maintenance-teams': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/maintenance-teams": {
     /**
      * List maintenance teams (resursgrupper)
      * @description Returns the selectable Odoo maintenance teams (resursgrupper) for the inspection work-order picker.
@@ -3030,19 +3016,19 @@ export interface paths {
         /** @description Maintenance teams retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceTeam'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceTeam"][];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/from-inspection': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/from-inspection": {
     /**
      * Create work orders from an inspection (one per resursgrupp)
      * @description Resolves the apartment from rentalObjectCode, then creates one work order per resursgrupp group. Each group is an independent Odoo commit, so the response reports per-group success/failure.
@@ -3050,34 +3036,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateInspectionWorkOrdersRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateInspectionWorkOrdersRequest"];
+        };
+      };
       responses: {
         /** @description Work orders processed (see per-group results) */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CreateInspectionWorkOrdersResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["CreateInspectionWorkOrdersResponse"];
+            };
+          };
+        };
         /** @description Bad request (invalid body or not an apartment). */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Rental property not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/{workOrderId}/update': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/{workOrderId}/update": {
     /**
      * Update a work order with a message
      * @description Adds a message to the specified work order.
@@ -3086,49 +3072,49 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be updated. */
-          workOrderId: string
-        }
-      }
+          workOrderId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The message to be added to the work order. */
-            message?: string
-          }
-        }
-      }
+            message?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully added the message to the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Message added to work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Message is missing from the request body */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to add the message to the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to add message to work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/{workOrderId}/close': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/{workOrderId}/close": {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -3137,32 +3123,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string
-        }
-      }
+          workOrderId: string;
+        };
+      };
       responses: {
         /** @description Successfully closed the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order with ID {workOrderId} updated successfully */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to close the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/send-sms': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/send-sms": {
     /**
      * Send SMS for a work order
      * @description Sends an SMS message to the specified phone number for a work order.
@@ -3170,46 +3156,46 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The phone number to send the SMS to. */
-            phoneNumber?: string
+            phoneNumber?: string;
             /** @description The message to be sent via SMS. */
-            text?: string
-          }
-        }
-      }
+            text?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully sent the SMS. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Sms sent to {phoneNumber} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Bad request: phoneNumber and message are required */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to send the SMS. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Unexpected error sending sms to {phoneNumber} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/send-email': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/send-email": {
     /**
      * Send email for a work order
      * @description Sends an email to the specified recipient for a work order.
@@ -3217,48 +3203,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The email address of the recipient. */
-            to?: string
+            to?: string;
             /** @description The subject of the email. */
-            subject?: string
+            subject?: string;
             /** @description The message to be sent in the email. */
-            text?: string
-          }
-        }
-      }
+            text?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully sent the email. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Email sent to {to} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Bad request: to, subject, and message are required */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to send the email. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to send email to {to}, status: {statusCode} */
-              text?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/components/by-room/{roomId}': {
+              text?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/components/by-room/{roomId}": {
     /**
      * Get components by room ID
      * @description Returns all components currently installed in a specific space via their installation records.
@@ -3268,40 +3254,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the room */
-          roomId: string
-        }
-      }
+          roomId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the components list */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"][];
+            };
+          };
+        };
         /** @description Room not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Room not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-categories': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-categories": {
     /**
      * Get all component categories
      * @description Top-level groupings for building components (e.g., Ventilation, VVS, Vitvaror, Tak). Use categoryId to filter component types.
@@ -3309,21 +3295,21 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?: number
-          limit?: number
-        }
-      }
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component categories */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory'][]
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"][];
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component category
      * @description Creates a new top-level category for organizing component types.
@@ -3331,22 +3317,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentCategoryRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentCategoryRequest"];
+        };
+      };
       responses: {
         /** @description Component category created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-categories/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-categories/{id}": {
     /**
      * Get component category by ID
      * @description Returns a single category with its name and metadata.
@@ -3354,24 +3340,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component category details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
         /** @description Component category not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component category
      * @description Updates category name or metadata.
@@ -3379,25 +3365,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentCategoryRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentCategoryRequest"];
+        };
+      };
       responses: {
         /** @description Component category updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
+      };
+    };
     /**
      * Delete a component category
      * @description Removes a category. Will fail if category has associated types.
@@ -3405,18 +3391,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component category deleted */
         204: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-types': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-types": {
     /**
      * Get all component types
      * @description Specific kinds of components within a category (e.g., Diskmaskin, Värmepump, Takbeläggning). Filter by categoryId to get types for a specific category.
@@ -3425,22 +3411,22 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter types by category ID */
-          categoryId?: string
-          page?: number
-          limit?: number
-        }
-      }
+          categoryId?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component types */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType'][]
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"][];
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component type
      * @description Creates a new type within a category. Requires categoryId.
@@ -3448,22 +3434,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentTypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentTypeRequest"];
+        };
+      };
       responses: {
         /** @description Component type created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-types/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-types/{id}": {
     /**
      * Get component type by ID
      * @description Returns a single type with its category relationship.
@@ -3471,24 +3457,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component type details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
         /** @description Component type not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component type
      * @description Updates type name or category assignment.
@@ -3496,25 +3482,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentTypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentTypeRequest"];
+        };
+      };
       responses: {
         /** @description Component type updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
+      };
+    };
     /**
      * Delete a component type
      * @description Removes a type. Will fail if type has associated subtypes.
@@ -3522,18 +3508,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component type deleted */
         204: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-subtypes': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-subtypes": {
     /**
      * Get all component subtypes
      * @description Variants of a type with lifecycle data including depreciation price, technical/economic lifespan, and replacement interval. Filter by typeId or subtypeName.
@@ -3542,30 +3528,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter subtypes by type ID */
-          typeId?: string
+          typeId?: string;
           /** @description Search subtypes by name (case-insensitive) */
-          subtypeName?: string
-          page?: number
-          limit?: number
-        }
-      }
+          subtypeName?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component subtypes */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component subtype
      * @description Creates a subtype with lifecycle parameters. Requires typeId.
@@ -3573,22 +3559,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentSubtypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentSubtypeRequest"];
+        };
+      };
       responses: {
         /** @description Component subtype created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-subtypes/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-subtypes/{id}": {
     /**
      * Get component subtype by ID
      * @description Returns subtype with full lifecycle and cost planning data.
@@ -3596,24 +3582,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component subtype details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component subtype
      * @description Updates subtype specifications or lifecycle data.
@@ -3621,29 +3607,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentSubtypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentSubtypeRequest"];
+        };
+      };
       responses: {
         /** @description Component subtype updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component subtype
      * @description Removes a subtype. Will fail if subtype has associated models.
@@ -3651,22 +3637,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component subtype deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models": {
     /**
      * Get all component models
      * @description Specific manufacturer products with pricing, warranty, specifications, and dimensions. Filter by subtypeId, manufacturer, or modelName.
@@ -3675,32 +3661,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter models by component type ID */
-          componentTypeId?: string
+          componentTypeId?: string;
           /** @description Filter models by subtype ID */
-          subtypeId?: string
+          subtypeId?: string;
           /** @description Filter models by manufacturer name */
-          manufacturer?: string
-          page?: number
-          limit?: number
-        }
-      }
+          manufacturer?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component models */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component model
      * @description Creates a manufacturer product entry. Requires subtypeId.
@@ -3708,49 +3694,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentModelRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentModelRequest"];
+        };
+      };
       responses: {
         /** @description Component model created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/documents/component-models/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/documents/component-models/{id}": {
     /** Get all documents for a component model */
     get: {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            'application/json': components['schemas']['DocumentWithUrl'][]
-          }
-        }
+            "application/json": components["schemas"]["DocumentWithUrl"][];
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/{id}": {
     /**
      * Get component model by ID
      * @description Returns full model details including specs and current pricing.
@@ -3758,24 +3744,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component model details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component model
      * @description Updates model pricing, specs, or warranty info.
@@ -3783,29 +3769,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentModelRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentModelRequest"];
+        };
+      };
       responses: {
         /** @description Component model updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component model
      * @description Removes a model. Will fail if model has associated components.
@@ -3813,22 +3799,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component model deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/surface': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/surface": {
     /**
      * Get surface component models (Ytskikt hierarchy)
      * @description Returns all ComponentModels under the Ytskikt category with full Subtype → Type → Category hierarchy populated. Subtypes whose name starts with "Ospecificera" sort first within each Type.
@@ -3838,19 +3824,19 @@ export interface paths {
         /** @description List of surface component models */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components": {
     /**
      * Get all components
      * @description Physical units with serial numbers and status. Filter by modelId, status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED), or serialNumber.
@@ -3858,31 +3844,31 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          modelId?: string
-          status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+          modelId?: string;
+          status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
           /** @description Search by serial number (case-insensitive partial match) */
-          serialNumber?: string
-          page?: number
-          limit?: number
-        }
-      }
+          serialNumber?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of components */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component'][]
+            "application/json": {
+              content?: components["schemas"]["Component"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component
      * @description Registers a new physical unit. Requires modelId and serialNumber.
@@ -3890,22 +3876,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentRequest"];
+        };
+      };
       responses: {
         /** @description Component created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/components/{id}': {
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/components/{id}": {
     /**
      * Get component by ID
      * @description Returns full component details including purchase info, warranty dates, and current status.
@@ -3913,24 +3899,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component
      * @description Updates component status, warranty dates, or other attributes.
@@ -3939,29 +3925,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentRequest"];
+        };
+      };
       responses: {
         /** @description Component updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component
      * @description Removes a component record. Automatically deletes associated installation records.
@@ -3969,22 +3955,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/{id}/inspection-state': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/{id}/inspection-state": {
     /**
      * Update component inspection state
      * @description Updates component condition and last inspection date
@@ -3993,40 +3979,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component instance ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @enum {string} */
-            condition: 'GOOD' | 'FAIR' | 'DAMAGED'
+            condition: "GOOD" | "FAIR" | "DAMAGED";
             /** Format: date-time */
-            lastInspectionDate: string
-          }
-        }
-      }
+            lastInspectionDate: string;
+          };
+        };
+      };
       responses: {
         /** @description Component inspection state updated */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-installations': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-installations": {
     /**
      * Get all component installations
      * @description Placement records linking components to property locations (spaceId). A component can be moved between locations over time. Filter by componentId, spaceId, or buildingPartId.
@@ -4034,30 +4020,30 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          componentId?: string
-          spaceId?: string
-          buildingPartId?: string
-          page?: number
-          limit?: number
-        }
-      }
+          componentId?: string;
+          spaceId?: string;
+          buildingPartId?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component installations */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component installation
      * @description Records a component being installed at a location. Requires componentId and spaceId.
@@ -4065,22 +4051,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentInstallationRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentInstallationRequest"];
+        };
+      };
       responses: {
         /** @description Component installation created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-installations/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-installations/{id}": {
     /**
      * Get component installation by ID
      * @description Returns installation record with dates, location, order number, and cost.
@@ -4088,24 +4074,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component installation details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component installation
      * @description Updates installation details or records deinstallation date.
@@ -4114,29 +4100,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component installation ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentInstallationRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentInstallationRequest"];
+        };
+      };
       responses: {
         /** @description Component installation updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component installation
      * @description Removes an installation record.
@@ -4144,22 +4130,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component installation deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/{id}/upload": {
     /**
      * Upload a file to a component
      * @description Attach photos or documents to a specific component (e.g., installation photos, receipts).
@@ -4168,92 +4154,92 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
+            fileData: string;
             /** @description Original file name */
-            fileName: string
+            fileName: string;
             /** @description MIME type of the file */
-            contentType: string
+            contentType: string;
             /** @description Optional caption for the file */
-            caption?: string
-          }
-        }
-      }
+            caption?: string;
+          };
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/documents/component-instances/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/documents/component-instances/{id}": {
     /** Get all documents for a component */
     get: {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            'application/json': components['schemas']['DocumentWithUrl'][]
-          }
-        }
+            "application/json": components["schemas"]["DocumentWithUrl"][];
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/documents/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/documents/{id}": {
     /** Delete a document by ID */
     delete: {
       parameters: {
         path: {
           /** @description Document ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Document deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Document not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/{id}/upload": {
     /**
      * Upload a document to a component model
      * @description Attach product documentation, manuals, or spec sheets to a model for reference.
@@ -4262,38 +4248,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
+            fileData: string;
             /** @description Original file name */
-            fileName: string
+            fileName: string;
             /** @description MIME type of the file */
-            contentType: string
-          }
-        }
-      }
+            contentType: string;
+          };
+        };
+      };
       responses: {
         /** @description Document uploaded successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/analyze-image': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/analyze-image": {
     /**
      * Analyze component image(s) using AI
      * @description Upload photos to identify component type, model, or condition using AI image analysis. Can accept a typeplate/label image, product photo, or both for improved accuracy.
@@ -4301,30 +4287,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['AnalyzeComponentImageRequest']
-        }
-      }
+          "application/json": components["schemas"]["AnalyzeComponentImageRequest"];
+        };
+      };
       responses: {
         /** @description Component analysis successful */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['AIComponentAnalysis']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["AIComponentAnalysis"];
+            };
+          };
+        };
         /** @description Invalid request (e.g., image too large, missing required fields) */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description AI analysis failed */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/processes/add-component': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/processes/add-component": {
     /**
      * Add a component with model, instance, and installation
      * @description Unified process to add a component. This handles:
@@ -4340,99 +4326,99 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Model name (used to find existing model or create new one) */
-            modelName: string
+            modelName: string;
             /**
              * Format: uuid
              * @description Subtype ID (must exist)
              */
-            componentSubtypeId: string
+            componentSubtypeId: string;
             /** @description Required if model doesn't exist */
-            manufacturer?: string
+            manufacturer?: string;
             /** @description Required if model doesn't exist */
-            currentPrice?: number
+            currentPrice?: number;
             /** @description Required if model doesn't exist */
-            currentInstallPrice?: number
+            currentInstallPrice?: number;
             /** @description Required if model doesn't exist */
-            modelWarrantyMonths?: number
-            technicalSpecification?: string
-            dimensions?: string
-            coclassCode?: string
-            serialNumber: string
-            specifications?: string
-            additionalInformation?: string
+            modelWarrantyMonths?: number;
+            technicalSpecification?: string;
+            dimensions?: string;
+            coclassCode?: string;
+            serialNumber: string;
+            specifications?: string;
+            additionalInformation?: string;
             /**
              * Format: date-time
              * @description ISO-8601 DateTime format (e.g., 2026-01-01T00:00:00.000Z)
              */
-            warrantyStartDate?: string
-            componentWarrantyMonths: number
-            priceAtPurchase: number
-            depreciationPriceAtPurchase: number
-            economicLifespan: number
+            warrantyStartDate?: string;
+            componentWarrantyMonths: number;
+            priceAtPurchase: number;
+            depreciationPriceAtPurchase: number;
+            economicLifespan: number;
             /** @default 1 */
-            quantity?: number
+            quantity?: number;
             /** @description NCS color code */
-            ncsCode?: string
+            ncsCode?: string;
             /**
              * @default ACTIVE
              * @enum {string}
              */
-            status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+            status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
             /**
              * @description Physical condition of the component (optional)
              * @enum {string|null}
              */
-            condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+            condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
             /** @description Where to install the component */
-            spaceId: string
+            spaceId: string;
             /** @enum {string} */
-            spaceType: 'OBJECT' | 'PropertyObject'
-            installationDate: string
-            orderNumber?: string
-            installationCost: number
-          }
-        }
-      }
+            spaceType: "OBJECT" | "PropertyObject";
+            installationDate: string;
+            orderNumber?: string;
+            installationCost: number;
+          };
+        };
+      };
       responses: {
         /** @description Component added successfully */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                modelCreated?: boolean
+                modelCreated?: boolean;
                 model?: {
-                  id?: string
-                  modelName?: string
-                  manufacturer?: string
-                }
+                  id?: string;
+                  modelName?: string;
+                  manufacturer?: string;
+                };
                 component?: {
-                  id?: string
-                  serialNumber?: string
-                  status?: string
-                }
+                  id?: string;
+                  serialNumber?: string;
+                  status?: string;
+                };
                 installation?: {
-                  id?: string
-                  spaceId?: string
-                  installationDate?: string
-                }
-              }
-            }
-          }
-        }
+                  id?: string;
+                  spaceId?: string;
+                  installationDate?: string;
+                };
+              };
+            };
+          };
+        };
         /** @description Validation error or missing required model fields */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/buildings': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/buildings": {
     /**
      * Get all buildings for a specific property
      * @description Retrieves all buildings associated with a given property code.
@@ -4443,30 +4429,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the property. */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the buildings. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/buildings/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/buildings/{id}": {
     /**
      * Get detailed information about a specific building
      * @description Retrieves comprehensive information about a building using its unique building id.
@@ -4477,40 +4463,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique id of the building */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved building information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"];
+            };
+          };
+        };
         /** @description Building not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Building not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/buildings/by-building-code/{buildingCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/buildings/by-building-code/{buildingCode}": {
     /**
      * Get building by building code
      * @description Retrieves building data by building code
@@ -4519,40 +4505,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved building */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"];
+            };
+          };
+        };
         /** @description Building not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Building not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/buildings/by-property-code/{propertyCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/buildings/by-property-code/{propertyCode}": {
     /**
      * Get buildings by property code
      * @description Retrieves buildings by property code
@@ -4561,31 +4547,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property to fetch buildings for */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved buildings */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/companies': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/companies": {
     /**
      * Get all companies
      * @description Retrieves companies from property base
@@ -4595,24 +4581,24 @@ export interface paths {
         /** @description Successfully retrieved companies */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Company'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Company"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/companies/{organizationNumber}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/companies/{organizationNumber}": {
     /**
      * Get detailed information about a specific company
      * @description Retrieves comprehensive information about a company using its organization number.
@@ -4621,40 +4607,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The organization number of the company. */
-          organizationNumber: string
-        }
-      }
+          organizationNumber: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved company information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CompanyDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["CompanyDetails"];
+            };
+          };
+        };
         /** @description Company not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Company not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences": {
     /**
      * Get residences by building code and (optional) staircase code
      * @description Retrieves residences by building code and (optional) staircase code
@@ -4663,41 +4649,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch residences from */
-          buildingCode: string
+          buildingCode: string;
           /** @description Code for the staircase to fetch residences from */
-          staircaseCode?: string
-        }
-      }
+          staircaseCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residences */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Residence'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Residence"][];
+            };
+          };
+        };
         /** @description Missing building code or invalid query parameters */
         400: {
           content: {
-            'application/json': {
-              error?: Record<string, never>
-            }
-          }
-        }
+            "application/json": {
+              error?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/properties': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/properties": {
     /**
      * Get properties by company code and (optional) tract
      * @description Retrieves properties by company code and (optional) tract
@@ -4706,41 +4692,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the company that owns the properties. */
-          companyCode: string
+          companyCode: string;
           /** @description Optional filter to get properties in a specific tract. */
-          tract?: string
-        }
-      }
+          tract?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved properties */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"][];
+            };
+          };
+        };
         /** @description Missing company code or invalid query parameters */
         400: {
           content: {
-            'application/json': {
-              error?: Record<string, never>
-            }
-          }
-        }
+            "application/json": {
+              error?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/properties/search': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/properties/search": {
     /**
      * Search properties
      * @description Retrieves a list of all real estate properties by name.
@@ -4749,30 +4735,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The search query. */
-          q?: string
-        }
-      }
+          q?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved list of properties. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/properties/{propertyCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/properties/{propertyCode}": {
     /**
      * Get property by property code
      * @description Retrieves property by property code
@@ -4781,40 +4767,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved property */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"];
+            };
+          };
+        };
         /** @description Property not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Property not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/by-rental-id/{rentalId}": {
     /**
      * Get residence data by residence rental id
      * @description Retrieves residence data by residence rental id
@@ -4823,40 +4809,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id for the residence to fetch */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residence. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceDetails"];
+            };
+          };
+        };
         /** @description Residence not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Residence not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve residence data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/by-rental-id/{rentalId}": {
     /**
      * Get rental blocks by rental ID
      * @description Retrieves rental blocks by rental ID
@@ -4865,44 +4851,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean
-        }
+          active?: boolean;
+        };
         path: {
           /** @description Rental id to fetch rental blocks for */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved rental blocks. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlock'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["RentalBlock"][];
+            };
+          };
+        };
         /** @description Rental ID not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental ID not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve rental blocks. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/export': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/export": {
     /**
      * Export rental blocks to Excel
      * @description Generates and downloads an Excel file with all rental blocks matching the filters
@@ -4911,36 +4897,36 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term */
-          q?: string
+          q?: string;
           /** @description Filter by category (supports multiple values) */
-          kategori?: string[]
+          kategori?: string[];
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[]
+          distrikt?: string[];
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[]
+          blockReason?: string[];
           /** @description Filter by property (supports multiple values) */
-          fastighet?: string[]
+          fastighet?: string[];
           /** @description Filter by start date */
-          fromDateGte?: string
+          fromDateGte?: string;
           /** @description Filter by end date */
-          toDateLte?: string
+          toDateLte?: string;
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean
-        }
-      }
+          active?: boolean;
+        };
+      };
       responses: {
         /** @description Excel file download */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/search": {
     /**
      * Search rental blocks with server-side filtering
      * @description Search and filter rental blocks. Searches by rentalId and address.
@@ -4949,55 +4935,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term (searches rentalId, address) */
-          q?: string
+          q?: string;
           /** @description Comma-separated fields to search (default rentalId,address,propertyName,blockReason) */
-          fields?: string
+          fields?: string;
           /** @description Filter by category (Bostad, Bilplats, Lokal, Förråd) - supports multiple values */
-          kategori?: string[]
+          kategori?: string[];
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[]
+          distrikt?: string[];
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[]
+          blockReason?: string[];
           /** @description Filter by property code/name (supports multiple values) */
-          fastighet?: string[]
+          fastighet?: string[];
           /** @description Filter blocks starting on or after this date */
-          fromDateGte?: string
+          fromDateGte?: string;
           /** @description Filter blocks ending on or before this date */
-          toDateLte?: string
+          toDateLte?: string;
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean
-          page?: number
-          limit?: number
-        }
-      }
+          active?: boolean;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully searched rental blocks */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlockWithRentalObject'][]
+            "application/json": {
+              content?: components["schemas"]["RentalBlockWithRentalObject"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
-              _links?: {
-                href?: string
-                /** @enum {string} */
-                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
+              _links?: ({
+                  href?: string;
+                  /** @enum {string} */
+                  rel?: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/all': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/all": {
     /**
      * Get all rental blocks (paginated)
      * @description Retrieves all rental blocks for residences across the system with pagination support
@@ -5006,46 +4992,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean
+          active?: boolean;
           /** @description Page number (1-indexed) */
-          page?: number
+          page?: number;
           /** @description Number of items per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved all rental blocks. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlockWithRentalObject'][]
+            "application/json": {
+              content?: components["schemas"]["RentalBlockWithRentalObject"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
-              _links?: {
-                href?: string
-                /** @enum {string} */
-                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
+              _links?: ({
+                  href?: string;
+                  /** @enum {string} */
+                  rel?: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/block-reasons': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/block-reasons": {
     /**
      * Get all block reasons
      * @description Returns all available block reasons for rental blocks. Used for filtering dropdowns.
@@ -5055,22 +5041,22 @@ export interface paths {
         /** @description Successfully retrieved block reasons */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                id?: string
-                caption?: string
-              }[]
-            }
-          }
-        }
+                  id?: string;
+                  caption?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/search": {
     /**
      * Search residences
      * @description Searches for residences by rental object id.
@@ -5079,30 +5065,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental object id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residences matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceSearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceSearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/summary/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/summary/by-building-code/{buildingCode}": {
     /**
      * Get residences by building code, optionally filtered by staircase code.
      * @description Returns all residences belonging to a specific building, optionally filtered by staircase code.
@@ -5111,34 +5097,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string
-        }
+          staircaseCode?: string;
+        };
         path: {
           /** @description The building code of the building. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the residences. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceSummary'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceSummary"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/staircases': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/staircases": {
     /**
      * Get staircases for a building
      * @description Retrieves staircases for a building
@@ -5147,42 +5133,42 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch staircases for */
-          buildingCode: string
+          buildingCode: string;
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string
-        }
-      }
+          staircaseCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved staircases. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Staircase'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Staircase"][];
+            };
+          };
+        };
         /** @description Missing buildingCode */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Missing buildingCode */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rooms': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rooms": {
     /**
      * Get rooms by rental id.
      * @description Returns all rooms belonging to a residence.
@@ -5191,30 +5177,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The rental id of the residence. */
-          rentalId: string
+          rentalId: string;
           /** @description The code of the room (optional). */
-          roomCode?: string
-        }
-      }
+          roomCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Create a room for a residence.
      * @description Forwards to property-base-service which performs a transactional
@@ -5224,34 +5210,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateRoomRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateRoomRequest"];
+        };
+      };
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Residence not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/rooms/by-facility-id/{facilityId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/rooms/by-facility-id/{facilityId}": {
     /**
      * Get rooms by facility id.
      * @description Returns all rooms belonging to a facility.
@@ -5260,26 +5246,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The id of the facility. */
-          facilityId: string
-        }
-      }
+          facilityId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"][];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/parking-spaces/by-rental-id/{rentalId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/parking-spaces/by-rental-id/{rentalId}": {
     /**
      * Get parking space data by rentalId
      * @description Retrieves parking space data by rentalId
@@ -5288,40 +5274,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id to fetch parking space for */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved parking space. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ParkingSpace']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ParkingSpace"];
+            };
+          };
+        };
         /** @description Parking space not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Parking space not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve parking space data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-rental-id/{rentalId}": {
     /**
      * Get maintenance units by rental id.
      * @description Returns all maintenance units belonging to a rental property.
@@ -5330,30 +5316,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property for which to retrieve maintenance units. */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-building-code/{buildingCode}": {
     /**
      * Get maintenance units by building code.
      * @description Returns all maintenance units belonging to a building.
@@ -5362,30 +5348,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve maintenance units. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-rental-id/{rentalId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-rental-id/{rentalId}": {
     /**
      * Get facility by rental id.
      * @description Returns facility.
@@ -5394,30 +5380,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental id of the facility. */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facility. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FacilityDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FacilityDetails"];
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-property-code/{code}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-property-code/{code}": {
     /**
      * Get maintenance units by property code.
      * @description Returns all maintenance units belonging to a property.
@@ -5426,30 +5412,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve maintenance units. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-code/{code}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-code/{code}": {
     /**
      * Get a maintenance unit by its code
      * @description Returns a single maintenance unit by its unique code.
@@ -5458,30 +5444,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the maintenance unit to retrieve. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance unit. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"];
+            };
+          };
+        };
         /** @description Maintenance unit not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/search": {
     /**
      * Search maintenance units
      * @description Searches for maintenance units by code.
@@ -5490,30 +5476,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (maintenance unit code). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved maintenance units matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-property-code/{propertyCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-property-code/{propertyCode}": {
     /**
      * Get facilities by property code.
      * @description Returns all facilities belonging to a property.
@@ -5522,30 +5508,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve facilities. */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Facilities not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-building-code/{buildingCode}": {
     /**
      * Get facilities by building code.
      * @description Returns all facilities belonging to a building.
@@ -5554,30 +5540,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve facilities. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Facilities not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/search": {
     /**
      * Search facilities
      * @description Searches for facilities by rental id.
@@ -5586,30 +5572,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved facilities matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FacilitySearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FacilitySearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/parking-spaces/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/parking-spaces/search": {
     /**
      * Search parking spaces
      * @description Searches for parking spaces by rental id.
@@ -5618,30 +5604,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved parking spaces matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ParkingSpaceSearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ParkingSpaceSearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/apartments/{objectNumber}/temperatures': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/apartments/{objectNumber}/temperatures": {
     /**
      * Get indoor temperatures for an apartment
      * @description Fetches indoor temperature time series for an apartment by its object
@@ -5654,42 +5640,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Unix timestamp (seconds) for range start. Defaults to `to - 86400`. */
-          from?: number
+          from?: number;
           /** @description Unix timestamp (seconds) for range end. Defaults to now. */
-          to?: number
+          to?: number;
           /** @description Aggregation bucket size. Defaults to "H" (hourly). */
-          interval?: 'H' | 'D'
-        }
+          interval?: "H" | "D";
+        };
         path: {
           /** @description Apartment object number (e.g. "806-032-01-0101"). */
-          objectNumber: string
-        }
-      }
+          objectNumber: string;
+        };
+      };
       responses: {
         /** @description Temperature series successfully retrieved. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ApartmentTemperaturesResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ApartmentTemperaturesResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description No apartment node found for the given object number. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/search": {
     /**
      * Omni-search for different entities
      * @description Search for properties, buildings, residences, parking spaces, and maintenance units.
@@ -5706,30 +5692,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query string */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description A list of search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SearchResult"][];
+            };
+          };
+        };
         /** @description Bad request - invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/inspections': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/inspections": {
     /**
      * Retrieve inspections from all sources
      * @description Retrieves inspections from both the local database and Xpand, merged with a source indicator per item.
@@ -5738,58 +5724,58 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number
+          page?: number;
           /** @description Maximum number of records to return. */
-          limit?: number
+          limit?: number;
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
+          statusFilter?: "ongoing" | "completed";
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false
+          sortAscending?: true | false;
           /** @description Filter inspections by inspector name. */
-          inspector?: string
+          inspector?: string;
           /** @description Filter inspections by address. */
-          address?: string
-        }
-      }
+          address?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections from all sources. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['InspectionWithSource'][]
+            "application/json": {
+              content?: components["schemas"]["InspectionWithSource"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid query parameters */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
+              error?: string;
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new inspection
      * @description Creates a new inspection in the local inspection database
@@ -5797,40 +5783,40 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateInspectionRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateInspectionRequest"];
+        };
+      };
       responses: {
         /** @description Inspection created successfully */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['DetailedInspection']
-              }
-            }
-          }
-        }
+                inspection?: components["schemas"]["DetailedInspection"];
+              };
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/residence/{residenceId}': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/residence/{residenceId}": {
     /**
      * Retrieve inspections by residence ID from all sources
      * @description Retrieves inspections associated with a specific residence ID from both the local database and Xpand.
@@ -5839,37 +5825,37 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
-        }
+          statusFilter?: "ongoing" | "completed";
+        };
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string
-        }
-      }
+          residenceId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspections?: components['schemas']['InspectionWithSource'][]
-              }
-            }
-          }
-        }
+                inspections?: components["schemas"]["InspectionWithSource"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand": {
     /**
      * Retrieve inspections from Xpand
      * @description Retrieves inspections from Xpand with pagination and status filtering support.
@@ -5878,60 +5864,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number
+          page?: number;
           /** @description Maximum number of records to return. */
-          limit?: number
+          limit?: number;
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
+          statusFilter?: "ongoing" | "completed";
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false
+          sortAscending?: true | false;
           /** @description Filter inspections by inspector name. */
-          inspector?: string
+          inspector?: string;
           /** @description Filter inspections by address. */
-          address?: string
-        }
-      }
+          address?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Inspection'][]
+            "application/json": {
+              content?: components["schemas"]["Inspection"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid query parameters */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/residence/{residenceId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/residence/{residenceId}": {
     /**
      * Retrieve inspections by residence ID from Xpand
      * @description Retrieves inspections associated with a specific residence ID from Xpand.
@@ -5940,46 +5926,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
-        }
+          statusFilter?: "ongoing" | "completed";
+        };
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string
-        }
-      }
+          residenceId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspections?: components['schemas']['Inspection'][]
-              }
-            }
-          }
-        }
+                inspections?: components["schemas"]["Inspection"][];
+              };
+            };
+          };
+        };
         /** @description No inspections found for the specified residence ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/{inspectionId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/{inspectionId}": {
     /**
      * Retrieve an inspection by ID from Xpand
      * @description Retrieves a specific inspection by its ID from Xpand.
@@ -5988,40 +5974,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['DetailedInspection']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["DetailedInspection"];
+            };
+          };
+        };
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve the inspection. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/{inspectionId}/pdf': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/{inspectionId}/pdf": {
     /**
      * Generate PDF protocol for an inspection
      * @description Generates and returns a PDF protocol for a specific inspection by its ID.
@@ -6030,47 +6016,47 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean
-        }
+          includeCosts?: boolean;
+        };
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string
-              }
-            }
-          }
-        }
+                pdfBase64?: string;
+              };
+            };
+          };
+        };
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to generate PDF. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/details': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/details": {
     /**
      * Retrieve an enriched internal inspection by ID
      * @description Retrieves a specific internal inspection by its ID, normalized into the same shape as Xpand inspections (with lease, residence, and flattened room remarks) so it can be rendered by the protocol UI without source-specific branching.
@@ -6079,38 +6065,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['DetailedInspection']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["DetailedInspection"];
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/pdf': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/pdf": {
     /**
      * Generate PDF protocol for an internal inspection
      * @description Generates and returns a PDF protocol for a specific internal inspection by its ID.
@@ -6119,45 +6105,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean
-        }
+          includeCosts?: boolean;
+        };
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string
-              }
-            }
-          }
-        }
+                pdfBase64?: string;
+              };
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/tenant-contacts': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/tenant-contacts": {
     /**
      * Get tenant contacts for an internal inspection
      * @description Retrieves contact information for new and previous tenants associated with an internal inspection's residence.
@@ -6165,38 +6151,38 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant contacts. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['TenantContactsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["TenantContactsResponse"];
+            };
+          };
+        };
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/send-protocol': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/send-protocol": {
     /**
      * Send inspection protocol to tenant for an internal inspection
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous) for an internal inspection.
@@ -6204,51 +6190,51 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SendProtocolRequest']
-        }
-      }
+          "application/json": components["schemas"]["SendProtocolRequest"];
+        };
+      };
       responses: {
         /** @description Protocol sent successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SendProtocolResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SendProtocolResponse"];
+            };
+          };
+        };
         /** @description Invalid request or no contract found. */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/{inspectionId}/tenant-contacts': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/{inspectionId}/tenant-contacts": {
     /**
      * Get tenant contacts for inspection protocol modal
      * @description Retrieves contact information for new and previous tenants to display in confirmation modal before sending protocol
@@ -6257,40 +6243,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant contacts */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['TenantContactsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["TenantContactsResponse"];
+            };
+          };
+        };
         /** @description Inspection or residence not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Inspection not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/{inspectionId}/send-protocol': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/{inspectionId}/send-protocol": {
     /**
      * Send inspection protocol to tenant
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous)
@@ -6299,90 +6285,90 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SendProtocolRequest']
-        }
-      }
+          "application/json": components["schemas"]["SendProtocolRequest"];
+        };
+      };
       responses: {
         /** @description Protocol sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SendProtocolResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SendProtocolResponse"];
+            };
+          };
+        };
         /** @description Invalid request or no contract found */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid request body */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Inspection not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}": {
     /** Get internal inspection by ID including draft room data */
     get: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Internal inspection with draft room data */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['InternalInspection']
-              }
-            }
-          }
-        }
+                inspection?: components["schemas"]["InternalInspection"];
+              };
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
     /**
      * Update internal inspection
      * @description Updates an internal inspection. Supports updating status (with valid transitions Registrerad → Påbörjad → Genomförd) and/or inspector. At least one field must be provided.
@@ -6391,100 +6377,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to update */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateInspectionStatusRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateInspectionStatusRequest"];
+        };
+      };
       responses: {
         /** @description Inspection updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['InternalInspection']
+                inspection?: components["schemas"]["InternalInspection"];
                 /** @description Per-component write-back errors recorded when transitioning to "Genomförd". Empty for other status transitions. */
-                componentWriteBackErrors?: components['schemas']['ComponentWriteBackError'][]
-              }
-            }
-          }
-        }
+                componentWriteBackErrors?: components["schemas"]["ComponentWriteBackError"][];
+              };
+            };
+          };
+        };
         /** @description Invalid request body or invalid status transition */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/draft': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/draft": {
     /** Save inspection draft data (rooms and inspector name) */
     patch: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SaveInspectionDraftRequest']
-        }
-      }
+          "application/json": components["schemas"]["SaveInspectionDraftRequest"];
+        };
+      };
       responses: {
         /** @description Draft saved successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request body */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/rooms': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/rooms": {
     /**
      * Add a room to a residence during an inspection.
      * @description Creates a new room in Xpand (via property-base) for the residence
@@ -6500,53 +6486,53 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['AddInspectionRoomRequest']
-        }
-      }
+          "application/json": components["schemas"]["AddInspectionRoomRequest"];
+        };
+      };
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                room?: components['schemas']['Room']
-              }
-            }
-          }
-        }
+                room?: components["schemas"]["Room"];
+              };
+            };
+          };
+        };
         /** @description Invalid request body or no residence linked to the inspection. */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/rooms/{roomId}': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/rooms/{roomId}": {
     /**
      * Remove a room that was added during the current inspection.
      * @description Symmetric to POST /inspections/internal/{inspectionId}/rooms.
@@ -6562,206 +6548,206 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          inspectionId: string
-          roomId: string
-        }
-      }
+          inspectionId: string;
+          roomId: string;
+        };
+      };
       responses: {
         /** @description Room removed. */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /**
          * @description Inspection not found, room not found in Xpand, or the room was
          * not added during this inspection.
          */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Room has installed components and cannot be removed. */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files": {
     /** List files with optional prefix */
     get: {
       parameters: {
         query?: {
-          prefix?: string
-        }
-      }
+          prefix?: string;
+        };
+      };
       responses: {
         /** @description List of files with metadata */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListFilesResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListFilesResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/upload": {
     /** Upload a file */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['FileUploadRequest']
-        }
-      }
+          "application/json": components["schemas"]["FileUploadRequest"];
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileUploadResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileUploadResponse"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/url': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/url": {
     /** Get presigned URL for file download */
     get: {
       parameters: {
         query?: {
           /** @description URL expiry time in seconds */
-          expirySeconds?: number
-        }
+          expirySeconds?: number;
+        };
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description Presigned URL generated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileUrlResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileUrlResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/metadata': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/metadata": {
     /** Get file metadata */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File metadata */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileMetadata']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileMetadata"];
+            };
+          };
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}": {
     /** Delete a file */
     delete: {
       parameters: {
         path: {
           /** @description Name of the file to delete */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/exists': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/exists": {
     /** Check if file exists */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File existence status */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileExistsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileExistsResponse"];
+            };
+          };
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/dax/card-owners': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/dax/card-owners": {
     /**
      * Search card owners from DAX
      * @description Search for card owners in the DAX access control system
@@ -6770,44 +6756,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by name (rental object ID / object code) */
-          nameFilter?: string
+          nameFilter?: string;
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string
+          expand?: string;
           /** @description Filter by ID */
-          idfilter?: string
+          idfilter?: string;
           /** @description Filter by attribute */
-          attributeFilter?: string
+          attributeFilter?: string;
           /** @description Select specific attributes to return */
-          selectedAttributes?: string
+          selectedAttributes?: string;
           /** @description Filter by folder */
-          folderFilter?: string
+          folderFilter?: string;
           /** @description Filter by organisation */
-          organisationFilter?: string
+          organisationFilter?: string;
           /** @description Pagination offset */
-          offset?: number
+          offset?: number;
           /** @description Maximum number of results */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Card owners retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              cardOwners?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              cardOwners?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Failed to fetch card owners */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/dax/card-owners/{cardOwnerId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/dax/card-owners/{cardOwnerId}": {
     /**
      * Get a specific card owner from DAX
      * @description Retrieve a card owner by ID from the DAX access control system
@@ -6816,38 +6802,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string
-        }
+          expand?: string;
+        };
         path: {
           /** @description The card owner ID */
-          cardOwnerId: string
-        }
-      }
+          cardOwnerId: string;
+        };
+      };
       responses: {
         /** @description Card owner retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              cardOwner?: components['schemas']['CardOwner']
-            }
-          }
-        }
+            "application/json": {
+              cardOwner?: components["schemas"]["CardOwner"];
+            };
+          };
+        };
         /** @description Card owner not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Failed to fetch card owner */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/dax/cards/{cardId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/dax/cards/{cardId}": {
     /**
      * Get a specific card from DAX
      * @description Retrieve a card by ID from the DAX access control system
@@ -6856,38 +6842,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "codes") */
-          expand?: string
-        }
+          expand?: string;
+        };
         path: {
           /** @description The card ID */
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Card retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              card?: components['schemas']['Card']
-            }
-          }
-        }
+            "application/json": {
+              card?: components["schemas"]["Card"];
+            };
+          };
+        };
         /** @description Card not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Failed to fetch card */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-bundles': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-bundles": {
     /**
      * List key bundles with pagination
      * @description Fetches a paginated list of all key bundles ordered by name.
@@ -6896,28 +6882,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description A paginated list of key bundles. */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description An error occurred while listing key bundles. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key bundle
      * @description Create a new key bundle record.
@@ -6925,30 +6911,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyBundleRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyBundleRequest"];
+        };
+      };
       responses: {
         /** @description Key bundle created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while creating the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/search": {
     /**
      * Search key bundles with pagination
      * @description Search key bundles with flexible filtering and pagination.
@@ -6957,35 +6943,35 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. */
-          fields?: string
-        }
-      }
+          fields?: string;
+        };
+      };
       responses: {
         /** @description Paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description Invalid search parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/by-key/{keyId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/by-key/{keyId}": {
     /**
      * Get all bundles containing a specific key
      * @description Returns all bundle records containing the specified key ID
@@ -6994,26 +6980,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to search for */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description Array of bundles containing this key */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/{id}": {
     /**
      * Get key bundle by ID
      * @description Fetch a specific key bundle by its ID.
@@ -7022,28 +7008,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key bundle object. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while fetching the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a key bundle
      * @description Delete a key bundle by ID.
@@ -7052,24 +7038,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to delete. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key bundle deleted successfully. */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while deleting the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a key bundle
      * @description Partially update an existing key bundle.
@@ -7078,39 +7064,39 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyBundleRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyBundleRequest"];
+        };
+      };
       responses: {
         /** @description Key bundle updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while updating the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/{id}/keys-with-loan-status': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/{id}/keys-with-loan-status": {
     /**
      * Get keys in bundle with maintenance loan status
      * @description Fetches all keys in a key bundle along with their active maintenance loan information
@@ -7124,38 +7110,38 @@ export interface paths {
            * Soft fails — if the contacts service errors, the response is
            * returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The key bundle ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Bundle information and keys with loan status */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundleDetailsResponse']
+            "application/json": {
+              content?: components["schemas"]["KeyBundleDetailsResponse"];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Key bundle not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/by-contact/{contactCode}/with-loaned-keys': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/by-contact/{contactCode}/with-loaned-keys": {
     /**
      * Get key bundles with keys loaned to a contact
      * @description Fetches all key bundles that have keys currently loaned to a specific contact.
@@ -7164,28 +7150,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code (F-number) to find bundles for */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description A list of bundles with loaned keys info. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BundleWithLoanedKeysInfo'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BundleWithLoanedKeysInfo"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching bundles. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events": {
     /**
      * Get all key events
      * @description Returns all key events ordered by creation date.
@@ -7195,19 +7181,19 @@ export interface paths {
         /** @description List of key events. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a key event
      * @description Create a new key event record. Will fail with 409 if any of the keys have an incomplete event (status not COMPLETED).
@@ -7215,43 +7201,43 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyEventRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyEventRequest"];
+        };
+      };
       responses: {
         /** @description Key event created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Conflict - one or more keys have incomplete events. */
         409: {
           content: {
-            'application/json': {
-              reason?: string
-              conflictingKeys?: string[]
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+              conflictingKeys?: string[];
+            };
+          };
+        };
         /** @description An error occurred while creating the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events/by-key/{keyId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events/by-key/{keyId}": {
     /**
      * Get all key events for a specific key
      * @description Returns all key events associated with a specific key ID. Optionally limit results to get only the latest event(s).
@@ -7260,32 +7246,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional limit on number of results (e.g., 1 for latest event only). */
-          limit?: number
-        }
+          limit?: number;
+        };
         path: {
           /** @description The key ID to filter events by. */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description List of key events for the key. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events/{id}": {
     /**
      * Get key event by ID
      * @description Fetch a specific key event by its ID.
@@ -7294,32 +7280,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key event object. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Key event not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while fetching the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key event
      * @description Update an existing key event.
@@ -7328,45 +7314,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyEventRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyEventRequest"];
+        };
+      };
       responses: {
         /** @description Key event updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key event not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while updating the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans": {
     /**
      * List all key loans
      * @description Fetches a list of all key loans ordered by creation date.
@@ -7376,19 +7362,19 @@ export interface paths {
         /** @description A list of key loans. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
+            };
+          };
+        };
         /** @description An error occurred while listing key loans. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key loan
      * @description Create a new key loan record.
@@ -7396,34 +7382,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyLoanRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyLoanRequest"];
+        };
+      };
       responses: {
         /** @description Key loan created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"];
+            };
+          };
+        };
         /** @description Invalid request data. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description An error occurred while creating the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/search": {
     /**
      * Search key loans
      * @description Search key loans with flexible filtering.
@@ -7436,69 +7422,69 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          q?: string
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to contact and contact2. */
-          fields?: string
+          fields?: string;
           /** @description Search by key name or rental object code (requires JOIN with keys table) */
-          keyNameOrObjectCode?: string
+          keyNameOrObjectCode?: string;
           /** @description Minimum number of keys in loan */
-          minKeys?: number
+          minKeys?: number;
           /** @description Maximum number of keys in loan */
-          maxKeys?: number
+          maxKeys?: number;
           /** @description Filter by pickedUpAt null status (true = NOT NULL, false = NULL) */
-          hasPickedUp?: boolean
+          hasPickedUp?: boolean;
           /** @description Filter by returnedAt null status (true = NOT NULL, false = NULL) */
-          hasReturned?: boolean
-          id?: string
-          keys?: string
-          contact?: string
-          contact2?: string
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          hasReturned?: boolean;
+          id?: string;
+          keys?: string;
+          contact?: string;
+          contact2?: string;
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          returnedAt?: string
-          availableToNextTenantFrom?: string
+          returnedAt?: string;
+          availableToNextTenantFrom?: string;
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          pickedUpAt?: string
-          createdAt?: string
-          updatedAt?: string
+          pickedUpAt?: string;
+          createdAt?: string;
+          updatedAt?: string;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Successfully retrieved search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-key/{keyId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-key/{keyId}": {
     /**
      * Get all loans for a specific key
      * @description Returns all loan records for the specified key ID, ordered by creation date DESC
@@ -7512,36 +7498,36 @@ export interface paths {
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The key ID to fetch loans for */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description Array of loans for this key */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-card/{cardId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-card/{cardId}": {
     /**
      * Get all loans for a specific card
      * @description Returns all loan records for the specified card ID, ordered by creation date DESC
@@ -7550,23 +7536,23 @@ export interface paths {
       parameters: {
         path: {
           /** @description The card ID to fetch loans for */
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Array of loans for this card */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
-            }
-          }
-        }
-        500: components['responses']['InternalServerError']
-      }
-    }
-  }
-  '/key-loans/by-rental-object/{rentalObjectCode}': {
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
+            };
+          };
+        };
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+  };
+  "/key-loans/by-rental-object/{rentalObjectCode}": {
     /**
      * Get key loans by rental object code
      * @description Returns all key loans for a specific rental object with keys and optional receipts
@@ -7575,43 +7561,43 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by contact code */
-          contact?: string
+          contact?: string;
           /** @description Filter by second contact code */
-          contact2?: string
+          contact2?: string;
           /** @description Include receipts in the response */
-          includeReceipts?: boolean
+          includeReceipts?: boolean;
           /**
            * @description Filter by return status:
            * - true: Only returned loans (returnedAt IS NOT NULL)
            * - false: Only active loans (returnedAt IS NULL)
            * - omitted: All loans (no filter)
            */
-          returned?: boolean
-        }
+          returned?: boolean;
+        };
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description A list of key loans with details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-contact/{contact}/with-keys': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-contact/{contact}/with-keys": {
     /**
      * Get key loans by contact with keys
      * @description Returns all key loans for a specific contact with full key details, optionally filtered by loan type and return status
@@ -7620,45 +7606,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean
+          returned?: boolean;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The contact identifier to search for */
-          contact: string
-        }
-      }
+          contact: string;
+        };
+      };
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-bundle/{bundleId}/with-keys': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-bundle/{bundleId}/with-keys": {
     /**
      * Get key loans by bundle with keys
      * @description Returns all key loans for a specific bundle with full key details, optionally filtered by loan type and return status
@@ -7667,45 +7653,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean
+          returned?: boolean;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The bundle ID to search for */
-          bundleId: string
-        }
-      }
+          bundleId: string;
+        };
+      };
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/{id}": {
     /**
      * Get key loan by ID
      * @description Fetch a specific key loan by its ID.
@@ -7718,44 +7704,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description When true, includes keysArray with keySystem data attached to each key. */
-          includeKeySystem?: boolean
+          includeKeySystem?: boolean;
           /** @description When true, includes keyCardsArray with card data from DAX. Auto-implies key fetching. */
-          includeCards?: boolean
+          includeCards?: boolean;
           /** @description When true, includes loan history attached to each key in keysArray. */
-          includeLoans?: boolean
+          includeLoans?: boolean;
           /** @description When true, includes event history attached to each key in keysArray. */
-          includeEvents?: boolean
-        }
+          includeEvents?: boolean;
+        };
         path: {
           /** @description The unique ID of the key loan to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key loan object. Returns KeyLoanWithDetails if includeKeySystem or includeCards is true. */
         200: {
           content: {
-            'application/json': {
-              content?:
-                | components['schemas']['KeyLoan']
-                | components['schemas']['KeyLoanWithDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"] | components["schemas"]["KeyLoanWithDetails"];
+            };
+          };
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while fetching the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a key loan
      * @description Delete an existing key loan by ID.
@@ -7764,28 +7748,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to delete. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key loan deleted successfully. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while deleting the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key loan
      * @description Partially update an existing key loan.
@@ -7794,45 +7778,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyLoanRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyLoanRequest"];
+        };
+      };
       responses: {
         /** @description Key loan updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"];
+            };
+          };
+        };
         /** @description Invalid request data. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while updating the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes/{id}": {
     /**
      * Get key note by ID
      * @description Retrieve a specific key note by its ID
@@ -7841,32 +7825,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key note
      * @description Update the description of an existing key note
@@ -7875,45 +7859,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyNoteRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyNoteRequest"];
+        };
+      };
       responses: {
         /** @description Key note updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes/by-rental-object/{rentalObjectCode}": {
     /**
      * Get key note by rental object code
      * @description Retrieve the key note for a specific rental object
@@ -7922,34 +7906,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes": {
     /**
      * Create a new key note
      * @description Create a new key note for a rental object
@@ -7957,34 +7941,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyNoteRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyNoteRequest"];
+        };
+      };
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems": {
     /**
      * List all key systems with pagination
      * @description Retrieve a paginated list of all key systems
@@ -7993,28 +7977,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated key systems */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeySystem'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeySystem"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key system
      * @description Create a new key system
@@ -8022,34 +8006,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeySystemRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeySystemRequest"];
+        };
+      };
       responses: {
         /** @description Key system created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/search": {
     /**
      * Search key systems
      * @description Search key systems with flexible filtering.
@@ -8066,54 +8050,54 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Search query for OR search across fields specified in 'fields' parameter */
-          q?: string
+          q?: string;
           /** @description Comma-separated list of fields for OR search (e.g., "systemCode,manufacturer"). Defaults to systemCode. */
-          fields?: string
-          id?: string
-          systemCode?: string
-          name?: string
-          manufacturer?: string
-          managingSupplier?: string
-          type?: string
-          propertyIds?: string
-          installationDate?: string
-          isActive?: string
-          notes?: string
-          createdAt?: string
-          updatedAt?: string
-          createdBy?: string
-          updatedBy?: string
-        }
-      }
+          fields?: string;
+          id?: string;
+          systemCode?: string;
+          name?: string;
+          manufacturer?: string;
+          managingSupplier?: string;
+          type?: string;
+          propertyIds?: string;
+          installationDate?: string;
+          isActive?: string;
+          notes?: string;
+          createdAt?: string;
+          updatedAt?: string;
+          createdBy?: string;
+          updatedBy?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeySystem'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeySystem"][];
+            };
+          };
+        };
         /** @description Bad request. Invalid parameters or field names */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/{id}": {
     /**
      * Get key system by ID
      * @description Retrieve a specific key system by its ID
@@ -8122,32 +8106,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key system */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a key system
      * @description Delete a key system by ID
@@ -8156,28 +8140,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to delete */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key system deleted successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key system
      * @description Partially update a key system
@@ -8186,139 +8170,139 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeySystemRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeySystemRequest"];
+        };
+      };
       responses: {
         /** @description Key system updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/upload-schema': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/upload-schema": {
     /** Upload a schema file for a key system */
     post: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
-            fileContentType?: string
-            fileName?: string
-          }
-        }
-      }
+            fileData: string;
+            fileContentType?: string;
+            fileName?: string;
+          };
+        };
+      };
       responses: {
         /** @description Schema file uploaded successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                fileId?: string
-              }
-            }
-          }
-        }
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Missing fileData */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/download-schema': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/download-schema": {
     /** Get presigned download URL for a key system schema file */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            'application/json': components['schemas']['SchemaDownloadUrlResponse']
-          }
-        }
+            "application/json": components["schemas"]["SchemaDownloadUrlResponse"];
+          };
+        };
         /** @description Key system or schema file not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/schema': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/schema": {
     /** Delete the schema file for a key system */
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Schema deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/keys': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/keys": {
     /**
      * List keys with pagination
      * @description Returns paginated keys ordered by createdAt (desc).
@@ -8327,71 +8311,71 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Paginated list of keys */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyDetails'][]
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Create a key */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyRequest"];
+        };
+      };
       responses: {
         /** @description Created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Invalid key_type */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/search": {
     /**
      * Search keys
      * @description Search keys with flexible filtering.
@@ -8404,59 +8388,59 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to keyName. */
-          fields?: string
-          id?: string
-          keyName?: string
-          keySequenceNumber?: string
-          flexNumber?: string
-          rentalObjectCode?: string
-          keyType?: string
-          keySystemId?: string
-          createdAt?: string
-          updatedAt?: string
+          fields?: string;
+          id?: string;
+          keyName?: string;
+          keySequenceNumber?: string;
+          flexNumber?: string;
+          rentalObjectCode?: string;
+          keyType?: string;
+          keySystemId?: string;
+          createdAt?: string;
+          updatedAt?: string;
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyDetails'][]
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/by-rental-object/{rentalObjectCode}": {
     /**
      * Get all keys by rental object code
      * @description Returns all keys associated with a specific rental object code without pagination
@@ -8465,182 +8449,182 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to filter keys by */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved keys */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/cards/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/cards/by-rental-object/{rentalObjectCode}": {
     /** Get cards by rental object code */
     get: {
       parameters: {
         query?: {
-          includeLoans?: boolean
-        }
+          includeLoans?: boolean;
+        };
         path: {
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Cards for the rental object */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CardDetails'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/cards/{cardId}': {
+            "application/json": {
+              content?: components["schemas"]["CardDetails"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/cards/{cardId}": {
     /** Get card by ID */
     get: {
       parameters: {
         path: {
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Card found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Card']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Card"];
+            };
+          };
+        };
         /** @description Card not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/{id}": {
     /** Get key by ID */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Delete a key */
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Deleted */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Update a key (partial) */
     patch: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyRequest"];
+        };
+      };
       responses: {
         /** @description Updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Invalid key_type */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-update': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-update": {
     /**
      * Bulk update keys
      * @description Update multiple keys with the same values. Maximum 100 keys per request.
@@ -8648,35 +8632,35 @@ export interface paths {
     patch: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['BulkUpdateKeysRequest']
-        }
-      }
+          "application/json": components["schemas"]["BulkUpdateKeysRequest"];
+        };
+      };
       responses: {
         /** @description Keys updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys updated */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-update-flex': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-update-flex": {
     /**
      * Bulk update flex number for all keys on a rental object
      * @description Update the flex number for all keys associated with a specific rental object code. Flex numbers range from 1-3.
@@ -8684,35 +8668,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['BulkUpdateFlexRequest']
-        }
-      }
+          "application/json": components["schemas"]["BulkUpdateFlexRequest"];
+        };
+      };
       responses: {
         /** @description Flex numbers updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys updated */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-delete': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-delete": {
     /**
      * Bulk delete keys
      * @description Delete multiple keys by their IDs. Maximum 100 keys per request.
@@ -8720,37 +8704,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            keyIds: string[]
-          }
-        }
-      }
+          "application/json": {
+            keyIds: string[];
+          };
+        };
+      };
       responses: {
         /** @description Keys deleted successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys deleted */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs": {
     /**
      * List logs with pagination
      * @description Returns paginated logs (most recent per objectId) ordered by eventTime (desc).
@@ -8759,60 +8743,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Paginated list of logs */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Create a log */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateLogRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateLogRequest"];
+        };
+      };
       responses: {
         /** @description Created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"];
+            };
+          };
+        };
         /** @description Invalid or missing fields */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/search": {
     /**
      * Search logs with pagination
      * @description Search logs with flexible filtering and pagination.
@@ -8825,46 +8809,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to objectId. */
-          fields?: string
-          id?: string
-          userName?: string
-          eventType?: string
-          eventTime?: string
-          objectType?: string
-          objectId?: string
-          description?: string
-        }
-      }
+          fields?: string;
+          id?: string;
+          userName?: string;
+          eventType?: string;
+          eventTime?: string;
+          objectType?: string;
+          objectId?: string;
+          description?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/object/{objectId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/object/{objectId}": {
     /**
      * Get all logs for a specific objectId
      * @description Returns all log entries for a given objectId, ordered by most recent first
@@ -8872,60 +8856,60 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          objectId: string
-        }
-      }
+          objectId: string;
+        };
+      };
       responses: {
         /** @description List of logs for the objectId */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/{id}": {
     /** Get log by ID */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Log found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"];
+            };
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/rental-object/{rentalObjectCode}": {
     /**
      * Get all logs for a specific rental object
      * @description Returns all log entries for a given rental object code by JOINing across multiple tables.
@@ -8942,40 +8926,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string
+          eventType?: string;
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string
+          objectType?: string;
           /** @description Filter by user name */
-          userName?: string
-        }
+          userName?: string;
+        };
         path: {
           /** @description The rental object code (e.g., "705-011-03-0102") */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Paginated list of logs for the rental object */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/contact/{contactId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/contact/{contactId}": {
     /**
      * Get all logs for a specific contact
      * @description Returns all log entries for a given contact code by JOINing across keyLoans and receipts.
@@ -8992,40 +8976,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string
+          eventType?: string;
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string
+          objectType?: string;
           /** @description Filter by user name */
-          userName?: string
-        }
+          userName?: string;
+        };
         path: {
           /** @description The contact code (e.g., "P079586", "F123456") */
-          contactId: string
-        }
-      }
+          contactId: string;
+        };
+      };
       responses: {
         /** @description Paginated list of logs for the contact */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts": {
     /**
      * Create a receipt
      * @description Create a new receipt record for a key loan
@@ -9033,34 +9017,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateReceiptRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateReceiptRequest"];
+        };
+      };
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts/{id}": {
     /**
      * Get a receipt by ID
      * @description Retrieve a specific receipt by its ID
@@ -9069,32 +9053,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The receipt ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved receipt */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a receipt
      * @description Delete a receipt by ID (and associated file from MinIO)
@@ -9103,28 +9087,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to delete */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Receipt deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a receipt
      * @description Update a receipt (e.g., set fileId after upload)
@@ -9133,144 +9117,144 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateReceiptRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateReceiptRequest"];
+        };
+      };
       responses: {
         /** @description Receipt updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts/by-key-loan/{keyLoanId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts/by-key-loan/{keyLoanId}": {
     /** Get receipts by key loan ID */
     get: {
       parameters: {
         path: {
-          keyLoanId: string
-        }
-      }
+          keyLoanId: string;
+        };
+      };
       responses: {
         /** @description Receipts for the key loan */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/receipts/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/receipts/{id}/upload": {
     /** Upload a file for a receipt */
     post: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
-            fileContentType?: string
-          }
-        }
-      }
+            fileData: string;
+            fileContentType?: string;
+          };
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                fileId?: string
-              }
-            }
-          }
-        }
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Missing fileData */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Receipt not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/receipts/{id}/download': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/receipts/{id}/download": {
     /** Get presigned download URL for a receipt file */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                url?: string
-                expiresIn?: number
-                fileId?: string
-              }
-            }
-          }
-        }
+                url?: string;
+                expiresIn?: number;
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Receipt or file not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/signatures/send': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/signatures/send": {
     /**
      * Send a document for digital signature via SimpleSign
      * @description Send a PDF document to SimpleSign for digital signature
@@ -9278,49 +9262,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @enum {string} */
-            resourceType: 'receipt'
+            resourceType: "receipt";
             /** Format: uuid */
-            resourceId: string
+            resourceId: string;
             /** Format: email */
-            recipientEmail: string
-            recipientName?: string
-            pdfBase64: string
-          }
-        }
-      }
+            recipientEmail: string;
+            recipientName?: string;
+            pdfBase64: string;
+          };
+        };
+      };
       responses: {
         /** @description Signature request sent successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Resource not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/signatures/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/signatures/{id}": {
     /**
      * Get a signature by ID
      * @description Retrieve a specific signature by its ID
@@ -9328,34 +9312,34 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Signature details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"];
+            };
+          };
+        };
         /** @description Signature not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/signatures/resource/{resourceType}/{resourceId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/signatures/resource/{resourceType}/{resourceId}": {
     /**
      * Get all signatures for a resource
      * @description Retrieve all signatures associated with a specific resource
@@ -9363,29 +9347,29 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          resourceType: 'receipt'
-          resourceId: string
-        }
-      }
+          resourceType: "receipt";
+          resourceId: string;
+        };
+      };
       responses: {
         /** @description List of signatures */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/webhooks/simplesign': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/webhooks/simplesign": {
     /**
      * Webhook endpoint for SimpleSign status updates
      * @description Receives webhook notifications from SimpleSign when document status changes (e.g., signed, declined)
@@ -9393,26 +9377,26 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['SimpleSignWebhookPayload']
-        }
-      }
+          "application/json": components["schemas"]["SimpleSignWebhookPayload"];
+        };
+      };
       responses: {
         /** @description Webhook processed successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Signature not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/v1/contacts': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/v1/contacts": {
     /**
      * List and filter(search) for contact information
      * @description Filtering can be done by wildcard search
@@ -9421,55 +9405,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Wildcard search string */
-          q?: string[]
+          q?: string[];
           /** @description Filter on contact type */
-          type?: 'individual' | 'organisation'
+          type?: "individual" | "organisation";
           /** @description Page number for paginated results (1-based) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              content: components['schemas']['ContactV1'][]
+            "application/json": {
+              content: components["schemas"]["ContactV1"][];
               _meta: {
-                totalRecords: number
-                page: number
-                limit: number
-                count: number
-              }
-              _links: {
-                href: string
-                /** @enum {string} */
-                rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords: number;
+                page: number;
+                limit: number;
+                count: number;
+              };
+              _links: ({
+                  href: string;
+                  /** @enum {string} */
+                  rel: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
         /** @description Internal Server Error */
         500: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/batch': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/batch": {
     /**
      * Batch lookup of contacts by contact code
      * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, or `includeAddress` to include those joins. Missing contact codes are simply absent from the response.
@@ -9478,3014 +9462,2868 @@ export interface paths {
       parameters: {
         query: {
           /** @description Contact code(s) to look up. Repeat the parameter for multiple codes, e.g. ?code=P123&code=P456. */
-          code: string[]
+          code: string[];
           /** @description Include phone numbers in the response. */
-          includePhone?: boolean
+          includePhone?: boolean;
           /** @description Include email addresses in the response. */
-          includeEmail?: boolean
+          includeEmail?: boolean;
           /** @description Include addresses in the response. */
-          includeAddress?: boolean
-        }
-      }
+          includeAddress?: boolean;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1'][]
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"][];
+            };
+          };
+        };
         /** @description Internal Server Error */
         500: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/{contactCode}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/{contactCode}": {
     /** Get a single contact by canonical id (contact code) */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/{contactCode}/trustee': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/{contactCode}/trustee": {
     /** Get the trustee of a contact */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-phone-number/{phoneNumber}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-phone-number/{phoneNumber}": {
     /** List contacts by phone number */
     get: {
       parameters: {
         path: {
           /** @description Phone Number */
-          phoneNumber: string
-        }
-      }
+          phoneNumber: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-email-address/{emailAddress}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-email-address/{emailAddress}": {
     /** List contacts by email address */
     get: {
       parameters: {
         path: {
           /** @description Email Address */
-          emailAddress: string
-        }
-      }
+          emailAddress: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-national-id/{nid}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-national-id/{nid}": {
     /** List contacts by national id (Personnummer / Org.nr) */
     get: {
       parameters: {
         path: {
           /** @description National ID */
-          nid: string
-        }
-      }
+          nid: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
 }
 
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 
 export interface components {
   schemas: {
     Lease: {
-      leaseId: string
-      leaseNumber: string
+      leaseId: string;
+      leaseNumber: string;
       /** Format: date-time */
-      leaseStartDate: string
+      leaseStartDate: string;
       /** Format: date-time */
-      leaseEndDate?: string
+      leaseEndDate?: string;
       /** @enum {string} */
-      status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-      tenantContactIds?: string[]
-      rentalPropertyId: string
+      status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+      tenantContactIds?: string[];
+      rentalPropertyId: string;
       rentalProperty?: {
-        rentalPropertyId: string
-        apartmentNumber: number
-        size: number
-        type: string
+        rentalPropertyId: string;
+        apartmentNumber: number;
+        size: number;
+        type: string;
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        rentalPropertyType: string
-        additionsIncludedInRent: string
-        otherInfo?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        rentalPropertyType: string;
+        additionsIncludedInRent: string;
+        otherInfo?: string;
         roomTypes?: {
-          roomTypeId: string
-          name: string
-        }[]
+            roomTypeId: string;
+            name: string;
+          }[];
         /** Format: date-time */
-        lastUpdated?: string
-      }
-      type: string
+        lastUpdated?: string;
+      };
+      type: string;
       rentInfo?: {
         currentRent: {
-          rentId?: string
-          leaseId?: string
-          currentRent: number
-          vat: number
-          additionalChargeDescription?: string
-          additionalChargeAmount?: number
+          rentId?: string;
+          leaseId?: string;
+          currentRent: number;
+          vat: number;
+          additionalChargeDescription?: string;
+          additionalChargeAmount?: number;
           /** Format: date-time */
-          rentStartDate?: string
+          rentStartDate?: string;
           /** Format: date-time */
-          rentEndDate?: string
-        }
-      }
+          rentEndDate?: string;
+        };
+      };
       address?: {
-        street?: string
-        number: string
-        postalCode: string
-        city: string
-      }
-      noticeGivenBy?: string
+        street?: string;
+        number: string;
+        postalCode: string;
+        city: string;
+      };
+      noticeGivenBy?: string;
       /** Format: date-time */
-      noticeDate?: string
-      noticeTimeTenant?: string | number
+      noticeDate?: string;
+      noticeTimeTenant?: string | number;
       /** Format: date-time */
-      preferredMoveOutDate?: string
+      preferredMoveOutDate?: string;
       /** Format: date-time */
-      terminationDate?: string
+      terminationDate?: string;
       /** Format: date-time */
-      contractDate?: string
+      contractDate?: string;
       /** Format: date-time */
-      lastDebitDate?: string
+      lastDebitDate?: string;
       /** Format: date-time */
-      approvalDate?: string
+      approvalDate?: string;
       residentialArea?: {
-        code: string
-        caption: string
-      }
+        code: string;
+        caption: string;
+      };
       tenants?: {
-        contactCode: string
-        contactKey: string
-        leaseIds?: string[]
-        firstName: string
-        lastName: string
-        fullName: string
-        nationalRegistrationNumber: string
-        /** Format: date-time */
-        birthDate: string
-        address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        phoneNumbers?: {
-          phoneNumber: string
-          type: string
-          isMainNumber: boolean
-        }[]
-        emailAddress?: string
-        isTenant: boolean
-        parkingSpaceWaitingList?: {
+          contactCode: string;
+          contactKey: string;
+          leaseIds?: string[];
+          firstName: string;
+          lastName: string;
+          fullName: string;
+          nationalRegistrationNumber: string;
           /** Format: date-time */
-          queueTime: string
-          queuePoints: number
-          type: number
-        }
-        specialAttention?: boolean
-        leaseContactType?: string
-      }[]
-    }
+          birthDate: string;
+          address?: {
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          phoneNumbers?: {
+              phoneNumber: string;
+              type: string;
+              isMainNumber: boolean;
+            }[];
+          emailAddress?: string;
+          isTenant: boolean;
+          parkingSpaceWaitingList?: {
+            /** Format: date-time */
+            queueTime: string;
+            queuePoints: number;
+            type: number;
+          };
+          specialAttention?: boolean;
+          leaseContactType?: string;
+        }[];
+    };
     IdentityCheckContact: {
-      contactCode: string
-      nationalRegistrationNumber: string
-    }
+      contactCode: string;
+      nationalRegistrationNumber: string;
+    };
     LeaseSearchResult: {
-      leaseId: string
-      objectTypeCode: string
-      leaseType: string
-      contacts: {
-        name: string
-        contactCode: string
-        email: string | null
-        phone: string | null
-      }[]
-      address: string | null
+      leaseId: string;
+      objectTypeCode: string;
+      leaseType: string;
+      contacts: ({
+          name: string;
+          contactCode: string;
+          email: string | null;
+          phone: string | null;
+        })[];
+      address: string | null;
       /** Format: date-time */
-      startDate: string | null
+      startDate: string | null;
       /** Format: date-time */
-      lastDebitDate: string | null
+      lastDebitDate: string | null;
       /** @enum {number} */
-      status: 0 | 1 | 2 | 3
-      rentalObjectCode: string | null
-      property?: string | null
-      buildingCode?: string | null
-      area?: string | null
-      buildingManager?: string | null
-      districtName?: string | null
-      parkingSpaceType?: string | null
-    }
+      status: 0 | 1 | 2 | 3;
+      rentalObjectCode: string | null;
+      property?: string | null;
+      buildingCode?: string | null;
+      area?: string | null;
+      buildingManager?: string | null;
+      districtName?: string | null;
+      parkingSpaceType?: string | null;
+    };
     ContactInfo: {
-      name: string
-      contactCode: string
-      email: string | null
-      phone: string | null
-    }
+      name: string;
+      contactCode: string;
+      email: string | null;
+      phone: string | null;
+    };
     PaginationMeta: {
-      totalRecords: number
-      page: number
-      limit: number
-      count: number
-    }
+      totalRecords: number;
+      page: number;
+      limit: number;
+      count: number;
+    };
     PaginationLinks: {
-      href: string
+      href: string;
       /** @enum {string} */
-      rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-    }
+      rel: "self" | "first" | "last" | "prev" | "next";
+    };
     Contact: {
-      contactCode: string
-      contactKey: string
-      leaseIds?: string[]
-      firstName: string | null
-      lastName: string | null
-      fullName: string | null
-      nationalRegistrationNumber: string
+      contactCode: string;
+      contactKey: string;
+      leaseIds?: string[];
+      firstName: string | null;
+      lastName: string | null;
+      fullName: string | null;
+      nationalRegistrationNumber: string;
       /** Format: date-time */
-      birthDate: string | null
+      birthDate: string | null;
       address: {
-        street: string
-        number: string
-        postalCode: string
-        city: string
-      } | null
+        street: string;
+        number: string;
+        postalCode: string;
+        city: string;
+      } | null;
       phoneNumbers: {
-        phoneNumber: string
-        type: string
-        isMainNumber: boolean
-      }[]
-      emailAddress: string | null
-      isTenant: boolean
-      specialAttention?: boolean
-    }
+          phoneNumber: string;
+          type: string;
+          isMainNumber: boolean;
+        }[];
+      emailAddress: string | null;
+      isTenant: boolean;
+      specialAttention?: boolean;
+    };
     ListingTextContent: {
       /** Format: uuid */
-      id: string
-      rentalObjectCode: string
-      contentBlocks: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
+      id: string;
+      rentalObjectCode: string;
+      contentBlocks: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     CreateListingTextContentRequest: {
-      rentalObjectCode: string
-      contentBlocks: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
-    }
+      rentalObjectCode: string;
+      contentBlocks: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
+    };
     UpdateListingTextContentRequest: {
-      contentBlocks?: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
-    }
+      contentBlocks?: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
+    };
     WorkOrder: {
-      accessCaption: string
-      caption: string
-      code: string
-      contactCode: string
-      description: string
-      detailsCaption: string
-      externalResource: boolean
-      id: string
+      accessCaption: string;
+      caption: string;
+      code: string;
+      contactCode: string;
+      description: string;
+      detailsCaption: string;
+      externalResource: boolean;
+      id: string;
       /** Format: date-time */
-      lastChanged: string
-      priority: string
+      lastChanged: string;
+      priority: string;
       /** Format: date-time */
-      registered: string
-      dueDate: ('null' | null) | string
-      rentalObjectCode: string
-      status: string
-      hiddenFromMyPages?: boolean
-      workOrderRows: {
-        description: string | null
-        locationCode: string | null
-        equipmentCode: string | null
-      }[]
+      registered: string;
+      dueDate: ("null" | null) | string;
+      rentalObjectCode: string;
+      status: string;
+      hiddenFromMyPages?: boolean;
+      workOrderRows: ({
+          description: string | null;
+          locationCode: string | null;
+          equipmentCode: string | null;
+        })[];
       messages?: {
-        id: number
-        body: string
-        messageType: string
-        author: string
-        /** Format: date-time */
-        createDate: string
-      }[]
-      url?: string
-    }
+          id: number;
+          body: string;
+          messageType: string;
+          author: string;
+          /** Format: date-time */
+          createDate: string;
+        }[];
+      url?: string;
+    };
     XpandWorkOrder: {
-      accessCaption: string
-      caption: string | null
-      code: string
-      contactCode: string | null
-      id: string
+      accessCaption: string;
+      caption: string | null;
+      code: string;
+      contactCode: string | null;
+      id: string;
       /** Format: date-time */
-      lastChanged: string
-      priority: string | null
+      lastChanged: string;
+      priority: string | null;
       /** Format: date-time */
-      registered: string
-      dueDate: ('null' | null) | string
-      rentalObjectCode: string
-      status: string
-    }
+      registered: string;
+      dueDate: ("null" | null) | string;
+      rentalObjectCode: string;
+      status: string;
+    };
     MaintenanceTeam: {
-      id: number
-      name: string
-    }
+      id: number;
+      name: string;
+    };
     CreateInspectionWorkOrdersRequest: {
-      rentalObjectCode: string
+      rentalObjectCode: string;
       groups: {
-        maintenanceTeamId: number
-        maintenanceTeamName: string
-        descriptionHtml: string
-      }[]
-    }
+          maintenanceTeamId: number;
+          maintenanceTeamName: string;
+          descriptionHtml: string;
+        }[];
+    };
     CreateInspectionWorkOrdersResponse: {
       results: {
-        maintenanceTeamId: number
-        ok: boolean
-        workOrderId?: number
-        err?: string
-      }[]
-    }
+          maintenanceTeamId: number;
+          ok: boolean;
+          workOrderId?: number;
+          err?: string;
+        }[];
+    };
     Building: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       buildingType: {
-        id: string | null
-        code: string | null
-        name: string | null
-      }
+        id: string | null;
+        code: string | null;
+        name: string | null;
+      };
       construction: {
-        constructionYear: number | null
-        renovationYear: number | null
-        valueYear: number | null
-      }
+        constructionYear: number | null;
+        renovationYear: number | null;
+        valueYear: number | null;
+      };
       features: {
-        heating?: string | null
-        fireRating?: string | null
-      }
+        heating?: string | null;
+        fireRating?: string | null;
+      };
       insurance: {
-        class: string | null
-        value: number | null
-      }
-      quantityValues?: {
-        id: string
-        value: number
-        name: string
-        unitId: string | null
-      }[]
-      deleted: boolean
-      property?: {
-        name: string | null
-        code: string
-        id: string
-      } | null
-    }
+        class: string | null;
+        value: number | null;
+      };
+      quantityValues?: ({
+          id: string;
+          value: number;
+          name: string;
+          unitId: string | null;
+        })[];
+      deleted: boolean;
+      property?: ({
+        name: string | null;
+        code: string;
+        id: string;
+      }) | null;
+    };
     Company: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string
-      organizationNumber: string | null
-    }
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string;
+      organizationNumber: string | null;
+    };
     CompanyDetails: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string
-      organizationNumber: string | null
-      phone: string | null
-      fax: string | null
-      vatNumber?: string | null
-      internalExternal: number
-      fTax: number
-      cooperativeHousingAssociation: number
-      differentiatedAdditionalCapital: number
-      rentAdministered: number
-      blocked: number
-      rentDaysPerMonth: number
-      economicPlanApproved: number
-      vatObligationPercent: number
-      vatRegistered: number
-      energyOptimization: number
-      ownedCompany: number
-      interestInvoice: number
-      errorReportAdministration: number
-      mediaBilling: number
-      ownResponsibilityForInternalMaintenance: number
-      subletPercentage: number
-      subletFeeAmount: number
-      disableQuantitiesBelowCompany: number
-      timestamp: string
-    }
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string;
+      organizationNumber: string | null;
+      phone: string | null;
+      fax: string | null;
+      vatNumber?: string | null;
+      internalExternal: number;
+      fTax: number;
+      cooperativeHousingAssociation: number;
+      differentiatedAdditionalCapital: number;
+      rentAdministered: number;
+      blocked: number;
+      rentDaysPerMonth: number;
+      economicPlanApproved: number;
+      vatObligationPercent: number;
+      vatRegistered: number;
+      energyOptimization: number;
+      ownedCompany: number;
+      interestInvoice: number;
+      errorReportAdministration: number;
+      mediaBilling: number;
+      ownResponsibilityForInternalMaintenance: number;
+      subletPercentage: number;
+      subletFeeAmount: number;
+      disableQuantitiesBelowCompany: number;
+      timestamp: string;
+    };
     Property: {
-      id: string
-      propertyObjectId: string
-      marketAreaId: string | null
-      districtId: string | null
-      propertyDesignationId: string | null
-      valueAreaId: string | null
-      code: string
-      designation: string
-      municipality: string
-      tract: string
-      block: string
-      sector: string | null
-      propertyIndexNumber: string | null
-      congregation: string | null
-      builtStatus: number
-      separateAssessmentUnit: number
-      consolidationNumber: string | null
-      ownershipType: string
-      registrationDate: string | null
-      acquisitionDate: string | null
-      isLeasehold: number
-      leaseholdTerminationDate: string | null
-      area: string | null
-      purpose: string | null
-      buildingType: string | null
-      propertyTaxNumber: string | null
-      mainPartAssessedValue: number
-      includeInAssessedValue: number
-      grading: number
-      deleteMark: number
+      id: string;
+      propertyObjectId: string;
+      marketAreaId: string | null;
+      districtId: string | null;
+      propertyDesignationId: string | null;
+      valueAreaId: string | null;
+      code: string;
+      designation: string;
+      municipality: string;
+      tract: string;
+      block: string;
+      sector: string | null;
+      propertyIndexNumber: string | null;
+      congregation: string | null;
+      builtStatus: number;
+      separateAssessmentUnit: number;
+      consolidationNumber: string | null;
+      ownershipType: string;
+      registrationDate: string | null;
+      acquisitionDate: string | null;
+      isLeasehold: number;
+      leaseholdTerminationDate: string | null;
+      area: string | null;
+      purpose: string | null;
+      buildingType: string | null;
+      propertyTaxNumber: string | null;
+      mainPartAssessedValue: number;
+      includeInAssessedValue: number;
+      grading: number;
+      deleteMark: number;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string
-      timestamp: string
-    }
+      toDate: string;
+      timestamp: string;
+    };
     Residence: {
-      id: string
-      code: string
-      name: string
-      deleted: boolean
+      id: string;
+      code: string;
+      name: string;
+      deleted: boolean;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string
+        fromDate: string;
         /** Format: date-time */
-        toDate: string
-      }
-    }
+        toDate: string;
+      };
+    };
     ResidenceDetails: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       /** @enum {string|null} */
-      status: 'VACANT' | 'LEASED' | null
-      entrance: string | null
-      location: string | null
-      floor: string | null
-      partNo: number | null
-      part: string | null
-      deleted: boolean
+      status: "VACANT" | "LEASED" | null;
+      entrance: string | null;
+      location: string | null;
+      floor: string | null;
+      partNo: number | null;
+      part: string | null;
+      deleted: boolean;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string
+        fromDate: string;
         /** Format: date-time */
-        toDate: string
-      }
+        toDate: string;
+      };
       accessibility: {
-        wheelchairAccessible: boolean
-        elevator: boolean
-        residenceAdapted: boolean
-      }
+        wheelchairAccessible: boolean;
+        elevator: boolean;
+        residenceAdapted: boolean;
+      };
       features: {
-        hygieneFacility: string | null
+        hygieneFacility: string | null;
         balcony1?: {
-          location: string
-          type: string
-        }
+          location: string;
+          type: string;
+        };
         balcony2?: {
-          location: string
-          type: string
-        }
-        patioLocation: string | null
-        sauna: boolean
-        extraToilet: boolean
-        sharedKitchen: boolean
-        petAllergyFree: boolean
+          location: string;
+          type: string;
+        };
+        patioLocation: string | null;
+        sauna: boolean;
+        extraToilet: boolean;
+        sharedKitchen: boolean;
+        petAllergyFree: boolean;
         /** @description Is the apartment checked for electric allergy intolerance? */
-        electricAllergyIntolerance: boolean
-        smokeFree: boolean
-        asbestos: boolean
-      }
+        electricAllergyIntolerance: boolean;
+        smokeFree: boolean;
+        asbestos: boolean;
+      };
       type: {
-        code: string
-        name: string | null
-        roomCount: number | null
-        kitchen: number
-      }
+        code: string;
+        name: string | null;
+        roomCount: number | null;
+        kitchen: number;
+      };
       residenceType: {
-        residenceTypeId: string
-        code: string
-        name: string | null
-        roomCount: number | null
-        kitchen: number
-        systemStandard: number
-        checklistId: string | null
-        componentTypeActionId: string | null
-        statisticsGroupSCBId: string | null
-        statisticsGroup2Id: string | null
-        statisticsGroup3Id: string | null
-        statisticsGroup4Id: string | null
-        timestamp: string
-      }
-      rentalInformation: {
-        apartmentNumber: string | null
-        rentalId: string | null
+        residenceTypeId: string;
+        code: string;
+        name: string | null;
+        roomCount: number | null;
+        kitchen: number;
+        systemStandard: number;
+        checklistId: string | null;
+        componentTypeActionId: string | null;
+        statisticsGroupSCBId: string | null;
+        statisticsGroup2Id: string | null;
+        statisticsGroup3Id: string | null;
+        statisticsGroup4Id: string | null;
+        timestamp: string;
+      };
+      rentalInformation: ({
+        apartmentNumber: string | null;
+        rentalId: string | null;
         type: {
-          code: string
-          name: string | null
-        }
-      } | null
+          code: string;
+          name: string | null;
+        };
+      }) | null;
       propertyObject: {
         energy: {
-          energyClass: number
+          energyClass: number;
           /** Format: date-time */
-          energyRegistered?: string
+          energyRegistered?: string;
           /** Format: date-time */
-          energyReceived?: string
-          energyIndex?: number
-        }
-        rentalId: string | null
-        rentalInformation: {
+          energyReceived?: string;
+          energyIndex?: number;
+        };
+        rentalId: string | null;
+        rentalInformation: ({
           type: {
-            code: string
-            name: string | null
-          }
-        } | null
-        rentalBlocks: {
-          id: string
-          blockReasonId: string | null
-          blockReason: string | null
-          /** Format: date-time */
-          fromDate: string
-          /** Format: date-time */
-          toDate: string | null
-          amount: number | null
-        }[]
-      }
+            code: string;
+            name: string | null;
+          };
+        }) | null;
+        rentalBlocks: ({
+            id: string;
+            blockReasonId: string | null;
+            blockReason: string | null;
+            /** Format: date-time */
+            fromDate: string;
+            /** Format: date-time */
+            toDate: string | null;
+            amount: number | null;
+          })[];
+      };
       property: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
       building: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
-      staircase: {
-        id: string
-        code: string
-        name: string | null
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
+      staircase: ({
+        id: string;
+        code: string;
+        name: string | null;
         features: {
-          floorPlan: string | null
-          accessibleByElevator: boolean
-        }
+          floorPlan: string | null;
+          accessibleByElevator: boolean;
+        };
         dates: {
           /** Format: date-time */
-          from: string
+          from: string;
           /** Format: date-time */
-          to: string
-        }
+          to: string;
+        };
         property?: {
-          propertyId: string | null
-          propertyName: string | null
-          propertyCode: string | null
-        }
+          propertyId: string | null;
+          propertyName: string | null;
+          propertyCode: string | null;
+        };
         building?: {
-          buildingId: string | null
-          buildingName: string | null
-          buildingCode: string | null
-        }
-        deleted: boolean
-        timestamp: string
-      } | null
-      areaSize: number | null
-      malarEnergiFacilityId: string | null
-    }
+          buildingId: string | null;
+          buildingName: string | null;
+          buildingCode: string | null;
+        };
+        deleted: boolean;
+        timestamp: string;
+      }) | null;
+      areaSize: number | null;
+      malarEnergiFacilityId: string | null;
+    };
     ResidenceSummary: {
-      id: string
-      code: string
-      name: string | null
-      deleted: boolean
-      rentalId: string
-      buildingCode: string
-      buildingName: string
-      staircaseCode: string
-      staircaseName: string
-      elevator: number | null
-      floor: string
-      hygieneFacility: string | null
-      wheelchairAccessible: number
+      id: string;
+      code: string;
+      name: string | null;
+      deleted: boolean;
+      rentalId: string;
+      buildingCode: string;
+      buildingName: string;
+      staircaseCode: string;
+      staircaseName: string;
+      elevator: number | null;
+      floor: string;
+      hygieneFacility: string | null;
+      wheelchairAccessible: number;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string | null
+        fromDate: string | null;
         /** Format: date-time */
-        toDate: string | null
-      }
+        toDate: string | null;
+      };
       residenceType: {
-        code: string
-        name: string
-        roomCount: number
-        kitchen: number
-      }
-      quantityValues: {
-        value: number
-        quantityTypeId: string
-        quantityType: {
-          name: string
-          unitId: string | null
-        }
-      }[]
-    }
+        code: string;
+        name: string;
+        roomCount: number;
+        kitchen: number;
+      };
+      quantityValues: ({
+          value: number;
+          quantityTypeId: string;
+          quantityType: {
+            name: string;
+            unitId: string | null;
+          };
+        })[];
+    };
     Staircase: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       features: {
-        floorPlan: string | null
-        accessibleByElevator: boolean
-      }
+        floorPlan: string | null;
+        accessibleByElevator: boolean;
+      };
       dates: {
         /** Format: date-time */
-        from: string
+        from: string;
         /** Format: date-time */
-        to: string
-      }
+        to: string;
+      };
       property?: {
-        propertyId: string | null
-        propertyName: string | null
-        propertyCode: string | null
-      }
+        propertyId: string | null;
+        propertyName: string | null;
+        propertyCode: string | null;
+      };
       building?: {
-        buildingId: string | null
-        buildingName: string | null
-        buildingCode: string | null
-      }
-      deleted: boolean
-      timestamp: string
-    }
+        buildingId: string | null;
+        buildingName: string | null;
+        buildingCode: string | null;
+      };
+      deleted: boolean;
+      timestamp: string;
+    };
     Room: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string | null
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string | null;
       usage: {
-        shared: boolean
-        allowPeriodicWorks: boolean
-        spaceType: number
-      }
+        shared: boolean;
+        allowPeriodicWorks: boolean;
+        spaceType: number;
+      };
       features: {
-        hasToilet: boolean
-        isHeated: boolean
-        hasThermostatValve: boolean
-        orientation: number
-      }
+        hasToilet: boolean;
+        isHeated: boolean;
+        hasThermostatValve: boolean;
+        orientation: number;
+      };
       dates: {
         /** Format: date-time */
-        installation: string | null
+        installation: string | null;
         /** Format: date-time */
-        from: string
+        from: string;
         /** Format: date-time */
-        to: string
+        to: string;
         /** Format: date-time */
-        availableFrom: string | null
+        availableFrom: string | null;
         /** Format: date-time */
-        availableTo: string | null
-      }
-      sortingOrder: number
-      deleted: boolean
-      timestamp: string
-      roomType: {
-        id: string
-        code: string
-        name: string | null
-        use: number
-        optionAllowed: number
-        isSystemStandard: number
-        allowSmallRoomsInValuation: number
-        timestamp: string
-      } | null
-      area?: number
-    }
+        availableTo: string | null;
+      };
+      sortingOrder: number;
+      deleted: boolean;
+      timestamp: string;
+      roomType: ({
+        id: string;
+        code: string;
+        name: string | null;
+        use: number;
+        optionAllowed: number;
+        isSystemStandard: number;
+        allowSmallRoomsInValuation: number;
+        timestamp: string;
+      }) | null;
+      area?: number;
+    };
     CreateRoomRequest: {
-      rentalId: string
+      rentalId: string;
       /** @enum {string} */
-      roomTypeCode:
-        | 'BAD'
-        | 'BAL'
-        | 'BRS'
-        | 'DUSCH'
-        | 'FÖR'
-        | 'GROV'
-        | 'HALL'
-        | 'KLÄD'
-        | 'KÖK'
-        | 'KOV'
-        | 'KV'
-        | 'MAT'
-        | 'PA'
-        | 'RUM'
-        | 'TRAPP'
-        | 'UP'
-        | 'VARD'
-        | 'WC'
-        | 'WC/DU1'
-      code?: string
-      caption?: string
+      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
+      code?: string;
+      caption?: string;
       features?: {
-        hasToilet?: boolean
-        isHeated?: boolean
-        hasThermostatValve?: boolean
-        orientation?: number
-      }
+        hasToilet?: boolean;
+        isHeated?: boolean;
+        hasThermostatValve?: boolean;
+        orientation?: number;
+      };
       usage?: {
-        shared?: boolean
-        allowPeriodicWorks?: boolean
-        spaceType?: number
-      }
-    }
+        shared?: boolean;
+        allowPeriodicWorks?: boolean;
+        spaceType?: number;
+      };
+    };
     ParkingSpace: {
-      rentalId: string
-      companyCode: string
-      companyName: string
-      managementUnitCode: string
-      managementUnitName: string
-      propertyCode: string
-      propertyName: string
-      buildingCode: string | null
-      buildingName: string | null
+      rentalId: string;
+      companyCode: string;
+      companyName: string;
+      managementUnitCode: string;
+      managementUnitName: string;
+      propertyCode: string;
+      propertyName: string;
+      buildingCode: string | null;
+      buildingName: string | null;
       parkingSpace: {
-        propertyObjectId: string
-        code: string
-        name: string
-        parkingNumber: string
+        propertyObjectId: string;
+        code: string;
+        name: string;
+        parkingNumber: string;
         parkingSpaceType: {
-          code: string
-          name: string
-        }
-      }
+          code: string;
+          name: string;
+        };
+      };
       address: {
-        streetAddress: string | null
-        streetAddress2: string | null
-        postalCode: string | null
-        city: string | null
-      }
-    }
+        streetAddress: string | null;
+        streetAddress2: string | null;
+        postalCode: string | null;
+        city: string | null;
+      };
+    };
     MaintenanceUnit: {
-      id: string
-      propertyObjectId: string
-      rentalPropertyId?: string
-      code: string
-      caption: string | null
-      type?: string | null
-      estateCode: string | null
-      estate: string | null
-    }
+      id: string;
+      propertyObjectId: string;
+      rentalPropertyId?: string;
+      code: string;
+      caption: string | null;
+      type?: string | null;
+      estateCode: string | null;
+      estate: string | null;
+    };
     FacilityDetails: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string | null
-      entrance: string | null
-      deleted: boolean
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string | null;
+      entrance: string | null;
+      deleted: boolean;
       type: {
-        code: string
-        name: string | null
-      }
-      rentalInformation: {
-        apartmentNumber: string | null
-        rentalId: string | null
+        code: string;
+        name: string | null;
+      };
+      rentalInformation: ({
+        apartmentNumber: string | null;
+        rentalId: string | null;
         type: {
-          code: string
-          name: string | null
-        }
-      } | null
+          code: string;
+          name: string | null;
+        };
+      }) | null;
       property: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
       building: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
-      areaSize: number | null
-    }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
+      areaSize: number | null;
+    };
     RentalBlock: {
-      id: string
-      blockReasonId: string
-      blockReason: string
+      id: string;
+      blockReasonId: string;
+      blockReason: string;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string | null
-      amount: number | null
-    }
+      toDate: string | null;
+      amount: number | null;
+    };
     RentalBlockWithRentalObject: {
-      id: string
-      blockReasonId: string | null
-      blockReason: string | null
+      id: string;
+      blockReasonId: string | null;
+      blockReason: string | null;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string | null
-      amount: number | null
-      distrikt: string | null
+      toDate: string | null;
+      amount: number | null;
+      distrikt: string | null;
       rentalObject: {
-        code: string | null
-        name: string | null
+        code: string | null;
+        name: string | null;
         /** @enum {string} */
-        category: 'Bostad' | 'Bilplats' | 'Lokal' | 'Förråd' | 'Övrigt'
-        address: string | null
-        rentalId: string | null
-        residenceId: string | null
-        yearlyRent: number
-        type: string | null
-      }
+        category: "Bostad" | "Bilplats" | "Lokal" | "Förråd" | "Övrigt";
+        address: string | null;
+        rentalId: string | null;
+        residenceId: string | null;
+        yearlyRent: number;
+        type: string | null;
+      };
       building: {
-        code: string | null
-        name: string | null
-      }
+        code: string | null;
+        name: string | null;
+      };
       property: {
-        code: string | null
-        name: string | null
-      }
-    }
+        code: string | null;
+        name: string | null;
+      };
+    };
     FacilitySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a facility result
        * @enum {string}
        */
-      type: 'facility'
+      type: "facility";
       /** @description Name of the facility */
-      name: string | null
+      name: string | null;
       /** @description Rental ID of the facility */
-      rentalId: string
+      rentalId: string;
       /** @description Code of the facility */
-      code: string
+      code: string;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the facility */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the facility */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     ResidenceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a residence result
        * @enum {string}
        */
-      type: 'residence'
+      type: "residence";
       /** @description Name of the residence */
-      name: string | null
+      name: string | null;
       /** @description Rental object ID of the residence */
-      rentalId: string | null
+      rentalId: string | null;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the residence */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the residence */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     ParkingSpaceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a parking space result
        * @enum {string}
        */
-      type: 'parking-space'
+      type: "parking-space";
       /** @description Name of the parking space */
-      name: string | null
+      name: string | null;
       /** @description Rental ID of the parking space */
-      rentalId: string
+      rentalId: string;
       /** @description Code of the parking space */
-      code: string
+      code: string;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the parking space */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the parking space */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     Component: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      modelId: string
-      serialNumber: string | null
-      specifications?: string | null
-      additionalInformation?: string | null
-      warrantyStartDate: string | null
-      warrantyMonths: number
-      priceAtPurchase: number
-      depreciationPriceAtPurchase: number
-      ncsCode?: string | null
+      modelId: string;
+      serialNumber: string | null;
+      specifications?: string | null;
+      additionalInformation?: string | null;
+      warrantyStartDate: string | null;
+      warrantyMonths: number;
+      priceAtPurchase: number;
+      depreciationPriceAtPurchase: number;
+      ncsCode?: string | null;
       /** @enum {string} */
-      status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-      lastInspectionDate?: string | null
-      quantity: number
-      economicLifespan: number
-      createdAt: string
-      updatedAt: string
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      lastInspectionDate?: string | null;
+      quantity: number;
+      economicLifespan: number;
+      createdAt: string;
+      updatedAt: string;
       model?: {
         /** Format: uuid */
-        id: string
-        modelName: string
+        id: string;
+        modelName: string;
         /** Format: uuid */
-        componentSubtypeId: string
-        currentPrice: number
-        currentInstallPrice: number
-        warrantyMonths: number
-        manufacturer: string
-        technicalSpecification: string | null
-        installationInstructions: string | null
-        dimensions: string | null
-        coclassCode: string | null
-        createdAt: string
-        updatedAt: string
+        componentSubtypeId: string;
+        currentPrice: number;
+        currentInstallPrice: number;
+        warrantyMonths: number;
+        manufacturer: string;
+        technicalSpecification: string | null;
+        installationInstructions: string | null;
+        dimensions: string | null;
+        coclassCode: string | null;
+        createdAt: string;
+        updatedAt: string;
         subtype?: {
           /** Format: uuid */
-          id: string
-          subTypeName: string
+          id: string;
+          subTypeName: string;
           /** Format: uuid */
-          typeId: string
-          xpandCode: string | null
-          depreciationPrice: number
-          technicalLifespan: number
-          economicLifespan: number
-          replacementIntervalMonths: number
+          typeId: string;
+          xpandCode: string | null;
+          depreciationPrice: number;
+          technicalLifespan: number;
+          economicLifespan: number;
+          replacementIntervalMonths: number;
           /** @enum {string} */
-          quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-          createdAt: string
-          updatedAt: string
+          quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+          createdAt: string;
+          updatedAt: string;
           componentType?: {
             /** Format: uuid */
-            id: string
-            typeName: string
+            id: string;
+            typeName: string;
             /** Format: uuid */
-            categoryId: string
-            description: string | null
-            createdAt: string
-            updatedAt: string
+            categoryId: string;
+            description: string | null;
+            createdAt: string;
+            updatedAt: string;
             category?: {
               /** Format: uuid */
-              id: string
-              categoryName: string
-              description: string
-              createdAt: string
-              updatedAt: string
-            }
-          }
-        }
-      }
-      componentInstallations?: {
-        /** Format: uuid */
-        id: string
-        /** Format: uuid */
-        componentId: string
-        spaceId: string | null
-        /** @enum {string} */
-        spaceType: 'OBJECT' | 'PropertyObject'
-        installationDate: string | null
-        deinstallationDate: string | null
-        orderNumber?: string | null
-        cost: number
-        createdAt: string
-        updatedAt: string
-        propertyObject?: {
-          id: string
-          propertyStructures?: {
-            roomId?: string | null
-            roomCode?: string | null
-            roomName?: string | null
-            residenceId?: string | null
-            residenceCode?: string | null
-            residenceName?: string | null
-            rentalId?: string | null
-            buildingCode?: string | null
-            buildingName?: string | null
-            residence?: {
-              id: string
-            } | null
-          }[]
-        } | null
-      }[]
-    }
+              id: string;
+              categoryName: string;
+              description: string;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+      };
+      componentInstallations?: ({
+          /** Format: uuid */
+          id: string;
+          /** Format: uuid */
+          componentId: string;
+          spaceId: string | null;
+          /** @enum {string} */
+          spaceType: "OBJECT" | "PropertyObject";
+          installationDate: string | null;
+          deinstallationDate: string | null;
+          orderNumber?: string | null;
+          cost: number;
+          createdAt: string;
+          updatedAt: string;
+          propertyObject?: ({
+            id: string;
+            propertyStructures?: ({
+                roomId?: string | null;
+                roomCode?: string | null;
+                roomName?: string | null;
+                residenceId?: string | null;
+                residenceCode?: string | null;
+                residenceName?: string | null;
+                rentalId?: string | null;
+                buildingCode?: string | null;
+                buildingName?: string | null;
+                residence?: {
+                  id: string;
+                } | null;
+              })[];
+          }) | null;
+        })[];
+    };
     ComponentCategory: {
       /** Format: uuid */
-      id: string
-      categoryName: string
-      description: string
-      createdAt: string
-      updatedAt: string
-    }
+      id: string;
+      categoryName: string;
+      description: string;
+      createdAt: string;
+      updatedAt: string;
+    };
     ComponentType: {
       /** Format: uuid */
-      id: string
-      typeName: string
+      id: string;
+      typeName: string;
       /** Format: uuid */
-      categoryId: string
-      description: string | null
-      createdAt: string
-      updatedAt: string
+      categoryId: string;
+      description: string | null;
+      createdAt: string;
+      updatedAt: string;
       category?: {
         /** Format: uuid */
-        id: string
-        categoryName: string
-        description: string
-        createdAt: string
-        updatedAt: string
-      }
-    }
+        id: string;
+        categoryName: string;
+        description: string;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
     ComponentSubtype: {
       /** Format: uuid */
-      id: string
-      subTypeName: string
+      id: string;
+      subTypeName: string;
       /** Format: uuid */
-      typeId: string
-      xpandCode: string | null
-      depreciationPrice: number
-      technicalLifespan: number
-      economicLifespan: number
-      replacementIntervalMonths: number
+      typeId: string;
+      xpandCode: string | null;
+      depreciationPrice: number;
+      technicalLifespan: number;
+      economicLifespan: number;
+      replacementIntervalMonths: number;
       /** @enum {string} */
-      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-      createdAt: string
-      updatedAt: string
+      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+      createdAt: string;
+      updatedAt: string;
       componentType?: {
         /** Format: uuid */
-        id: string
-        typeName: string
+        id: string;
+        typeName: string;
         /** Format: uuid */
-        categoryId: string
-        description: string | null
-        createdAt: string
-        updatedAt: string
+        categoryId: string;
+        description: string | null;
+        createdAt: string;
+        updatedAt: string;
         category?: {
           /** Format: uuid */
-          id: string
-          categoryName: string
-          description: string
-          createdAt: string
-          updatedAt: string
-        }
-      }
-    }
+          id: string;
+          categoryName: string;
+          description: string;
+          createdAt: string;
+          updatedAt: string;
+        };
+      };
+    };
     ComponentModel: {
       /** Format: uuid */
-      id: string
-      modelName: string
+      id: string;
+      modelName: string;
       /** Format: uuid */
-      componentSubtypeId: string
-      currentPrice: number
-      currentInstallPrice: number
-      warrantyMonths: number
-      manufacturer: string
-      technicalSpecification: string | null
-      installationInstructions: string | null
-      dimensions: string | null
-      coclassCode: string | null
-      createdAt: string
-      updatedAt: string
+      componentSubtypeId: string;
+      currentPrice: number;
+      currentInstallPrice: number;
+      warrantyMonths: number;
+      manufacturer: string;
+      technicalSpecification: string | null;
+      installationInstructions: string | null;
+      dimensions: string | null;
+      coclassCode: string | null;
+      createdAt: string;
+      updatedAt: string;
       subtype?: {
         /** Format: uuid */
-        id: string
-        subTypeName: string
+        id: string;
+        subTypeName: string;
         /** Format: uuid */
-        typeId: string
-        xpandCode: string | null
-        depreciationPrice: number
-        technicalLifespan: number
-        economicLifespan: number
-        replacementIntervalMonths: number
+        typeId: string;
+        xpandCode: string | null;
+        depreciationPrice: number;
+        technicalLifespan: number;
+        economicLifespan: number;
+        replacementIntervalMonths: number;
         /** @enum {string} */
-        quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-        createdAt: string
-        updatedAt: string
+        quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+        createdAt: string;
+        updatedAt: string;
         componentType?: {
           /** Format: uuid */
-          id: string
-          typeName: string
+          id: string;
+          typeName: string;
           /** Format: uuid */
-          categoryId: string
-          description: string | null
-          createdAt: string
-          updatedAt: string
+          categoryId: string;
+          description: string | null;
+          createdAt: string;
+          updatedAt: string;
           category?: {
             /** Format: uuid */
-            id: string
-            categoryName: string
-            description: string
-            createdAt: string
-            updatedAt: string
-          }
-        }
-      }
-    }
+            id: string;
+            categoryName: string;
+            description: string;
+            createdAt: string;
+            updatedAt: string;
+          };
+        };
+      };
+    };
     ComponentInstallation: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      componentId: string
-      spaceId: string | null
+      componentId: string;
+      spaceId: string | null;
       /** @enum {string} */
-      spaceType: 'OBJECT' | 'PropertyObject'
-      installationDate: string | null
-      deinstallationDate: string | null
-      orderNumber?: string | null
-      cost: number
-      createdAt: string
-      updatedAt: string
+      spaceType: "OBJECT" | "PropertyObject";
+      installationDate: string | null;
+      deinstallationDate: string | null;
+      orderNumber?: string | null;
+      cost: number;
+      createdAt: string;
+      updatedAt: string;
       component?: {
         /** Format: uuid */
-        id: string
+        id: string;
         /** Format: uuid */
-        modelId: string
-        serialNumber: string | null
-        specifications?: string | null
-        additionalInformation?: string | null
-        warrantyStartDate: string | null
-        warrantyMonths: number
-        priceAtPurchase: number
-        depreciationPriceAtPurchase: number
-        ncsCode?: string | null
+        modelId: string;
+        serialNumber: string | null;
+        specifications?: string | null;
+        additionalInformation?: string | null;
+        warrantyStartDate: string | null;
+        warrantyMonths: number;
+        priceAtPurchase: number;
+        depreciationPriceAtPurchase: number;
+        ncsCode?: string | null;
         /** @enum {string} */
-        status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+        status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
         /** @enum {string|null} */
-        condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-        lastInspectionDate?: string | null
-        quantity: number
-        economicLifespan: number
-        createdAt: string
-        updatedAt: string
+        condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+        lastInspectionDate?: string | null;
+        quantity: number;
+        economicLifespan: number;
+        createdAt: string;
+        updatedAt: string;
         model?: {
           /** Format: uuid */
-          id: string
-          modelName: string
+          id: string;
+          modelName: string;
           /** Format: uuid */
-          componentSubtypeId: string
-          currentPrice: number
-          currentInstallPrice: number
-          warrantyMonths: number
-          manufacturer: string
-          technicalSpecification: string | null
-          installationInstructions: string | null
-          dimensions: string | null
-          coclassCode: string | null
-          createdAt: string
-          updatedAt: string
+          componentSubtypeId: string;
+          currentPrice: number;
+          currentInstallPrice: number;
+          warrantyMonths: number;
+          manufacturer: string;
+          technicalSpecification: string | null;
+          installationInstructions: string | null;
+          dimensions: string | null;
+          coclassCode: string | null;
+          createdAt: string;
+          updatedAt: string;
           subtype?: {
             /** Format: uuid */
-            id: string
-            subTypeName: string
+            id: string;
+            subTypeName: string;
             /** Format: uuid */
-            typeId: string
-            xpandCode: string | null
-            depreciationPrice: number
-            technicalLifespan: number
-            economicLifespan: number
-            replacementIntervalMonths: number
+            typeId: string;
+            xpandCode: string | null;
+            depreciationPrice: number;
+            technicalLifespan: number;
+            economicLifespan: number;
+            replacementIntervalMonths: number;
             /** @enum {string} */
-            quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-            createdAt: string
-            updatedAt: string
+            quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+            createdAt: string;
+            updatedAt: string;
             componentType?: {
               /** Format: uuid */
-              id: string
-              typeName: string
+              id: string;
+              typeName: string;
               /** Format: uuid */
-              categoryId: string
-              description: string | null
-              createdAt: string
-              updatedAt: string
+              categoryId: string;
+              description: string | null;
+              createdAt: string;
+              updatedAt: string;
               category?: {
                 /** Format: uuid */
-                id: string
-                categoryName: string
-                description: string
-                createdAt: string
-                updatedAt: string
-              }
-            }
-          }
-        }
-        componentInstallations?: {
-          /** Format: uuid */
-          id: string
-          /** Format: uuid */
-          componentId: string
-          spaceId: string | null
-          spaceType: components['schemas']['ComponentInstallation']['spaceType']
-          installationDate: string | null
-          deinstallationDate: string | null
-          orderNumber?: string | null
-          cost: number
-          createdAt: string
-          updatedAt: string
-          propertyObject?: {
-            id: string
-            propertyStructures?: {
-              roomId?: string | null
-              roomCode?: string | null
-              roomName?: string | null
-              residenceId?: string | null
-              residenceCode?: string | null
-              residenceName?: string | null
-              rentalId?: string | null
-              buildingCode?: string | null
-              buildingName?: string | null
-              residence?: {
-                id: string
-              } | null
-            }[]
-          } | null
-        }[]
-      }
-    }
+                id: string;
+                categoryName: string;
+                description: string;
+                createdAt: string;
+                updatedAt: string;
+              };
+            };
+          };
+        };
+        componentInstallations?: ({
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            componentId: string;
+            spaceId: string | null;
+            spaceType: components["schemas"]["ComponentInstallation"]["spaceType"];
+            installationDate: string | null;
+            deinstallationDate: string | null;
+            orderNumber?: string | null;
+            cost: number;
+            createdAt: string;
+            updatedAt: string;
+            propertyObject?: ({
+              id: string;
+              propertyStructures?: ({
+                  roomId?: string | null;
+                  roomCode?: string | null;
+                  roomName?: string | null;
+                  residenceId?: string | null;
+                  residenceCode?: string | null;
+                  residenceName?: string | null;
+                  rentalId?: string | null;
+                  buildingCode?: string | null;
+                  buildingName?: string | null;
+                  residence?: {
+                    id: string;
+                  } | null;
+                })[];
+            }) | null;
+          })[];
+      };
+    };
     CreateComponentCategoryRequest: {
-      categoryName: string
-      description: string
-    }
+      categoryName: string;
+      description: string;
+    };
     UpdateComponentCategoryRequest: {
-      categoryName?: string
-      description?: string
-    }
+      categoryName?: string;
+      description?: string;
+    };
     CreateComponentTypeRequest: {
-      typeName: string
+      typeName: string;
       /** Format: uuid */
-      categoryId: string
-      description?: string
-    }
+      categoryId: string;
+      description?: string;
+    };
     UpdateComponentTypeRequest: {
-      typeName?: string
+      typeName?: string;
       /** Format: uuid */
-      categoryId?: string
-      description?: string
-    }
+      categoryId?: string;
+      description?: string;
+    };
     CreateComponentSubtypeRequest: {
-      subTypeName: string
+      subTypeName: string;
       /** Format: uuid */
-      typeId: string
-      xpandCode?: string
+      typeId: string;
+      xpandCode?: string;
       /** @default 0 */
-      depreciationPrice?: number
+      depreciationPrice?: number;
       /** @default 0 */
-      technicalLifespan?: number
+      technicalLifespan?: number;
       /** @default 0 */
-      economicLifespan?: number
+      economicLifespan?: number;
       /** @default 0 */
-      replacementIntervalMonths?: number
+      replacementIntervalMonths?: number;
       /** @enum {string} */
-      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-    }
+      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+    };
     UpdateComponentSubtypeRequest: {
-      subTypeName?: string
+      subTypeName?: string;
       /** Format: uuid */
-      typeId?: string
-      xpandCode?: string
-      depreciationPrice?: number
-      technicalLifespan?: number
-      economicLifespan?: number
-      replacementIntervalMonths?: number
+      typeId?: string;
+      xpandCode?: string;
+      depreciationPrice?: number;
+      technicalLifespan?: number;
+      economicLifespan?: number;
+      replacementIntervalMonths?: number;
       /** @enum {string} */
-      quantityType?: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-    }
+      quantityType?: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+    };
     CreateComponentModelRequest: {
-      modelName: string
+      modelName: string;
       /** Format: uuid */
-      componentSubtypeId: string
+      componentSubtypeId: string;
       /** @default 0 */
-      currentPrice?: number
+      currentPrice?: number;
       /** @default 0 */
-      currentInstallPrice?: number
+      currentInstallPrice?: number;
       /** @default 0 */
-      warrantyMonths?: number
+      warrantyMonths?: number;
       /** @default */
-      manufacturer?: string
-      technicalSpecification?: string
-      installationInstructions?: string
-      dimensions?: string
-      coclassCode?: string
-    }
+      manufacturer?: string;
+      technicalSpecification?: string;
+      installationInstructions?: string;
+      dimensions?: string;
+      coclassCode?: string;
+    };
     UpdateComponentModelRequest: {
-      modelName?: string
+      modelName?: string;
       /** Format: uuid */
-      componentSubtypeId?: string
-      currentPrice?: number
-      currentInstallPrice?: number
-      warrantyMonths?: number
-      manufacturer?: string
-      technicalSpecification?: string
-      installationInstructions?: string
-      dimensions?: string
-      coclassCode?: string
-    }
+      componentSubtypeId?: string;
+      currentPrice?: number;
+      currentInstallPrice?: number;
+      warrantyMonths?: number;
+      manufacturer?: string;
+      technicalSpecification?: string;
+      installationInstructions?: string;
+      dimensions?: string;
+      coclassCode?: string;
+    };
     CreateComponentRequest: {
       /** Format: uuid */
-      modelId: string
-      serialNumber?: string | null
-      specifications?: string
-      additionalInformation?: string
+      modelId: string;
+      serialNumber?: string | null;
+      specifications?: string;
+      additionalInformation?: string;
       /** Format: date-time */
-      warrantyStartDate?: string
+      warrantyStartDate?: string;
       /** @default 0 */
-      warrantyMonths?: number
+      warrantyMonths?: number;
       /** @default 0 */
-      priceAtPurchase?: number
+      priceAtPurchase?: number;
       /** @default 0 */
-      depreciationPriceAtPurchase?: number
-      ncsCode?: string
+      depreciationPriceAtPurchase?: number;
+      ncsCode?: string;
       /**
        * @default ACTIVE
        * @enum {string}
        */
-      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
       /** @default 1 */
-      quantity?: number
+      quantity?: number;
       /** @default 0 */
-      economicLifespan?: number
-      files?: string
-    }
+      economicLifespan?: number;
+      files?: string;
+    };
     UpdateComponentRequest: {
       /** Format: uuid */
-      modelId?: string
-      serialNumber?: string | null
-      specifications?: string
-      additionalInformation?: string
+      modelId?: string;
+      serialNumber?: string | null;
+      specifications?: string;
+      additionalInformation?: string;
       /** Format: date-time */
-      warrantyStartDate?: string
-      warrantyMonths?: number
-      priceAtPurchase?: number
-      depreciationPriceAtPurchase?: number
-      ncsCode?: string
+      warrantyStartDate?: string;
+      warrantyMonths?: number;
+      priceAtPurchase?: number;
+      depreciationPriceAtPurchase?: number;
+      ncsCode?: string;
       /** @enum {string} */
-      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-      quantity?: number
-      economicLifespan?: number
-      files?: string
-    }
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      quantity?: number;
+      economicLifespan?: number;
+      files?: string;
+    };
     CreateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId: string
-      spaceId?: string
+      componentId: string;
+      spaceId?: string;
       /** @enum {string} */
-      spaceType: 'OBJECT' | 'PropertyObject'
+      spaceType: "OBJECT" | "PropertyObject";
       /** Format: date-time */
-      installationDate?: string | null
+      installationDate?: string | null;
       /** Format: date-time */
-      deinstallationDate?: string
-      orderNumber?: string
-      cost: number
-    }
+      deinstallationDate?: string;
+      orderNumber?: string;
+      cost: number;
+    };
     UpdateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId?: string
-      spaceId?: string
+      componentId?: string;
+      spaceId?: string;
       /** @enum {string} */
-      spaceType?: 'OBJECT' | 'PropertyObject'
+      spaceType?: "OBJECT" | "PropertyObject";
       /** Format: date-time */
-      installationDate?: string
+      installationDate?: string;
       /** Format: date-time */
-      deinstallationDate?: string
-      orderNumber?: string
-      cost?: number
-    }
+      deinstallationDate?: string;
+      orderNumber?: string;
+      cost?: number;
+    };
     DocumentWithUrl: {
-      id: string
-      fileId: string
-      originalName: string
-      mimeType: string
-      size: number
-      createdAt: string
-      url: string
-      uploadedAt?: string
-      caption?: string
-    }
+      id: string;
+      fileId: string;
+      originalName: string;
+      mimeType: string;
+      size: number;
+      createdAt: string;
+      url: string;
+      uploadedAt?: string;
+      caption?: string;
+    };
     AnalyzeComponentImageRequest: {
-      image: string
-      additionalImage?: string
-    }
+      image: string;
+      additionalImage?: string;
+    };
     AIComponentAnalysis: {
-      componentType: string | null
-      componentSubtype: string | null
-      manufacturer: string | null
-      model: string | null
-      serialNumber: string | null
-      estimatedAge: string | null
-      condition: string | null
-      specifications: string | null
-      dimensions: string | null
-      warrantyMonths: number | null
-      ncsCode: string | null
-      additionalInformation: string | null
-      confidence: number
-    }
+      componentType: string | null;
+      componentSubtype: string | null;
+      manufacturer: string | null;
+      model: string | null;
+      serialNumber: string | null;
+      estimatedAge: string | null;
+      condition: string | null;
+      specifications: string | null;
+      dimensions: string | null;
+      warrantyMonths: number | null;
+      ncsCode: string | null;
+      additionalInformation: string | null;
+      confidence: number;
+    };
     ApartmentTemperaturePoint: {
-      time: number
-      avg: number | null
-      min: number | null
-      max: number | null
-    }
+      time: number;
+      avg: number | null;
+      min: number | null;
+      max: number | null;
+    };
     ApartmentTemperatureSeries: {
-      subNodeId: number
-      subNodeName: string
-      points: {
-        time: number
-        avg: number | null
-        min: number | null
-        max: number | null
-      }[]
-    }
+      subNodeId: number;
+      subNodeName: string;
+      points: ({
+          time: number;
+          avg: number | null;
+          min: number | null;
+          max: number | null;
+        })[];
+    };
     ApartmentTemperaturesResponse: {
-      objectNumber: string
-      nodeId: number
-      from: number
-      to: number
+      objectNumber: string;
+      nodeId: number;
+      from: number;
+      to: number;
       /** @enum {string} */
-      interval: 'H' | 'D'
-      unit: string
-      series: {
-        subNodeId: number
-        subNodeName: string
-        points: {
-          time: number
-          avg: number | null
-          min: number | null
-          max: number | null
-        }[]
-      }[]
-    }
+      interval: "H" | "D";
+      unit: string;
+      series: ({
+          subNodeId: number;
+          subNodeName: string;
+          points: ({
+              time: number;
+              avg: number | null;
+              min: number | null;
+              max: number | null;
+            })[];
+        })[];
+    };
     Key: {
       /** Format: uuid */
-      id: string
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      id: string;
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
+      keySystemId?: string | null;
       /** @default false */
-      disposed?: boolean
-      notes?: string | null
+      disposed?: boolean;
+      notes?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     KeySystem: {
       /** Format: uuid */
-      id: string
-      systemCode: string
-      name: string
-      manufacturer: string
-      managingSupplier?: string | null
+      id: string;
+      systemCode: string;
+      name: string;
+      manufacturer: string;
+      managingSupplier?: string | null;
       /** @enum {string} */
-      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-      schemaFileId?: string | null
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+      schemaFileId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-    }
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+    };
     KeyLoan: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-      keyCount?: number
-      cardCount?: number
-    }
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+      keyCount?: number;
+      cardCount?: number;
+    };
     KeyDetails: {
       /** Format: uuid */
-      id: string
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      id: string;
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
+      keySystemId?: string | null;
       /** @default false */
-      disposed?: boolean
-      notes?: string | null
+      disposed?: boolean;
+      notes?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      keySystem?: components['schemas']['KeySystem'] | null
-      loans?: components['schemas']['KeyLoan'][] | null
-      events?:
-        | {
-            /** Format: uuid */
-            id: string
-            /** @enum {string} */
-            type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
-            /** @enum {string} */
-            status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
-            /** Format: uuid */
-            workOrderId?: string | null
-            /** Format: date-time */
-            createdAt: string
-            /** Format: date-time */
-            updatedAt: string
-          }[]
-        | null
-      activeLoanContact?: string | null
-    }
+      updatedAt: string;
+      keySystem?: components["schemas"]["KeySystem"] | null;
+      loans?: components["schemas"]["KeyLoan"][] | null;
+      events?: (({
+          /** Format: uuid */
+          id: string;
+          /** @enum {string} */
+          type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+          /** @enum {string} */
+          status: "ORDERED" | "RECEIVED" | "COMPLETED";
+          /** Format: uuid */
+          workOrderId?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+        })[]) | null;
+      activeLoanContact?: string | null;
+    };
     KeyLoanWithDetails: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-      keyCount?: number
-      cardCount?: number
-      keysArray: {
-        /** Format: uuid */
-        id: string
-        keyName: string
-        keySequenceNumber?: number | null
-        flexNumber?: number | null
-        rentalObjectCode?: string | null
-        /** @enum {string} */
-        keyType:
-          | 'HN'
-          | 'FS'
-          | 'MV'
-          | 'LGH'
-          | 'PB'
-          | 'GAR'
-          | 'LOK'
-          | 'HL'
-          | 'FÖR'
-          | 'SOP'
-          | 'ÖVR'
-        /** Format: uuid */
-        keySystemId?: string | null
-        /** @default false */
-        disposed?: boolean
-        notes?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-        keySystem?: {
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+      keyCount?: number;
+      cardCount?: number;
+      keysArray: ({
           /** Format: uuid */
-          id: string
-          systemCode: string
-          name: string
-          manufacturer: string
-          managingSupplier?: string | null
+          id: string;
+          keyName: string;
+          keySequenceNumber?: number | null;
+          flexNumber?: number | null;
+          rentalObjectCode?: string | null;
           /** @enum {string} */
-          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-          propertyIds?: string
+          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+          /** Format: uuid */
+          keySystemId?: string | null;
+          /** @default false */
+          disposed?: boolean;
+          notes?: string | null;
           /** Format: date-time */
-          installationDate?: string | null
-          isActive?: boolean
-          notes?: string | null
-          schemaFileId?: string | null
+          createdAt: string;
           /** Format: date-time */
-          createdAt: string
-          /** Format: date-time */
-          updatedAt: string
-          createdBy?: string | null
-          updatedBy?: string | null
-        } | null
-        loans?:
-          | {
-              id: components['schemas']['KeyLoanWithDetails']['id']
-              loanType: components['schemas']['KeyLoanWithDetails']['loanType']
-              contact?: components['schemas']['KeyLoanWithDetails']['contact']
-              contact2?: components['schemas']['KeyLoanWithDetails']['contact2']
-              contactPerson?: components['schemas']['KeyLoanWithDetails']['contactPerson']
-              notes?: components['schemas']['KeyLoanWithDetails']['notes']
-              returnedAt?: components['schemas']['KeyLoanWithDetails']['returnedAt']
-              availableToNextTenantFrom?: components['schemas']['KeyLoanWithDetails']['availableToNextTenantFrom']
-              pickedUpAt?: components['schemas']['KeyLoanWithDetails']['pickedUpAt']
-              createdAt: components['schemas']['KeyLoanWithDetails']['createdAt']
-              updatedAt: components['schemas']['KeyLoanWithDetails']['updatedAt']
-              createdBy?: components['schemas']['KeyLoanWithDetails']['createdBy']
-              updatedBy?: components['schemas']['KeyLoanWithDetails']['updatedBy']
-              keyCount?: components['schemas']['KeyLoanWithDetails']['keyCount']
-              cardCount?: components['schemas']['KeyLoanWithDetails']['cardCount']
-            }[]
-          | null
-        events?:
-          | {
+          updatedAt: string;
+          keySystem?: ({
+            /** Format: uuid */
+            id: string;
+            systemCode: string;
+            name: string;
+            manufacturer: string;
+            managingSupplier?: string | null;
+            /** @enum {string} */
+            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+            propertyIds?: string;
+            /** Format: date-time */
+            installationDate?: string | null;
+            isActive?: boolean;
+            notes?: string | null;
+            schemaFileId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            createdBy?: string | null;
+            updatedBy?: string | null;
+          }) | null;
+          loans?: {
+              id: components["schemas"]["KeyLoanWithDetails"]["id"];
+              loanType: components["schemas"]["KeyLoanWithDetails"]["loanType"];
+              contact?: components["schemas"]["KeyLoanWithDetails"]["contact"];
+              contact2?: components["schemas"]["KeyLoanWithDetails"]["contact2"];
+              contactPerson?: components["schemas"]["KeyLoanWithDetails"]["contactPerson"];
+              notes?: components["schemas"]["KeyLoanWithDetails"]["notes"];
+              returnedAt?: components["schemas"]["KeyLoanWithDetails"]["returnedAt"];
+              availableToNextTenantFrom?: components["schemas"]["KeyLoanWithDetails"]["availableToNextTenantFrom"];
+              pickedUpAt?: components["schemas"]["KeyLoanWithDetails"]["pickedUpAt"];
+              createdAt: components["schemas"]["KeyLoanWithDetails"]["createdAt"];
+              updatedAt: components["schemas"]["KeyLoanWithDetails"]["updatedAt"];
+              createdBy?: components["schemas"]["KeyLoanWithDetails"]["createdBy"];
+              updatedBy?: components["schemas"]["KeyLoanWithDetails"]["updatedBy"];
+              keyCount?: components["schemas"]["KeyLoanWithDetails"]["keyCount"];
+              cardCount?: components["schemas"]["KeyLoanWithDetails"]["cardCount"];
+            }[] | null;
+          events?: (({
               /** Format: uuid */
-              id: string
+              id: string;
               /** @enum {string} */
-              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
               /** @enum {string} */
-              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+              status: "ORDERED" | "RECEIVED" | "COMPLETED";
               /** Format: uuid */
-              workOrderId?: string | null
+              workOrderId?: string | null;
               /** Format: date-time */
-              createdAt: string
+              createdAt: string;
               /** Format: date-time */
-              updatedAt: string
-            }[]
-          | null
-        activeLoanContact?: string | null
-      }[]
-      keyCardsArray: {
-        cardId: string
-        name?: string | null
-        owner?: unknown
-        appearanceCode?: string | null
-        classification?: string | null
-        disabled?: boolean
-        startTime?: string | null
-        stopTime?: string | null
-        createTime: string
-        pinCode?: string | null
-        state?: string | null
-        archivedAt?: string | null
-        codes?: unknown[] | null
-      }[]
-      receipts: {
-        /** Format: uuid */
-        id: string
-        /** Format: uuid */
-        keyLoanId: string
-        /** @enum {string} */
-        receiptType: 'LOAN' | 'RETURN'
-        /** @enum {string} */
-        type: 'DIGITAL' | 'PHYSICAL'
-        fileId?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-      }[]
-    }
+              updatedAt: string;
+            })[]) | null;
+          activeLoanContact?: string | null;
+        })[];
+      keyCardsArray: ({
+          cardId: string;
+          name?: string | null;
+          owner?: unknown;
+          appearanceCode?: string | null;
+          classification?: string | null;
+          disabled?: boolean;
+          startTime?: string | null;
+          stopTime?: string | null;
+          createTime: string;
+          pinCode?: string | null;
+          state?: string | null;
+          archivedAt?: string | null;
+          codes?: unknown[] | null;
+        })[];
+      receipts: ({
+          /** Format: uuid */
+          id: string;
+          /** Format: uuid */
+          keyLoanId: string;
+          /** @enum {string} */
+          receiptType: "LOAN" | "RETURN";
+          /** @enum {string} */
+          type: "DIGITAL" | "PHYSICAL";
+          fileId?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+        })[];
+    };
     Log: {
       /** Format: uuid */
-      id: string
-      userName: string
+      id: string;
+      userName: string;
       /** @enum {string} */
-      eventType: 'creation' | 'update' | 'delete'
+      eventType: "creation" | "update" | "delete";
       /** @enum {string} */
-      objectType:
-        | 'key'
-        | 'keySystem'
-        | 'keyLoan'
-        | 'keyBundle'
-        | 'receipt'
-        | 'keyEvent'
-        | 'signature'
-        | 'keyNote'
+      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
       /** Format: uuid */
-      objectId?: string | null
+      objectId?: string | null;
       /** Format: date-time */
-      eventTime: string
-      description?: string | null
-      eventTypeLabel?: string
-      objectTypeLabel?: string
-    }
+      eventTime: string;
+      description?: string | null;
+      eventTypeLabel?: string;
+      objectTypeLabel?: string;
+    };
     KeyNote: {
       /** Format: uuid */
-      id: string
-      rentalObjectCode: string
-      description: string
-    }
+      id: string;
+      rentalObjectCode: string;
+      description: string;
+    };
     Receipt: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      keyLoanId: string
+      keyLoanId: string;
       /** @enum {string} */
-      receiptType: 'LOAN' | 'RETURN'
+      receiptType: "LOAN" | "RETURN";
       /** @enum {string} */
-      type: 'DIGITAL' | 'PHYSICAL'
-      fileId?: string | null
+      type: "DIGITAL" | "PHYSICAL";
+      fileId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     KeyEvent: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
+      workOrderId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     Signature: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
-      simpleSignDocumentId: number
+      resourceId: string;
+      simpleSignDocumentId: number;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string | null
-      status: string
+      recipientEmail: string;
+      recipientName?: string | null;
+      status: string;
       /** Format: date-time */
-      sentAt: string
+      sentAt: string;
       /** Format: date-time */
-      completedAt?: string | null
+      completedAt?: string | null;
       /** Format: date-time */
-      lastSyncedAt?: string | null
-    }
+      lastSyncedAt?: string | null;
+    };
     CreateKeyRequest: {
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
-      notes?: string | null
-    }
+      keySystemId?: string | null;
+      notes?: string | null;
+    };
     UpdateKeyRequest: {
-      keyName?: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      keyName?: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType?:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType?: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
-      disposed?: boolean
-      notes?: string | null
-    }
+      keySystemId?: string | null;
+      disposed?: boolean;
+      notes?: string | null;
+    };
     BulkUpdateFlexRequest: {
-      rentalObjectCode: string
-      flexNumber: number
-    }
+      rentalObjectCode: string;
+      flexNumber: number;
+    };
     BulkUpdateKeysRequest: {
-      keyIds: string[]
+      keyIds: string[];
       updates: {
-        keyName?: string
-        flexNumber?: number | null
+        keyName?: string;
+        flexNumber?: number | null;
         /** Format: uuid */
-        keySystemId?: string | null
-        rentalObjectCode?: string
-        disposed?: boolean
-        notes?: string | null
-        clearNotes?: boolean
-      }
-    }
+        keySystemId?: string | null;
+        rentalObjectCode?: string;
+        disposed?: boolean;
+        notes?: string | null;
+        clearNotes?: boolean;
+      };
+    };
     CreateKeyLoanRequest: {
-      keys?: string[]
-      keyCards?: string[]
+      keys?: string[];
+      keyCards?: string[];
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
-      createdBy?: string | null
-    }
+      availableToNextTenantFrom?: string | null;
+      createdBy?: string | null;
+    };
     UpdateKeyLoanRequest: {
-      keys?: string[]
-      keyCards?: string[]
+      keys?: string[];
+      keyCards?: string[];
       /** @enum {string} */
-      loanType?: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType?: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
-      updatedBy?: string | null
-    }
+      pickedUpAt?: string | null;
+      updatedBy?: string | null;
+    };
     CreateKeySystemRequest: {
-      systemCode: string
-      name: string
-      manufacturer: string
+      systemCode: string;
+      name: string;
+      manufacturer: string;
       /** @enum {string} */
-      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-    }
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+    };
     UpdateKeySystemRequest: {
-      systemCode?: string
-      name?: string
-      manufacturer?: string
+      systemCode?: string;
+      name?: string;
+      manufacturer?: string;
       /** @enum {string} */
-      type?: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type?: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-      schemaFileId?: string | null
-    }
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+      schemaFileId?: string | null;
+    };
     CreateLogRequest: {
-      userName: string
+      userName: string;
       /** @enum {string} */
-      eventType: 'creation' | 'update' | 'delete'
+      eventType: "creation" | "update" | "delete";
       /** @enum {string} */
-      objectType:
-        | 'key'
-        | 'keySystem'
-        | 'keyLoan'
-        | 'keyBundle'
-        | 'receipt'
-        | 'keyEvent'
-        | 'signature'
-        | 'keyNote'
+      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
       /** Format: uuid */
-      objectId?: string | null
-      description?: string | null
-      autoGenerateDescription?: boolean
-      entityData?: unknown
+      objectId?: string | null;
+      description?: string | null;
+      autoGenerateDescription?: boolean;
+      entityData?: unknown;
       /** @enum {string} */
-      action?: 'Skapad' | 'Uppdaterad' | 'Kasserad' | 'Raderad'
+      action?: "Skapad" | "Uppdaterad" | "Kasserad" | "Raderad";
       /** Format: date-time */
-      eventTime?: string
-    }
+      eventTime?: string;
+    };
     CreateKeyNoteRequest: {
-      rentalObjectCode: string
-      description: string
-    }
+      rentalObjectCode: string;
+      description: string;
+    };
     UpdateKeyNoteRequest: {
-      rentalObjectCode?: string
-      description?: string
-    }
+      rentalObjectCode?: string;
+      description?: string;
+    };
     KeyBundle: {
       /** Format: uuid */
-      id: string
-      name: string
-      description?: string | null
-      keyCount?: number
-    }
+      id: string;
+      name: string;
+      description?: string | null;
+      keyCount?: number;
+    };
     BundleWithLoanedKeysInfo: {
       /** Format: uuid */
-      id: string
-      name: string
-      description: string | null
-      loanedKeyCount: number
-      totalKeyCount: number
-    }
+      id: string;
+      name: string;
+      description: string | null;
+      loanedKeyCount: number;
+      totalKeyCount: number;
+    };
     CreateKeyBundleRequest: {
-      name: string
-      keys: string[]
-      description?: string | null
-    }
+      name: string;
+      keys: string[];
+      description?: string | null;
+    };
     UpdateKeyBundleRequest: {
-      name?: string
-      keys?: string[]
-      description?: string | null
-    }
+      name?: string;
+      keys?: string[];
+      description?: string | null;
+    };
     KeyBundleDetailsResponse: {
       bundle: {
         /** Format: uuid */
-        id: string
-        name: string
-        description?: string | null
-        keyCount?: number
-      }
-      keys: {
-        /** Format: uuid */
-        id: string
-        keyName: string
-        keySequenceNumber?: number | null
-        flexNumber?: number | null
-        rentalObjectCode?: string | null
-        /** @enum {string} */
-        keyType:
-          | 'HN'
-          | 'FS'
-          | 'MV'
-          | 'LGH'
-          | 'PB'
-          | 'GAR'
-          | 'LOK'
-          | 'HL'
-          | 'FÖR'
-          | 'SOP'
-          | 'ÖVR'
-        /** Format: uuid */
-        keySystemId?: string | null
-        /** @default false */
-        disposed?: boolean
-        notes?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-        keySystem?: {
+        id: string;
+        name: string;
+        description?: string | null;
+        keyCount?: number;
+      };
+      keys: ({
           /** Format: uuid */
-          id: string
-          systemCode: string
-          name: string
-          manufacturer: string
-          managingSupplier?: string | null
+          id: string;
+          keyName: string;
+          keySequenceNumber?: number | null;
+          flexNumber?: number | null;
+          rentalObjectCode?: string | null;
           /** @enum {string} */
-          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-          propertyIds?: string
+          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+          /** Format: uuid */
+          keySystemId?: string | null;
+          /** @default false */
+          disposed?: boolean;
+          notes?: string | null;
           /** Format: date-time */
-          installationDate?: string | null
-          isActive?: boolean
-          notes?: string | null
-          schemaFileId?: string | null
+          createdAt: string;
           /** Format: date-time */
-          createdAt: string
-          /** Format: date-time */
-          updatedAt: string
-          createdBy?: string | null
-          updatedBy?: string | null
-        } | null
-        loans?: components['schemas']['KeyLoan'][] | null
-        events?:
-          | {
+          updatedAt: string;
+          keySystem?: ({
+            /** Format: uuid */
+            id: string;
+            systemCode: string;
+            name: string;
+            manufacturer: string;
+            managingSupplier?: string | null;
+            /** @enum {string} */
+            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+            propertyIds?: string;
+            /** Format: date-time */
+            installationDate?: string | null;
+            isActive?: boolean;
+            notes?: string | null;
+            schemaFileId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            createdBy?: string | null;
+            updatedBy?: string | null;
+          }) | null;
+          loans?: components["schemas"]["KeyLoan"][] | null;
+          events?: (({
               /** Format: uuid */
-              id: string
+              id: string;
               /** @enum {string} */
-              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
               /** @enum {string} */
-              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+              status: "ORDERED" | "RECEIVED" | "COMPLETED";
               /** Format: uuid */
-              workOrderId?: string | null
+              workOrderId?: string | null;
               /** Format: date-time */
-              createdAt: string
+              createdAt: string;
               /** Format: date-time */
-              updatedAt: string
-            }[]
-          | null
-        activeLoanContact?: string | null
-      }[]
-    }
+              updatedAt: string;
+            })[]) | null;
+          activeLoanContact?: string | null;
+        })[];
+    };
     CreateKeyEventRequest: {
-      keys: string[]
+      keys: string[];
       /** @enum {string} */
-      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
-    }
+      workOrderId?: string | null;
+    };
     UpdateKeyEventRequest: {
-      keys?: string[]
+      keys?: string[];
       /** @enum {string} */
-      type?: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type?: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status?: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status?: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
-    }
+      workOrderId?: string | null;
+    };
     CreateSignatureRequest: {
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
-      simpleSignDocumentId: number
+      resourceId: string;
+      simpleSignDocumentId: number;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string | null
+      recipientEmail: string;
+      recipientName?: string | null;
       /** @default sent */
-      status?: string
-    }
+      status?: string;
+    };
     UpdateSignatureRequest: {
-      status?: string
+      status?: string;
       /** Format: date-time */
-      completedAt?: string | null
+      completedAt?: string | null;
       /** Format: date-time */
-      lastSyncedAt?: string | null
-    }
+      lastSyncedAt?: string | null;
+    };
     SendSignatureRequest: {
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
+      resourceId: string;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string
-      pdfBase64: string
-    }
+      recipientEmail: string;
+      recipientName?: string;
+      pdfBase64: string;
+    };
     SimpleSignWebhookPayload: {
-      id: number
-      status: string
-      status_updated_at: string
-    }
+      id: number;
+      status: string;
+      status_updated_at: string;
+    };
     CreateReceiptRequest: {
       /** Format: uuid */
-      keyLoanId: string
+      keyLoanId: string;
       /** @enum {string} */
-      receiptType: 'LOAN' | 'RETURN'
+      receiptType: "LOAN" | "RETURN";
       /** @enum {string} */
-      type?: 'DIGITAL' | 'PHYSICAL'
-      fileId?: string
-      fileData?: string
-      fileContentType?: string
-    }
+      type?: "DIGITAL" | "PHYSICAL";
+      fileId?: string;
+      fileData?: string;
+      fileContentType?: string;
+    };
     UpdateReceiptRequest: {
-      fileId?: string
-    }
+      fileId?: string;
+    };
     /** @enum {string} */
-    ReceiptType: 'LOAN' | 'RETURN'
+    ReceiptType: "LOAN" | "RETURN";
     /** @enum {string} */
-    ReceiptFormat: 'DIGITAL' | 'PHYSICAL'
+    ReceiptFormat: "DIGITAL" | "PHYSICAL";
     ErrorResponse: {
       /** @example Internal server error */
-      error?: string
-      reason?: string
-    }
+      error?: string;
+      reason?: string;
+    };
     NotFoundResponse: {
       /** @example Resource not found */
-      reason: string
-    }
+      reason: string;
+    };
     BadRequestResponse: {
-      reason: string
-    }
+      reason: string;
+    };
     SchemaDownloadUrlResponse: {
-      url: string
-      expiresIn: number
-    }
+      url: string;
+      expiresIn: number;
+    };
     CardOwner: {
-      cardOwnerId: string
-      cardOwnerType?: string | null
-      familyName?: string | null
-      specificName?: string | null
-      primaryOrganization?: unknown
-      cards?:
-        | {
-            cardId: string
-            name?: string | null
-            owner?: unknown
-            appearanceCode?: string | null
-            classification?: string | null
-            disabled?: boolean
-            startTime?: string | null
-            stopTime?: string | null
-            createTime: string
-            pinCode?: string | null
-            state?: string | null
-            archivedAt?: string | null
-            codes?: unknown[] | null
-          }[]
-        | null
-      comment?: string | null
-      folderId?: number | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      pinCode?: string | null
+      cardOwnerId: string;
+      cardOwnerType?: string | null;
+      familyName?: string | null;
+      specificName?: string | null;
+      primaryOrganization?: unknown;
+      cards?: (({
+          cardId: string;
+          name?: string | null;
+          owner?: unknown;
+          appearanceCode?: string | null;
+          classification?: string | null;
+          disabled?: boolean;
+          startTime?: string | null;
+          stopTime?: string | null;
+          createTime: string;
+          pinCode?: string | null;
+          state?: string | null;
+          archivedAt?: string | null;
+          codes?: unknown[] | null;
+        })[]) | null;
+      comment?: string | null;
+      folderId?: number | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      pinCode?: string | null;
       attributes?: {
-        [key: string]: string
-      } | null
-      state?: string | null
-      archivedAt?: string | null
-      createTime?: string
-    }
+        [key: string]: string;
+      } | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      createTime?: string;
+    };
     Card: {
-      cardId: string
-      name?: string | null
-      owner?: unknown
-      appearanceCode?: string | null
-      classification?: string | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      createTime: string
-      pinCode?: string | null
-      state?: string | null
-      archivedAt?: string | null
-      codes?: unknown[] | null
-    }
+      cardId: string;
+      name?: string | null;
+      owner?: unknown;
+      appearanceCode?: string | null;
+      classification?: string | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      createTime: string;
+      pinCode?: string | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      codes?: unknown[] | null;
+    };
     CardDetails: {
-      cardId: string
-      name?: string | null
-      owner?: unknown
-      appearanceCode?: string | null
-      classification?: string | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      createTime: string
-      pinCode?: string | null
-      state?: string | null
-      archivedAt?: string | null
-      codes?: unknown[] | null
-      loans?:
-        | {
-            /** Format: uuid */
-            id: string
-            /** @enum {string} */
-            loanType: 'TENANT' | 'MAINTENANCE'
-            contact?: string | null
-            contact2?: string | null
-            contactPerson?: string | null
-            notes?: string | null
-            /** Format: date-time */
-            returnedAt?: string | null
-            /** Format: date-time */
-            availableToNextTenantFrom?: string | null
-            /** Format: date-time */
-            pickedUpAt?: string | null
-            /** Format: date-time */
-            createdAt: string
-            /** Format: date-time */
-            updatedAt: string
-            createdBy?: string | null
-            updatedBy?: string | null
-            keyCount?: number
-            cardCount?: number
-          }[]
-        | null
-    }
+      cardId: string;
+      name?: string | null;
+      owner?: unknown;
+      appearanceCode?: string | null;
+      classification?: string | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      createTime: string;
+      pinCode?: string | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      codes?: unknown[] | null;
+      loans?: (({
+          /** Format: uuid */
+          id: string;
+          /** @enum {string} */
+          loanType: "TENANT" | "MAINTENANCE";
+          contact?: string | null;
+          contact2?: string | null;
+          contactPerson?: string | null;
+          notes?: string | null;
+          /** Format: date-time */
+          returnedAt?: string | null;
+          /** Format: date-time */
+          availableToNextTenantFrom?: string | null;
+          /** Format: date-time */
+          pickedUpAt?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+          createdBy?: string | null;
+          updatedBy?: string | null;
+          keyCount?: number;
+          cardCount?: number;
+        })[]) | null;
+    };
     QueryCardOwnersParams: {
-      nameFilter?: string
-      expand?: string
-      idfilter?: string
-      attributeFilter?: string
-      selectedAttributes?: string
-      folderFilter?: string
-      organisationFilter?: string
-      offset?: number
-      limit?: number
-    }
+      nameFilter?: string;
+      expand?: string;
+      idfilter?: string;
+      attributeFilter?: string;
+      selectedAttributes?: string;
+      folderFilter?: string;
+      organisationFilter?: string;
+      offset?: number;
+      limit?: number;
+    };
     PaginatedResponse: {
-      content: unknown[]
+      content: unknown[];
       _meta: {
-        totalRecords: number
-        page: number
-        limit: number
-        count: number
-      }
-      _links: {
-        href: string
-        /** @enum {string} */
-        rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-      }[]
-    }
+        totalRecords: number;
+        page: number;
+        limit: number;
+        count: number;
+      };
+      _links: ({
+          href: string;
+          /** @enum {string} */
+          rel: "self" | "first" | "last" | "prev" | "next";
+        })[];
+    };
     SearchQueryParams: {
       /** @description The search query string used to find properties, buildings and residences */
-      q: string
-    }
+      q: string;
+    };
     PropertySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a property result
        * @enum {string}
        */
-      type: 'property'
+      type: "property";
       /** @description Property code */
-      code: string
+      code: string;
       /** @description Name or designation of the property */
-      name: string
-    }
+      name: string;
+    };
     BuildingSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a building result
        * @enum {string}
        */
-      type: 'building'
+      type: "building";
       /** @description Building code */
-      code: string
+      code: string;
       /** @description Name of the building */
-      name: string | null
-      property?: {
+      name: string | null;
+      property?: ({
         /** @description Property associated with the building */
-        name: string | null
-        id: string
-        code: string
-      } | null
-    }
+        name: string | null;
+        id: string;
+        code: string;
+      }) | null;
+    };
     MaintenanceUnitSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a maintenance unit result
        * @enum {string}
        */
-      type: 'maintenance-unit'
+      type: "maintenance-unit";
       /** @description Code of the maintenance unit */
-      code: string
+      code: string;
       /** @description Caption/name of the maintenance unit */
-      caption: string | null
+      caption: string | null;
       /** @description Type of maintenance unit */
-      maintenanceType: string | null
+      maintenanceType: string | null;
       /** @description Property code */
-      estateCode: string | null
+      estateCode: string | null;
       /** @description Property name */
-      estate: string | null
-    }
+      estate: string | null;
+    };
     StaircaseSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a staircase result
        * @enum {string}
        */
-      type: 'staircase'
+      type: "staircase";
       /** @description Code of the staircase */
-      code: string
+      code: string;
       /** @description Name (caption) of the staircase */
-      name: string | null
+      name: string | null;
       property: {
-        code: string
+        code: string;
         /** @description Name of property associated with the staircase */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string
+        code: string;
         /** @description Name of building associated with the staircase */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
-    SearchResult:
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a property result
-           * @enum {string}
-           */
-          type: 'property'
-          /** @description Property code */
-          code: string
-          /** @description Name or designation of the property */
-          name: string
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a building result
-           * @enum {string}
-           */
-          type: 'building'
-          /** @description Building code */
-          code: string
-          /** @description Name of the building */
-          name: string | null
-          property?: {
-            /** @description Property associated with the building */
-            name: string | null
-            id: string
-            code: string
-          } | null
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a residence result
-           * @enum {string}
-           */
-          type: 'residence'
-          /** @description Name of the residence */
-          name: string | null
-          /** @description Rental object ID of the residence */
-          rentalId: string | null
-          property: {
-            code: string | null
-            /** @description Name of property associated with the residence */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the residence */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a parking space result
-           * @enum {string}
-           */
-          type: 'parking-space'
-          /** @description Name of the parking space */
-          name: string | null
-          /** @description Rental ID of the parking space */
-          rentalId: string
-          /** @description Code of the parking space */
-          code: string
-          property: {
-            code: string | null
-            /** @description Name of property associated with the parking space */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the parking space */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a maintenance unit result
-           * @enum {string}
-           */
-          type: 'maintenance-unit'
-          /** @description Code of the maintenance unit */
-          code: string
-          /** @description Caption/name of the maintenance unit */
-          caption: string | null
-          /** @description Type of maintenance unit */
-          maintenanceType: string | null
-          /** @description Property code */
-          estateCode: string | null
-          /** @description Property name */
-          estate: string | null
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a facility result
-           * @enum {string}
-           */
-          type: 'facility'
-          /** @description Name of the facility */
-          name: string | null
-          /** @description Rental ID of the facility */
-          rentalId: string
-          /** @description Code of the facility */
-          code: string
-          property: {
-            code: string | null
-            /** @description Name of property associated with the facility */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the facility */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a staircase result
-           * @enum {string}
-           */
-          type: 'staircase'
-          /** @description Code of the staircase */
-          code: string
-          /** @description Name (caption) of the staircase */
-          name: string | null
-          property: {
-            code: string
-            /** @description Name of property associated with the staircase */
-            name: string | null
-          }
-          building: {
-            code: string
-            /** @description Name of building associated with the staircase */
-            name: string | null
-          }
-        }
+    SearchResult: {
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a property result
+       * @enum {string}
+       */
+      type: "property";
+      /** @description Property code */
+      code: string;
+      /** @description Name or designation of the property */
+      name: string;
+    } | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a building result
+       * @enum {string}
+       */
+      type: "building";
+      /** @description Building code */
+      code: string;
+      /** @description Name of the building */
+      name: string | null;
+      property?: ({
+        /** @description Property associated with the building */
+        name: string | null;
+        id: string;
+        code: string;
+      }) | null;
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a residence result
+       * @enum {string}
+       */
+      type: "residence";
+      /** @description Name of the residence */
+      name: string | null;
+      /** @description Rental object ID of the residence */
+      rentalId: string | null;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the residence */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the residence */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a parking space result
+       * @enum {string}
+       */
+      type: "parking-space";
+      /** @description Name of the parking space */
+      name: string | null;
+      /** @description Rental ID of the parking space */
+      rentalId: string;
+      /** @description Code of the parking space */
+      code: string;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the parking space */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the parking space */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a maintenance unit result
+       * @enum {string}
+       */
+      type: "maintenance-unit";
+      /** @description Code of the maintenance unit */
+      code: string;
+      /** @description Caption/name of the maintenance unit */
+      caption: string | null;
+      /** @description Type of maintenance unit */
+      maintenanceType: string | null;
+      /** @description Property code */
+      estateCode: string | null;
+      /** @description Property name */
+      estate: string | null;
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a facility result
+       * @enum {string}
+       */
+      type: "facility";
+      /** @description Name of the facility */
+      name: string | null;
+      /** @description Rental ID of the facility */
+      rentalId: string;
+      /** @description Code of the facility */
+      code: string;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the facility */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the facility */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: {
+        code: string;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      };
+      building: {
+        code: string;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      };
+    });
     Inspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
-      lease: {
-        leaseId: string
-        leaseNumber: string
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
         /** Format: date-time */
-        leaseStartDate: string
+        leaseStartDate: string;
         /** Format: date-time */
-        leaseEndDate?: string
+        leaseEndDate?: string;
         /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
         rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
           address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
           roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
+              roomTypeId: string;
+              name: string;
+            }[];
           /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
+          lastUpdated?: string;
+        };
+        type: string;
         rentInfo?: {
           currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
             /** Format: date-time */
-            rentStartDate?: string
+            rentStartDate?: string;
             /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
+            rentEndDate?: string;
+          };
+        };
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
         /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
         /** Format: date-time */
-        preferredMoveOutDate?: string
+        preferredMoveOutDate?: string;
         /** Format: date-time */
-        terminationDate?: string
+        terminationDate?: string;
         /** Format: date-time */
-        contractDate?: string
+        contractDate?: string;
         /** Format: date-time */
-        lastDebitDate?: string
+        lastDebitDate?: string;
         /** Format: date-time */
-        approvalDate?: string
+        approvalDate?: string;
         residentialArea?: {
-          code: string
-          caption: string
-        }
+          code: string;
+          caption: string;
+        };
         tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
             /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-      rooms:
-        | {
-            roomId: string
-            name?: string
-            conditions: {
-              details: string
-            }
-            actions: {
-              details: string[]
-            }
-            componentNotes: {
-              details: string
-            }
-            componentCosts: {
-              /** @default 0 */
-              details?: number
-            }
-            componentPhotos: {
-              details: string[]
-            }
-            componentCostResponsibilities: {
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              details?: 'tenant' | 'landlord' | null
-            }
-            photos: string[]
-            isApproved: boolean
-            isHandled: boolean
-            /** @default [] */
-            detailComponents?: {
-              id: string
-              type: string
-              label: string
-              note: string
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+      rooms: (({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
               /** @default */
-              condition?: string
-              cost?: number
+              condition?: string;
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default [] */
-            components?: {
-              componentId: string
-              label: string
-              condition: string
-              action: string[]
-              note: string
-              photos: string[]
-              cost?: number
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default false */
-            isAddedInThisInspection?: boolean
-          }[]
-        | null
-    }
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[]) | null;
+    };
     InspectionComponent: {
-      componentId: string
-      label: string
-      condition: string
-      action: string[]
-      note: string
-      photos: string[]
-      cost?: number
+      componentId: string;
+      label: string;
+      condition: string;
+      action: string[];
+      note: string;
+      photos: string[];
+      cost?: number;
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: 'tenant' | 'landlord' | null
-    }
+      costResponsibility?: "tenant" | "landlord" | null;
+    };
     InspectionRoom: {
-      roomId: string
-      name?: string
+      roomId: string;
+      name?: string;
       conditions: {
-        details: string
-      }
+        details: string;
+      };
       actions: {
-        details: string[]
-      }
+        details: string[];
+      };
       componentNotes: {
-        details: string
-      }
+        details: string;
+      };
       componentCosts: {
         /** @default 0 */
-        details?: number
-      }
+        details?: number;
+      };
       componentPhotos: {
-        details: string[]
-      }
+        details: string[];
+      };
       componentCostResponsibilities: {
         /**
          * @default null
          * @enum {string|null}
          */
-        details?: 'tenant' | 'landlord' | null
-      }
-      photos: string[]
-      isApproved: boolean
-      isHandled: boolean
+        details?: "tenant" | "landlord" | null;
+      };
+      photos: string[];
+      isApproved: boolean;
+      isHandled: boolean;
       /** @default [] */
-      detailComponents?: {
-        id: string
-        type: string
-        label: string
-        note: string
-        /** @default */
-        condition?: string
-        cost?: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-      }[]
+      detailComponents?: ({
+          id: string;
+          type: string;
+          label: string;
+          note: string;
+          /** @default */
+          condition?: string;
+          cost?: number;
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: "tenant" | "landlord" | null;
+        })[];
       /** @default [] */
-      components?: {
-        componentId: string
-        label: string
-        condition: string
-        action: string[]
-        note: string
-        photos: string[]
-        cost?: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-      }[]
+      components?: ({
+          componentId: string;
+          label: string;
+          condition: string;
+          action: string[];
+          note: string;
+          photos: string[];
+          cost?: number;
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: "tenant" | "landlord" | null;
+        })[];
       /** @default false */
-      isAddedInThisInspection?: boolean
-    }
+      isAddedInThisInspection?: boolean;
+    };
     DetailedInspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
+      date: string;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      inspector: string
-      type: string
-      residenceId: string
-      address: string
-      apartmentCode: string | null
-      isFurnished: boolean
-      leaseId: string
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      masterKeyAccess: string | null
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
-      remarkCount: number
+      endedAt: string | null;
+      inspector: string;
+      type: string;
+      residenceId: string;
+      address: string;
+      apartmentCode: string | null;
+      isFurnished: boolean;
+      leaseId: string;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      masterKeyAccess: string | null;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
+      remarkCount: number;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12496,379 +12334,379 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms: {
-        room: string
-        remarks: {
-          remarkId: string
-          location: string | null
-          buildingComponent: string | null
-          notes: string | null
-          remarkGrade: number
-          remarkStatus: string | null
-          cost: number
+        electricalSystem?: boolean;
+      };
+      rooms: ({
+          room: string;
+          remarks: ({
+              remarkId: string;
+              location: string | null;
+              buildingComponent: string | null;
+              notes: string | null;
+              remarkGrade: number;
+              remarkStatus: string | null;
+              cost: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+              invoice: boolean;
+              quantity: number;
+              isMissing: boolean;
+              /** Format: date-time */
+              fixedDate: string | null;
+              workOrderCreated: boolean;
+              workOrderStatus: number | null;
+            })[];
+        })[];
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
+        /** Format: date-time */
+        leaseStartDate: string;
+        /** Format: date-time */
+        leaseEndDate?: string;
+        /** @enum {string} */
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
+        rentalProperty?: {
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
+          address?: {
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
+          roomTypes?: {
+              roomTypeId: string;
+              name: string;
+            }[];
+          /** Format: date-time */
+          lastUpdated?: string;
+        };
+        type: string;
+        rentInfo?: {
+          currentRent: {
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
+            /** Format: date-time */
+            rentStartDate?: string;
+            /** Format: date-time */
+            rentEndDate?: string;
+          };
+        };
+        address?: {
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
+        /** Format: date-time */
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
+        /** Format: date-time */
+        preferredMoveOutDate?: string;
+        /** Format: date-time */
+        terminationDate?: string;
+        /** Format: date-time */
+        contractDate?: string;
+        /** Format: date-time */
+        lastDebitDate?: string;
+        /** Format: date-time */
+        approvalDate?: string;
+        residentialArea?: {
+          code: string;
+          caption: string;
+        };
+        tenants?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
+            /** Format: date-time */
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+      residence: ({
+        id: string;
+        code: string;
+        name: string | null;
+        /** @enum {string|null} */
+        status: "VACANT" | "LEASED" | null;
+        entrance: string | null;
+        location: string | null;
+        floor: string | null;
+        partNo: number | null;
+        part: string | null;
+        deleted: boolean;
+        validityPeriod: {
+          /** Format: date-time */
+          fromDate: string;
+          /** Format: date-time */
+          toDate: string;
+        };
+        accessibility: {
+          wheelchairAccessible: boolean;
+          elevator: boolean;
+          residenceAdapted: boolean;
+        };
+        features: {
+          hygieneFacility: string | null;
+          balcony1?: {
+            location: string;
+            type: string;
+          };
+          balcony2?: {
+            location: string;
+            type: string;
+          };
+          patioLocation: string | null;
+          sauna: boolean;
+          extraToilet: boolean;
+          sharedKitchen: boolean;
+          petAllergyFree: boolean;
+          /** @description Is the apartment checked for electric allergy intolerance? */
+          electricAllergyIntolerance: boolean;
+          smokeFree: boolean;
+          asbestos: boolean;
+        };
+        type: {
+          code: string;
+          name: string | null;
+          roomCount: number | null;
+          kitchen: number;
+        };
+        residenceType: {
+          residenceTypeId: string;
+          code: string;
+          name: string | null;
+          roomCount: number | null;
+          kitchen: number;
+          systemStandard: number;
+          checklistId: string | null;
+          componentTypeActionId: string | null;
+          statisticsGroupSCBId: string | null;
+          statisticsGroup2Id: string | null;
+          statisticsGroup3Id: string | null;
+          statisticsGroup4Id: string | null;
+          timestamp: string;
+        };
+        rentalInformation: ({
+          apartmentNumber: string | null;
+          rentalId: string | null;
+          type: {
+            code: string;
+            name: string | null;
+          };
+        }) | null;
+        propertyObject: {
+          energy: {
+            energyClass: number;
+            /** Format: date-time */
+            energyRegistered?: string;
+            /** Format: date-time */
+            energyReceived?: string;
+            energyIndex?: number;
+          };
+          rentalId: string | null;
+          rentalInformation: ({
+            type: {
+              code: string;
+              name: string | null;
+            };
+          }) | null;
+          rentalBlocks: ({
+              id: string;
+              blockReasonId: string | null;
+              blockReason: string | null;
+              /** Format: date-time */
+              fromDate: string;
+              /** Format: date-time */
+              toDate: string | null;
+              amount: number | null;
+            })[];
+        };
+        property: {
+          id: string | null;
+          name: string | null;
+          code: string | null;
+        };
+        building: {
+          id: string | null;
+          name: string | null;
+          code: string | null;
+        };
+        staircase: ({
+          id: string;
+          code: string;
+          name: string | null;
+          features: {
+            floorPlan: string | null;
+            accessibleByElevator: boolean;
+          };
+          dates: {
+            /** Format: date-time */
+            from: string;
+            /** Format: date-time */
+            to: string;
+          };
+          property?: {
+            propertyId: string | null;
+            propertyName: string | null;
+            propertyCode: string | null;
+          };
+          building?: {
+            buildingId: string | null;
+            buildingName: string | null;
+            buildingCode: string | null;
+          };
+          deleted: boolean;
+          timestamp: string;
+        }) | null;
+        areaSize: number | null;
+        malarEnergiFacilityId: string | null;
+      }) | null;
+    };
+    DetailedInspectionRoom: {
+      room: string;
+      remarks: ({
+          remarkId: string;
+          location: string | null;
+          buildingComponent: string | null;
+          notes: string | null;
+          remarkGrade: number;
+          remarkStatus: string | null;
+          cost: number;
           /**
            * @default null
            * @enum {string|null}
            */
-          costResponsibility?: 'tenant' | 'landlord' | null
-          invoice: boolean
-          quantity: number
-          isMissing: boolean
+          costResponsibility?: "tenant" | "landlord" | null;
+          invoice: boolean;
+          quantity: number;
+          isMissing: boolean;
           /** Format: date-time */
-          fixedDate: string | null
-          workOrderCreated: boolean
-          workOrderStatus: number | null
-        }[]
-      }[]
-      lease: {
-        leaseId: string
-        leaseNumber: string
-        /** Format: date-time */
-        leaseStartDate: string
-        /** Format: date-time */
-        leaseEndDate?: string
-        /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
-        rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
-          roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
-          /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
-        rentInfo?: {
-          currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
-            /** Format: date-time */
-            rentStartDate?: string
-            /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
-        address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
-        /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
-        /** Format: date-time */
-        preferredMoveOutDate?: string
-        /** Format: date-time */
-        terminationDate?: string
-        /** Format: date-time */
-        contractDate?: string
-        /** Format: date-time */
-        lastDebitDate?: string
-        /** Format: date-time */
-        approvalDate?: string
-        residentialArea?: {
-          code: string
-          caption: string
-        }
-        tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
-            /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-      residence: {
-        id: string
-        code: string
-        name: string | null
-        /** @enum {string|null} */
-        status: 'VACANT' | 'LEASED' | null
-        entrance: string | null
-        location: string | null
-        floor: string | null
-        partNo: number | null
-        part: string | null
-        deleted: boolean
-        validityPeriod: {
-          /** Format: date-time */
-          fromDate: string
-          /** Format: date-time */
-          toDate: string
-        }
-        accessibility: {
-          wheelchairAccessible: boolean
-          elevator: boolean
-          residenceAdapted: boolean
-        }
-        features: {
-          hygieneFacility: string | null
-          balcony1?: {
-            location: string
-            type: string
-          }
-          balcony2?: {
-            location: string
-            type: string
-          }
-          patioLocation: string | null
-          sauna: boolean
-          extraToilet: boolean
-          sharedKitchen: boolean
-          petAllergyFree: boolean
-          /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean
-          smokeFree: boolean
-          asbestos: boolean
-        }
-        type: {
-          code: string
-          name: string | null
-          roomCount: number | null
-          kitchen: number
-        }
-        residenceType: {
-          residenceTypeId: string
-          code: string
-          name: string | null
-          roomCount: number | null
-          kitchen: number
-          systemStandard: number
-          checklistId: string | null
-          componentTypeActionId: string | null
-          statisticsGroupSCBId: string | null
-          statisticsGroup2Id: string | null
-          statisticsGroup3Id: string | null
-          statisticsGroup4Id: string | null
-          timestamp: string
-        }
-        rentalInformation: {
-          apartmentNumber: string | null
-          rentalId: string | null
-          type: {
-            code: string
-            name: string | null
-          }
-        } | null
-        propertyObject: {
-          energy: {
-            energyClass: number
-            /** Format: date-time */
-            energyRegistered?: string
-            /** Format: date-time */
-            energyReceived?: string
-            energyIndex?: number
-          }
-          rentalId: string | null
-          rentalInformation: {
-            type: {
-              code: string
-              name: string | null
-            }
-          } | null
-          rentalBlocks: {
-            id: string
-            blockReasonId: string | null
-            blockReason: string | null
-            /** Format: date-time */
-            fromDate: string
-            /** Format: date-time */
-            toDate: string | null
-            amount: number | null
-          }[]
-        }
-        property: {
-          id: string | null
-          name: string | null
-          code: string | null
-        }
-        building: {
-          id: string | null
-          name: string | null
-          code: string | null
-        }
-        staircase: {
-          id: string
-          code: string
-          name: string | null
-          features: {
-            floorPlan: string | null
-            accessibleByElevator: boolean
-          }
-          dates: {
-            /** Format: date-time */
-            from: string
-            /** Format: date-time */
-            to: string
-          }
-          property?: {
-            propertyId: string | null
-            propertyName: string | null
-            propertyCode: string | null
-          }
-          building?: {
-            buildingId: string | null
-            buildingName: string | null
-            buildingCode: string | null
-          }
-          deleted: boolean
-          timestamp: string
-        } | null
-        areaSize: number | null
-        malarEnergiFacilityId: string | null
-      } | null
-    }
-    DetailedInspectionRoom: {
-      room: string
-      remarks: {
-        remarkId: string
-        location: string | null
-        buildingComponent: string | null
-        notes: string | null
-        remarkGrade: number
-        remarkStatus: string | null
-        cost: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-        invoice: boolean
-        quantity: number
-        isMissing: boolean
-        /** Format: date-time */
-        fixedDate: string | null
-        workOrderCreated: boolean
-        workOrderStatus: number | null
-      }[]
-    }
+          fixedDate: string | null;
+          workOrderCreated: boolean;
+          workOrderStatus: number | null;
+        })[];
+    };
     DetailedInspectionRemark: {
-      remarkId: string
-      location: string | null
-      buildingComponent: string | null
-      notes: string | null
-      remarkGrade: number
-      remarkStatus: string | null
-      cost: number
+      remarkId: string;
+      location: string | null;
+      buildingComponent: string | null;
+      notes: string | null;
+      remarkGrade: number;
+      remarkStatus: string | null;
+      cost: number;
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: 'tenant' | 'landlord' | null
-      invoice: boolean
-      quantity: number
-      isMissing: boolean
+      costResponsibility?: "tenant" | "landlord" | null;
+      invoice: boolean;
+      quantity: number;
+      isMissing: boolean;
       /** Format: date-time */
-      fixedDate: string | null
-      workOrderCreated: boolean
-      workOrderStatus: number | null
-    }
+      fixedDate: string | null;
+      workOrderCreated: boolean;
+      workOrderStatus: number | null;
+    };
     TenantContactsResponse: {
       inspection: {
-        id: string
-        address: string
-        apartmentCode: string | null
-      }
+        id: string;
+        address: string;
+        apartmentCode: string | null;
+      };
       new_tenant?: {
         contacts: {
-          fullName: string
-          emailAddress: string
-          contactCode: string
-        }[]
-        contractId: string
-      }
-      tenant?: components['schemas']['TenantContactsResponse']['new_tenant']
-    }
+            fullName: string;
+            emailAddress: string;
+            contactCode: string;
+          }[];
+        contractId: string;
+      };
+      tenant?: components["schemas"]["TenantContactsResponse"]["new_tenant"];
+    };
     SendProtocolRequest: {
       /** @enum {string} */
-      recipient: 'tenant' | 'new-tenant'
-    }
+      recipient: "tenant" | "new-tenant";
+    };
     SendProtocolResponse: {
-      success: boolean
+      success: boolean;
       /** @enum {string} */
-      recipient: 'tenant' | 'new-tenant'
+      recipient: "tenant" | "new-tenant";
       sentTo: {
-        emails: string[]
-        contactNames: string[]
-        contractId: string
-      }
-      error?: string
-    }
+        emails: string[];
+        contactNames: string[];
+        contractId: string;
+      };
+      error?: string;
+    };
     CreateInspectionRequest: {
-      status: string
+      status: string;
       /** Format: date-time */
-      date: string
+      date: string;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      inspector: string
-      type: string
-      residenceId: string
-      address: string
-      apartmentCode: string | null
-      isFurnished: boolean
-      leaseId: string
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      masterKeyAccess: string | null
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
+      endedAt: string | null;
+      inspector: string;
+      type: string;
+      residenceId: string;
+      address: string;
+      apartmentCode: string | null;
+      isFurnished: boolean;
+      leaseId: string;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      masterKeyAccess: string | null;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12879,185 +12717,185 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms: {
-        room: string
-        remarks: {
-          remarkId: string
-          location: string | null
-          buildingComponent: string | null
-          notes: string | null
-          remarkGrade: number
-          remarkStatus: string | null
-          cost: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-          invoice: boolean
-          quantity: number
-          isMissing: boolean
-          /** Format: date-time */
-          fixedDate: string | null
-          workOrderCreated: boolean
-          workOrderStatus: number | null
-        }[]
-      }[]
-    }
+        electricalSystem?: boolean;
+      };
+      rooms: ({
+          room: string;
+          remarks: ({
+              remarkId: string;
+              location: string | null;
+              buildingComponent: string | null;
+              notes: string | null;
+              remarkGrade: number;
+              remarkStatus: string | null;
+              cost: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+              invoice: boolean;
+              quantity: number;
+              isMissing: boolean;
+              /** Format: date-time */
+              fixedDate: string | null;
+              workOrderCreated: boolean;
+              workOrderStatus: number | null;
+            })[];
+        })[];
+    };
     UpdateInspectionStatusRequest: {
       /** @enum {string} */
-      status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
-      inspector?: string
-    }
+      status?: "Registrerad" | "Påbörjad" | "Genomförd";
+      inspector?: string;
+    };
     InspectionWithSource: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
       /** @enum {string} */
-      source: 'xpand' | 'internal'
-      lease: {
-        leaseId: string
-        leaseNumber: string
+      source: "xpand" | "internal";
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
         /** Format: date-time */
-        leaseStartDate: string
+        leaseStartDate: string;
         /** Format: date-time */
-        leaseEndDate?: string
+        leaseEndDate?: string;
         /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
         rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
           address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
           roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
+              roomTypeId: string;
+              name: string;
+            }[];
           /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
+          lastUpdated?: string;
+        };
+        type: string;
         rentInfo?: {
           currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
             /** Format: date-time */
-            rentStartDate?: string
+            rentStartDate?: string;
             /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
+            rentEndDate?: string;
+          };
+        };
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
         /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
         /** Format: date-time */
-        preferredMoveOutDate?: string
+        preferredMoveOutDate?: string;
         /** Format: date-time */
-        terminationDate?: string
+        terminationDate?: string;
         /** Format: date-time */
-        contractDate?: string
+        contractDate?: string;
         /** Format: date-time */
-        lastDebitDate?: string
+        lastDebitDate?: string;
         /** Format: date-time */
-        approvalDate?: string
+        approvalDate?: string;
         residentialArea?: {
-          code: string
-          caption: string
-        }
+          code: string;
+          caption: string;
+        };
         tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
             /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-    }
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+    };
     InternalInspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
-      residenceId: string
-      isFurnished: boolean
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
+      residenceId: string;
+      isFurnished: boolean;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
-      remarkCount: number
+      endedAt: string | null;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
+      remarkCount: number;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -13068,425 +12906,388 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms:
-        | {
-            roomId: string
-            name?: string
-            conditions: {
-              details: string
-            }
-            actions: {
-              details: string[]
-            }
-            componentNotes: {
-              details: string
-            }
-            componentCosts: {
-              /** @default 0 */
-              details?: number
-            }
-            componentPhotos: {
-              details: string[]
-            }
-            componentCostResponsibilities: {
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              details?: 'tenant' | 'landlord' | null
-            }
-            photos: string[]
-            isApproved: boolean
-            isHandled: boolean
-            /** @default [] */
-            detailComponents?: {
-              id: string
-              type: string
-              label: string
-              note: string
+        electricalSystem?: boolean;
+      };
+      rooms: (({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
               /** @default */
-              condition?: string
-              cost?: number
+              condition?: string;
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default [] */
-            components?: {
-              componentId: string
-              label: string
-              condition: string
-              action: string[]
-              note: string
-              photos: string[]
-              cost?: number
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default false */
-            isAddedInThisInspection?: boolean
-          }[]
-        | null
-    }
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[]) | null;
+    };
     SaveInspectionDraftRequest: {
-      inspectorName: string
-      rooms: {
-        roomId: string
-        name?: string
-        conditions: {
-          details: string
-        }
-        actions: {
-          details: string[]
-        }
-        componentNotes: {
-          details: string
-        }
-        componentCosts: {
-          /** @default 0 */
-          details?: number
-        }
-        componentPhotos: {
-          details: string[]
-        }
-        componentCostResponsibilities: {
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          details?: 'tenant' | 'landlord' | null
-        }
-        photos: string[]
-        isApproved: boolean
-        isHandled: boolean
-        /** @default [] */
-        detailComponents?: {
-          id: string
-          type: string
-          label: string
-          note: string
-          /** @default */
-          condition?: string
-          cost?: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-        }[]
-        /** @default [] */
-        components?: {
-          componentId: string
-          label: string
-          condition: string
-          action: string[]
-          note: string
-          photos: string[]
-          cost?: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-        }[]
-        /** @default false */
-        isAddedInThisInspection?: boolean
-      }[]
-      isFurnished: boolean
-      isTenantPresent?: boolean
-      isNewTenantPresent?: boolean
+      inspectorName: string;
+      rooms: ({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
+              /** @default */
+              condition?: string;
+              cost?: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[];
+      isFurnished: boolean;
+      isTenantPresent?: boolean;
+      isNewTenantPresent?: boolean;
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
+        electricalSystem?: boolean;
+      };
       /** Format: date-time */
-      date?: string
-      type?: string
-    }
+      date?: string;
+      type?: string;
+    };
     ComponentWriteBackError: {
-      componentId: string
-      componentLabel: string
-      message: string
-    }
+      componentId: string;
+      componentLabel: string;
+      message: string;
+    };
     AddInspectionRoomRequest: {
       /** @enum {string} */
-      roomTypeCode:
-        | 'BAD'
-        | 'BAL'
-        | 'BRS'
-        | 'DUSCH'
-        | 'FÖR'
-        | 'GROV'
-        | 'HALL'
-        | 'KLÄD'
-        | 'KÖK'
-        | 'KOV'
-        | 'KV'
-        | 'MAT'
-        | 'PA'
-        | 'RUM'
-        | 'TRAPP'
-        | 'UP'
-        | 'VARD'
-        | 'WC'
-        | 'WC/DU1'
-      caption?: string
-    }
+      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
+      caption?: string;
+    };
     FileListItem: {
       /** @description Full file path/name */
-      name: string
+      name: string;
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string
+      lastModified: string;
       /** @description ETag for file version */
-      etag: string
+      etag: string;
       /** @description File size in bytes */
-      size: number
-    }
+      size: number;
+    };
     FileMetadata: {
       /** @description Full file path/name */
-      name: string
+      name: string;
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string
+      lastModified: string;
       /** @description ETag for file version */
-      etag: string
+      etag: string;
       /** @description File size in bytes */
-      size: number
+      size: number;
       /** @description Custom metadata key-value pairs */
       metaData?: {
-        [key: string]: string
-      }
-    }
+        [key: string]: string;
+      };
+    };
     FileUploadRequest: {
       /** @description Target file name/path */
-      fileName: string
+      fileName: string;
       /** @description Base64 encoded file content */
-      fileData: string
+      fileData: string;
       /** @description MIME type of the file */
-      contentType: string
-    }
+      contentType: string;
+    };
     FileUploadResponse: {
       /** @description Stored file name/path */
-      fileName: string
+      fileName: string;
       /** @description Success message */
-      message: string
-    }
+      message: string;
+    };
     FileUrlResponse: {
       /**
        * Format: uri
        * @description Presigned download URL
        */
-      url: string
+      url: string;
       /** @description URL expiry time in seconds */
-      expiresIn: number
-    }
+      expiresIn: number;
+    };
     FileExistsResponse: {
       /** @description Whether the file exists */
-      exists: boolean
-    }
+      exists: boolean;
+    };
     ListFilesResponse: {
       /** @description Array of file metadata objects */
       files: {
-        /** @description Full file path/name */
-        name: string
-        /**
-         * Format: date-time
-         * @description ISO 8601 timestamp
-         */
-        lastModified: string
-        /** @description ETag for file version */
-        etag: string
-        /** @description File size in bytes */
-        size: number
-      }[]
-    }
+          /** @description Full file path/name */
+          name: string;
+          /**
+           * Format: date-time
+           * @description ISO 8601 timestamp
+           */
+          lastModified: string;
+          /** @description ETag for file version */
+          etag: string;
+          /** @description File size in bytes */
+          size: number;
+        }[];
+    };
     ListFilesQuery: {
       /** @description Filter files by prefix */
-      prefix?: string
-    }
+      prefix?: string;
+    };
     FileUrlQuery: {
       /**
        * @description URL expiry time
        * @default 3600
        */
-      expirySeconds?: number
-    }
+      expirySeconds?: number;
+    };
     BulkSmsResult: {
       /** @description Phone numbers that received SMS */
-      successful: string[]
+      successful: string[];
       /** @description Invalid phone numbers */
-      invalid: string[]
-      totalSent: number
-      totalInvalid: number
-    }
+      invalid: string[];
+      totalSent: number;
+      totalInvalid: number;
+    };
     BulkEmailResult: {
       /** @description Email addresses that received email */
-      successful: string[]
+      successful: string[];
       /** @description Invalid email addresses */
-      invalid: string[]
-      totalSent: number
-      totalInvalid: number
-    }
+      invalid: string[];
+      totalSent: number;
+      totalInvalid: number;
+    };
     KeycloakUser: {
-      id?: string
-      username?: string
-      firstName?: string
-      lastName?: string
-      email?: string
-    }
+      id?: string;
+      username?: string;
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+    };
     RentalPropertyResponse: {
       content?: {
-        id?: string
-        type?: string
+        id?: string;
+        type?: string;
         property?: {
-          rentalTypeCode?: string
-          rentalType?: string
-          address?: string
-          code?: string
-          number?: string
-          type?: string
-          roomTypeCode?: string
-          entrance?: string
-          floor?: string
-          hasElevator?: boolean
-          washSpace?: string
-          area?: number
-          estateCode?: string
-          estate?: string
-          buildingCode?: string
-          building?: string
-        }
-      }
+          rentalTypeCode?: string;
+          rentalType?: string;
+          address?: string;
+          code?: string;
+          number?: string;
+          type?: string;
+          roomTypeCode?: string;
+          entrance?: string;
+          floor?: string;
+          hasElevator?: boolean;
+          washSpace?: string;
+          area?: number;
+          estateCode?: string;
+          estate?: string;
+          buildingCode?: string;
+          building?: string;
+        };
+      };
       _links?: {
         self?: {
-          href?: string
-        }
+          href?: string;
+        };
         link?: {
-          href?: string
-          templated?: boolean
-        }
-      }
-    }
-    ContactV1:
-      | {
-          contactCode: string
-          communication: {
-            phoneNumbers: {
-              phoneNumber: string
-              /** @enum {string} */
-              type:
-                | 'work'
-                | 'home'
-                | 'mobile'
-                | 'direct-line'
-                | 'fax'
-                | 'pager'
-                | 'unspecified'
-              comment?: string
-              isPrimary: boolean
-            }[]
-            emailAddresses: {
-              emailAddress: string
-              type: string
-              isPrimary: boolean
-            }[]
-            specialAttention: boolean
-          }
-          addresses: {
-            careOf?: string
-            street: string | null
-            zipCode: string | null
-            city: string | null
-            region: string | null
-            country: string | null
-          }[]
-          /** @enum {string} */
-          type: 'individual'
-          personal: {
-            nationalRegistrationNumber: string | null
-            birthDate: string | null
-            firstName: string | null
-            lastName: string | null
-            fullName: string
-          }
-          trustee?: {
-            contactCode: string
-            fullName?: string
-          }
-        }
-      | {
-          contactCode: string
-          communication: {
-            phoneNumbers: {
-              phoneNumber: string
-              /** @enum {string} */
-              type:
-                | 'work'
-                | 'home'
-                | 'mobile'
-                | 'direct-line'
-                | 'fax'
-                | 'pager'
-                | 'unspecified'
-              comment?: string
-              isPrimary: boolean
-            }[]
-            emailAddresses: {
-              emailAddress: string
-              type: string
-              isPrimary: boolean
-            }[]
-            specialAttention: boolean
-          }
-          addresses: {
-            careOf?: string
-            street: string | null
-            zipCode: string | null
-            city: string | null
-            region: string | null
-            country: string | null
-          }[]
-          /** @enum {string} */
-          type: 'organisation'
-          organisation: {
-            organisationNumber: string
-            name: string
-          }
-        }
-  }
-  responses: never
-  parameters: never
-  requestBodies: never
-  headers: never
-  pathItems: never
+          href?: string;
+          templated?: boolean;
+        };
+      };
+    };
+    ContactV1: ({
+      contactCode: string;
+      communication: {
+        phoneNumbers: ({
+            phoneNumber: string;
+            /** @enum {string} */
+            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
+            comment?: string;
+            isPrimary: boolean;
+          })[];
+        emailAddresses: {
+            emailAddress: string;
+            type: string;
+            isPrimary: boolean;
+          }[];
+        specialAttention: boolean;
+      };
+      addresses: ({
+          careOf?: string;
+          street: string | null;
+          zipCode: string | null;
+          city: string | null;
+          region: string | null;
+          country: string | null;
+        })[];
+      /** @enum {string} */
+      type: "individual";
+      personal: {
+        nationalRegistrationNumber: string | null;
+        birthDate: string | null;
+        firstName: string | null;
+        lastName: string | null;
+        fullName: string;
+      };
+      trustee?: {
+        contactCode: string;
+        fullName?: string;
+      };
+    }) | ({
+      contactCode: string;
+      communication: {
+        phoneNumbers: ({
+            phoneNumber: string;
+            /** @enum {string} */
+            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
+            comment?: string;
+            isPrimary: boolean;
+          })[];
+        emailAddresses: {
+            emailAddress: string;
+            type: string;
+            isPrimary: boolean;
+          }[];
+        specialAttention: boolean;
+      };
+      addresses: ({
+          careOf?: string;
+          street: string | null;
+          zipCode: string | null;
+          city: string | null;
+          region: string | null;
+          country: string | null;
+        })[];
+      /** @enum {string} */
+      type: "organisation";
+      organisation: {
+        organisationNumber: string;
+        name: string;
+      };
+    });
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 
-export type $defs = Record<string, never>
+export type $defs = Record<string, never>;
 
-export type external = Record<string, never>
+export type external = Record<string, never>;
 
-export type operations = Record<string, never>
+export type operations = Record<string, never>;

--- a/apps/property-tree/src/features/inspections/hooks/useInspectionWorkOrders.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useInspectionWorkOrders.ts
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useMutation } from '@tanstack/react-query'
 
 import { workOrderService } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
@@ -39,7 +40,6 @@ export const useInspectionWorkOrders = ({
 
   const [assignments, setAssignments] = useState<Record<string, number>>({})
   const [isConfirmOpen, setIsConfirmOpen] = useState(false)
-  const [isCreating, setIsCreating] = useState(false)
   // Teams whose work order was already created — excluded on retry so a
   // partially failed batch never duplicates the errands that succeeded.
   const [createdTeamIds, setCreatedTeamIds] = useState<Set<number>>(new Set())
@@ -67,6 +67,39 @@ export const useInspectionWorkOrders = ({
   const assignedCount = damaged.filter((c) => assignments[c.key]).length
   const unassignedCount = damaged.length - assignedCount
 
+  const createMutation = useMutation({
+    mutationFn: workOrderService.createInspectionWorkOrders,
+    onSuccess: ({ results }) => {
+      const succeededTeamIds = results
+        .filter((result) => result.ok)
+        .map((result) => result.maintenanceTeamId)
+      if (succeededTeamIds.length > 0) {
+        setCreatedTeamIds((prev) => new Set([...prev, ...succeededTeamIds]))
+      }
+
+      const failed = results.length - succeededTeamIds.length
+      if (failed === 0) {
+        toast({
+          title: 'Ärenden skapade',
+          description: `${succeededTeamIds.length} ärende(n) skapades i Odoo.`,
+        })
+      } else {
+        toast({
+          title: 'Vissa ärenden kunde inte skapas',
+          description: `${succeededTeamIds.length} skapades, ${failed} misslyckades. Försök igen.`,
+          variant: 'destructive',
+        })
+      }
+    },
+    onError: () => {
+      toast({
+        title: 'Fel',
+        description: 'Kunde inte skapa ärenden i Odoo.',
+        variant: 'destructive',
+      })
+    },
+  })
+
   /**
    * Creates the assigned work orders in Odoo. Returns true when there was
    * nothing to create or everything succeeded; false if any group failed (so
@@ -79,9 +112,8 @@ export const useInspectionWorkOrders = ({
     )
     if (!rentalId || pendingGroups.length === 0) return true
 
-    setIsCreating(true)
     try {
-      const { results } = await workOrderService.createInspectionWorkOrders({
+      const { results } = await createMutation.mutateAsync({
         rentalObjectCode: rentalId,
         groups: pendingGroups.map((group) => ({
           maintenanceTeamId: group.maintenanceTeamId,
@@ -89,58 +121,25 @@ export const useInspectionWorkOrders = ({
           descriptionHtml: group.descriptionHtml,
         })),
       })
-
-      const succeededTeamIds = results
-        .filter((result) => result.ok)
-        .map((result) => result.maintenanceTeamId)
-      if (succeededTeamIds.length > 0) {
-        setCreatedTeamIds((prev) => new Set([...prev, ...succeededTeamIds]))
-      }
-
-      const failed = results.filter((result) => !result.ok)
-      const succeeded = results.length - failed.length
-
-      if (failed.length === 0) {
-        toast({
-          title: 'Ärenden skapade',
-          description: `${succeeded} ärende(n) skapades i Odoo.`,
-        })
-        return true
-      }
-
-      toast({
-        title: 'Vissa ärenden kunde inte skapas',
-        description: `${succeeded} skapades, ${failed.length} misslyckades. Försök igen.`,
-        variant: 'destructive',
-      })
+      return results.every((result) => result.ok)
+    } catch {
+      // Toast already shown by onError; the caller only needs the outcome.
       return false
-    } catch (error) {
-      console.error('Failed to create inspection work orders:', error)
-      toast({
-        title: 'Fel',
-        description: 'Kunde inte skapa ärenden i Odoo.',
-        variant: 'destructive',
-      })
-      return false
-    } finally {
-      setIsCreating(false)
     }
   }
 
   return {
     teams,
-    isLoadingTeams: teamsQuery.isLoading,
     assignments,
     assignTeam,
     damaged,
     groups,
-    assignedCount,
     unassignedCount,
     createdTeamIds,
     isConfirmOpen,
     openConfirm: () => setIsConfirmOpen(true),
     closeConfirm: () => setIsConfirmOpen(false),
-    isCreating,
+    isCreating: createMutation.isPending,
     createWorkOrders,
   }
 }

--- a/apps/property-tree/src/features/inspections/hooks/useInspectionWorkOrders.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useInspectionWorkOrders.ts
@@ -1,0 +1,146 @@
+import { useMemo, useState } from 'react'
+
+import { workOrderService } from '@/services/api/core'
+import type { components } from '@/services/api/core/generated/api-types'
+import type { Room } from '@/services/types'
+
+import { useToast } from '@/shared/hooks/useToast'
+
+import {
+  buildInspectionWorkOrderGroups,
+  getDamagedComponents,
+} from '../lib/buildInspectionWorkOrderGroups'
+import { useMaintenanceTeams } from './useMaintenanceTeams'
+
+type InspectionRoom = components['schemas']['InspectionRoom']
+
+interface UseInspectionWorkOrdersParams {
+  inspectionData: Record<string, InspectionRoom>
+  rooms: Room[]
+  meta: { id: string; address?: string }
+  rentalId?: string
+}
+
+/**
+ * Drives the "create work orders per resursgrupp" flow on the inspection summary
+ * step: holds the per-component team assignments, derives the grouped work
+ * orders, and submits them to Odoo (one per group) before the inspection is
+ * completed. Shared by the desktop and mobile inspection forms.
+ */
+export const useInspectionWorkOrders = ({
+  inspectionData,
+  rooms,
+  meta,
+  rentalId,
+}: UseInspectionWorkOrdersParams) => {
+  const { toast } = useToast()
+  const teamsQuery = useMaintenanceTeams()
+  const teams = teamsQuery.data ?? []
+
+  const [assignments, setAssignments] = useState<Record<string, number>>({})
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isCreating, setIsCreating] = useState(false)
+  // Teams whose work order was already created — excluded on retry so a
+  // partially failed batch never duplicates the errands that succeeded.
+  const [createdTeamIds, setCreatedTeamIds] = useState<Set<number>>(new Set())
+
+  const assignTeam = (key: string, teamId: number | null) =>
+    setAssignments((prev) => {
+      if (teamId === null) {
+        const next = { ...prev }
+        delete next[key]
+        return next
+      }
+      return { ...prev, [key]: teamId }
+    })
+
+  const damaged = useMemo(
+    () => getDamagedComponents(inspectionData, rooms),
+    [inspectionData, rooms]
+  )
+
+  const groups = useMemo(
+    () => buildInspectionWorkOrderGroups(damaged, assignments, teams, meta),
+    [damaged, assignments, teams, meta]
+  )
+
+  const assignedCount = damaged.filter((c) => assignments[c.key]).length
+  const unassignedCount = damaged.length - assignedCount
+
+  /**
+   * Creates the assigned work orders in Odoo. Returns true when there was
+   * nothing to create or everything succeeded; false if any group failed (so
+   * the caller can keep the confirm dialog open for a retry). Only groups not
+   * already created are submitted, so a retry re-creates just the failed ones.
+   */
+  const createWorkOrders = async (): Promise<boolean> => {
+    const pendingGroups = groups.filter(
+      (group) => !createdTeamIds.has(group.maintenanceTeamId)
+    )
+    if (!rentalId || pendingGroups.length === 0) return true
+
+    setIsCreating(true)
+    try {
+      const { results } = await workOrderService.createInspectionWorkOrders({
+        rentalObjectCode: rentalId,
+        groups: pendingGroups.map((group) => ({
+          maintenanceTeamId: group.maintenanceTeamId,
+          maintenanceTeamName: group.maintenanceTeamName,
+          descriptionHtml: group.descriptionHtml,
+        })),
+      })
+
+      const succeededTeamIds = results
+        .filter((result) => result.ok)
+        .map((result) => result.maintenanceTeamId)
+      if (succeededTeamIds.length > 0) {
+        setCreatedTeamIds((prev) => new Set([...prev, ...succeededTeamIds]))
+      }
+
+      const failed = results.filter((result) => !result.ok)
+      const succeeded = results.length - failed.length
+
+      if (failed.length === 0) {
+        toast({
+          title: 'Ärenden skapade',
+          description: `${succeeded} ärende(n) skapades i Odoo.`,
+        })
+        return true
+      }
+
+      toast({
+        title: 'Vissa ärenden kunde inte skapas',
+        description: `${succeeded} skapades, ${failed.length} misslyckades. Försök igen.`,
+        variant: 'destructive',
+      })
+      return false
+    } catch (error) {
+      console.error('Failed to create inspection work orders:', error)
+      toast({
+        title: 'Fel',
+        description: 'Kunde inte skapa ärenden i Odoo.',
+        variant: 'destructive',
+      })
+      return false
+    } finally {
+      setIsCreating(false)
+    }
+  }
+
+  return {
+    teams,
+    isLoadingTeams: teamsQuery.isLoading,
+    assignments,
+    assignTeam,
+    damaged,
+    groups,
+    assignedCount,
+    unassignedCount,
+    createdTeamIds,
+    isConfirmOpen,
+    openConfirm: () => setIsConfirmOpen(true),
+    closeConfirm: () => setIsConfirmOpen(false),
+    isCreating,
+    createWorkOrders,
+  }
+}

--- a/apps/property-tree/src/features/inspections/hooks/useMaintenanceTeams.ts
+++ b/apps/property-tree/src/features/inspections/hooks/useMaintenanceTeams.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { workOrderService } from '@/services/api/core'
+
+/**
+ * Fetches the selectable resursgrupper (Odoo maintenance teams) used when an
+ * inspector assigns damaged components to a team before creating work orders.
+ * Teams rarely change, so the result is cached aggressively.
+ */
+export const useMaintenanceTeams = () =>
+  useQuery({
+    queryKey: ['maintenanceTeams'],
+    queryFn: () => workOrderService.getMaintenanceTeams(),
+    staleTime: 1000 * 60 * 60,
+  })

--- a/apps/property-tree/src/features/inspections/lib/buildInspectionWorkOrderGroups.ts
+++ b/apps/property-tree/src/features/inspections/lib/buildInspectionWorkOrderGroups.ts
@@ -1,0 +1,148 @@
+import type { MaintenanceTeam } from '@/services/api/core'
+import type { components } from '@/services/api/core/generated/api-types'
+import type { Room } from '@/services/types'
+
+import { CONDITION_TYPE } from '../constants/conditions'
+import { COST_RESPONSIBILITY_LABEL } from '../constants/costResponsibility'
+
+type InspectionRoom = components['schemas']['InspectionRoom']
+
+export interface DamagedComponent {
+  key: string
+  roomName: string
+  label: string
+  actions: string[]
+  note: string
+  cost: number
+  costResponsibility: 'tenant' | 'landlord' | null
+}
+
+export interface InspectionWorkOrderGroup {
+  maintenanceTeamId: number
+  maintenanceTeamName: string
+  descriptionHtml: string
+  componentLabels: string[]
+}
+
+/**
+ * Stable per-component key used both for the resursgrupp dropdown state in the
+ * summary and for grouping at submit time. Scoped by room so the same component
+ * id in two rooms doesn't collide.
+ */
+export const componentAssignmentKey = (
+  roomId: string,
+  source: 'component' | 'detail',
+  componentId: string
+): string => `${roomId}:${source}:${componentId}`
+
+/**
+ * Enumerates every Skadad component (fetched components + detail components)
+ * across all rooms of the in-progress inspection form state.
+ */
+export const getDamagedComponents = (
+  inspectionData: Record<string, InspectionRoom>,
+  rooms: Room[]
+): DamagedComponent[] => {
+  const result: DamagedComponent[] = []
+
+  for (const room of rooms) {
+    const roomData = inspectionData[room.id]
+    if (!roomData) continue
+    const roomName = room.name ?? room.code
+
+    for (const component of roomData.components ?? []) {
+      if (component.condition !== CONDITION_TYPE.DAMAGED) continue
+      result.push({
+        key: componentAssignmentKey(
+          room.id,
+          'component',
+          component.componentId
+        ),
+        roomName,
+        label: component.label || component.componentId,
+        actions: component.action ?? [],
+        note: component.note ?? '',
+        cost: component.cost ?? 0,
+        costResponsibility: component.costResponsibility ?? null,
+      })
+    }
+
+    for (const detail of roomData.detailComponents ?? []) {
+      if (detail.condition !== CONDITION_TYPE.DAMAGED) continue
+      result.push({
+        key: componentAssignmentKey(room.id, 'detail', detail.id),
+        roomName,
+        label: detail.label || detail.id,
+        actions: [],
+        note: detail.note ?? '',
+        cost: detail.cost ?? 0,
+        costResponsibility: detail.costResponsibility ?? null,
+      })
+    }
+  }
+
+  return result
+}
+
+const formatLine = (component: DamagedComponent): string => {
+  let line = component.label
+  if (component.actions.length > 0) line += ` – ${component.actions.join(', ')}`
+  if (component.note.trim()) line += `: ${component.note.trim()}`
+
+  if (component.cost > 0) {
+    const responsibility = component.costResponsibility
+      ? ` (${COST_RESPONSIBILITY_LABEL[component.costResponsibility]})`
+      : ''
+    line += `. Kostnad: ${component.cost} kr${responsibility}`
+  }
+
+  return `- ${line}`
+}
+
+/**
+ * Groups the damaged components the inspector assigned to a resursgrupp into one
+ * work order per team. The description is HTML (`<br>`-joined — Odoo's field is
+ * Html), grouped by room. Components with no team assigned are excluded.
+ */
+export const buildInspectionWorkOrderGroups = (
+  damaged: DamagedComponent[],
+  assignments: Record<string, number>,
+  teams: MaintenanceTeam[],
+  meta: { id: string; address?: string }
+): InspectionWorkOrderGroup[] => {
+  const teamName = (id: number) =>
+    teams.find((team) => team.id === id)?.name ?? `Resursgrupp ${id}`
+
+  const byTeam = new Map<number, DamagedComponent[]>()
+  for (const component of damaged) {
+    const teamId = assignments[component.key]
+    if (!teamId) continue
+    byTeam.set(teamId, [...(byTeam.get(teamId) ?? []), component])
+  }
+
+  const header = meta.address
+    ? `Besiktning ${meta.id} – ${meta.address}`
+    : `Besiktning ${meta.id}`
+
+  return [...byTeam.entries()].map(([teamId, components]) => {
+    const byRoom = new Map<string, DamagedComponent[]>()
+    for (const component of components) {
+      byRoom.set(component.roomName, [
+        ...(byRoom.get(component.roomName) ?? []),
+        component,
+      ])
+    }
+
+    const roomBlocks = [...byRoom.entries()].map(
+      ([roomName, roomComponents]) =>
+        `${roomName}:<br>${roomComponents.map(formatLine).join('<br>')}`
+    )
+
+    return {
+      maintenanceTeamId: teamId,
+      maintenanceTeamName: teamName(teamId),
+      descriptionHtml: `${header}<br><br>${roomBlocks.join('<br><br>')}`,
+      componentLabels: components.map((component) => component.label),
+    }
+  })
+}

--- a/apps/property-tree/src/features/inspections/lib/buildInspectionWorkOrderGroups.ts
+++ b/apps/property-tree/src/features/inspections/lib/buildInspectionWorkOrderGroups.ts
@@ -2,6 +2,7 @@ import type { MaintenanceTeam } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
 
+import { getActionLabel } from '../constants/actions'
 import { CONDITION_TYPE } from '../constants/conditions'
 import { COST_RESPONSIBILITY_LABEL } from '../constants/costResponsibility'
 
@@ -86,7 +87,8 @@ export const getDamagedComponents = (
 
 const formatLine = (component: DamagedComponent): string => {
   let line = component.label
-  if (component.actions.length > 0) line += ` – ${component.actions.join(', ')}`
+  if (component.actions.length > 0)
+    line += ` – ${component.actions.map(getActionLabel).join(', ')}`
   if (component.note.trim()) line += `: ${component.note.trim()}`
 
   if (component.cost > 0) {

--- a/apps/property-tree/src/features/inspections/ui/ComponentDetailSheet.tsx
+++ b/apps/property-tree/src/features/inspections/ui/ComponentDetailSheet.tsx
@@ -111,26 +111,6 @@ export function ComponentDetailSheet({
               className="min-h-[100px]"
             />
           </div>
-
-          {/* History Section - hidden until dynamic data is available */}
-          {/* <Separator />
-          <div>
-            <div className="flex items-center gap-2 mb-3">
-              <Clock className="h-4 w-4 text-muted-foreground" />
-              <h3 className="font-medium">Historik</h3>
-            </div>
-            <div className="space-y-2 text-sm text-muted-foreground">
-              <p>• 2024-01-15: God (Anna A.)</p>
-              <p>• 2023-06-20: God (Erik E.)</p>
-            </div>
-          </div> */}
-
-          {/* Create Order Button - hidden until dynamic data is available */}
-          {/* <Separator />
-          <Button className="w-full" variant="outline">
-            <FileText className="h-4 w-4 mr-2" />
-            Skapa ärende
-          </Button> */}
         </div>
       </SheetContent>
     </Sheet>

--- a/apps/property-tree/src/features/inspections/ui/ComponentInspectionCard.tsx
+++ b/apps/property-tree/src/features/inspections/ui/ComponentInspectionCard.tsx
@@ -9,16 +9,14 @@ import {
   type ComponentType,
   CONDITION_OPTIONS,
   CONDITION_TYPE,
-  COST_RESPONSIBILITY,
-  COST_RESPONSIBILITY_LABEL,
   type CostResponsibility,
   getActionsForComponentType,
   getConditionConfig,
 } from '../constants'
+import { CostResponsibilitySelect } from './CostResponsibilitySelect'
 import { PhotoCapture, type InspectionPhotoUploadContext } from './PhotoCapture'
 
 interface ComponentInspectionCardProps {
-  componentKey: string
   label: string
   condition: string
   note: string
@@ -36,7 +34,6 @@ interface ComponentInspectionCardProps {
 }
 
 export function ComponentInspectionCard({
-  componentKey,
   label,
   condition,
   note,
@@ -178,31 +175,17 @@ export function ComponentInspectionCard({
             </div>
           )}
 
-          {/* Cost responsibility radio — only shown for Skadad */}
+          {/* Cost responsibility — only shown for Skadad */}
           {condition === CONDITION_TYPE.DAMAGED && (
             <div className="mb-3">
               <p className="text-sm text-muted-foreground mb-2">
                 Kostnadsansvar
               </p>
-              <div className="flex gap-4">
-                {[COST_RESPONSIBILITY.TENANT, COST_RESPONSIBILITY.LANDLORD].map(
-                  (value) => (
-                    <label
-                      key={value}
-                      className="flex items-center gap-2 text-sm cursor-pointer"
-                    >
-                      <input
-                        type="radio"
-                        name={`cost-${componentKey}`}
-                        value={value}
-                        checked={costResponsibility === value}
-                        onChange={() => onCostResponsibilityChange(value)}
-                      />
-                      {COST_RESPONSIBILITY_LABEL[value]}
-                    </label>
-                  )
-                )}
-              </div>
+              <CostResponsibilitySelect
+                value={costResponsibility}
+                onChange={onCostResponsibilityChange}
+                ariaLabel={`Kostnadsansvar för ${label}`}
+              />
             </div>
           )}
 

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionWorkOrdersDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionWorkOrdersDialog.tsx
@@ -1,0 +1,96 @@
+import { Button } from '@/shared/ui/Button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/Dialog'
+
+import type { InspectionWorkOrderGroup } from '../lib/buildInspectionWorkOrderGroups'
+
+interface CreateInspectionWorkOrdersDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  groups: InspectionWorkOrderGroup[]
+  unassignedCount: number
+  createdTeamIds: Set<number>
+  isCreating: boolean
+  onConfirm: () => void
+}
+
+/**
+ * Previews the work orders that will be created (one per resursgrupp) before the
+ * inspection is completed, and surfaces any Skadad components left unassigned.
+ * Groups already created in a previous attempt are marked and won't be resent.
+ */
+export function CreateInspectionWorkOrdersDialog({
+  open,
+  onOpenChange,
+  groups,
+  unassignedCount,
+  createdTeamIds,
+  isCreating,
+  onConfirm,
+}: CreateInspectionWorkOrdersDialogProps) {
+  const pendingCount = groups.filter(
+    (group) => !createdTeamIds.has(group.maintenanceTeamId)
+  ).length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Skapa ärenden och slutför</DialogTitle>
+          <DialogDescription>
+            {groups.length === 0
+              ? 'Inga komponenter har tilldelats en resursgrupp – inga ärenden skapas.'
+              : pendingCount === 0
+                ? 'Alla ärenden är redan skapade – besiktningen slutförs.'
+                : `${pendingCount} ärende(n) skapas i Odoo, ett per resursgrupp:`}
+          </DialogDescription>
+        </DialogHeader>
+
+        {groups.length > 0 && (
+          <ul className="space-y-2 text-sm">
+            {groups.map((group) => (
+              <li
+                key={group.maintenanceTeamId}
+                className="flex justify-between gap-2 rounded-md border p-2"
+              >
+                <span className="font-medium">{group.maintenanceTeamName}</span>
+                <span className="text-muted-foreground">
+                  {createdTeamIds.has(group.maintenanceTeamId)
+                    ? 'Redan skapad ✓'
+                    : `${group.componentLabels.length} komponent${group.componentLabels.length === 1 ? '' : 'er'}`}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {unassignedCount > 0 && (
+          <p className="text-sm text-muted-foreground">
+            {unassignedCount} skadad komponent
+            {unassignedCount === 1 ? '' : 'er'} utan resursgrupp – inget ärende
+            skapas för {unassignedCount === 1 ? 'den' : 'dem'}.
+          </p>
+        )}
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isCreating}
+          >
+            Avbryt
+          </Button>
+          <Button onClick={onConfirm} disabled={isCreating}>
+            {isCreating ? 'Skapar…' : 'Skapa och slutför'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionWorkOrdersDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionWorkOrdersDialog.tsx
@@ -8,7 +8,44 @@ import {
   DialogTitle,
 } from '@/shared/ui/Dialog'
 
+import type { useInspectionWorkOrders } from '../hooks/useInspectionWorkOrders'
 import type { InspectionWorkOrderGroup } from '../lib/buildInspectionWorkOrderGroups'
+
+interface InspectionWorkOrdersConfirmFlowProps {
+  workOrders: ReturnType<typeof useInspectionWorkOrders>
+  onCompleted: () => void
+}
+
+/**
+ * Wires the confirm dialog to the useInspectionWorkOrders hook: creates the
+ * work orders on confirm and, once everything succeeded (or there was nothing
+ * to create), closes the dialog and completes the inspection. Shared by the
+ * desktop and mobile inspection forms.
+ */
+export function InspectionWorkOrdersConfirmFlow({
+  workOrders,
+  onCompleted,
+}: InspectionWorkOrdersConfirmFlowProps) {
+  return (
+    <CreateInspectionWorkOrdersDialog
+      open={workOrders.isConfirmOpen}
+      onOpenChange={(open) => {
+        if (!open) workOrders.closeConfirm()
+      }}
+      groups={workOrders.groups}
+      unassignedCount={workOrders.unassignedCount}
+      createdTeamIds={workOrders.createdTeamIds}
+      isCreating={workOrders.isCreating}
+      onConfirm={async () => {
+        const ok = await workOrders.createWorkOrders()
+        if (ok) {
+          workOrders.closeConfirm()
+          onCompleted()
+        }
+      }}
+    />
+  )
+}
 
 interface CreateInspectionWorkOrdersDialogProps {
   open: boolean

--- a/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
@@ -22,7 +22,7 @@ import { Button } from '@/shared/ui/Button'
 import { FORM_STEP, type FormStep } from '../constants/formSteps'
 import { useInspectionForm } from '../hooks/useInspectionForm'
 import { useInspectionWorkOrders } from '../hooks/useInspectionWorkOrders'
-import { CreateInspectionWorkOrdersDialog } from './CreateInspectionWorkOrdersDialog'
+import { InspectionWorkOrdersConfirmFlow } from './CreateInspectionWorkOrdersDialog'
 import { InspectionChecklistStep } from './InspectionChecklistStep'
 import { InspectionInfoSection } from './InspectionInfoSection'
 import { InspectionMoreMenu } from './InspectionMoreMenu'
@@ -597,22 +597,9 @@ export function InspectionForm({
         onConfirm={handleConfirmSaveDraft}
       />
 
-      <CreateInspectionWorkOrdersDialog
-        open={workOrders.isConfirmOpen}
-        onOpenChange={(open) => {
-          if (!open) workOrders.closeConfirm()
-        }}
-        groups={workOrders.groups}
-        unassignedCount={workOrders.unassignedCount}
-        createdTeamIds={workOrders.createdTeamIds}
-        isCreating={workOrders.isCreating}
-        onConfirm={async () => {
-          const ok = await workOrders.createWorkOrders()
-          if (ok) {
-            workOrders.closeConfirm()
-            handleSubmit()
-          }
-        }}
+      <InspectionWorkOrdersConfirmFlow
+        workOrders={workOrders}
+        onCompleted={handleSubmit}
       />
 
       <RemoveInspectionRoomDialog

--- a/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionForm.tsx
@@ -21,6 +21,8 @@ import { Button } from '@/shared/ui/Button'
 
 import { FORM_STEP, type FormStep } from '../constants/formSteps'
 import { useInspectionForm } from '../hooks/useInspectionForm'
+import { useInspectionWorkOrders } from '../hooks/useInspectionWorkOrders'
+import { CreateInspectionWorkOrdersDialog } from './CreateInspectionWorkOrdersDialog'
 import { InspectionChecklistStep } from './InspectionChecklistStep'
 import { InspectionInfoSection } from './InspectionInfoSection'
 import { InspectionMoreMenu } from './InspectionMoreMenu'
@@ -121,6 +123,14 @@ export function InspectionForm({
   // canComplete delegates to the shared validation hook so it stays in sync
   // with the checklist gating (all four checks required).
   const canComplete = validation.canComplete
+
+  // Resursgrupp assignment + work-order creation on the summary step.
+  const workOrders = useInspectionWorkOrders({
+    inspectionData,
+    rooms,
+    meta: { id: existingInspection.id, address },
+    rentalId,
+  })
 
   const [isDraftConfirmOpen, setIsDraftConfirmOpen] = useState(false)
   const [step, setStep] = useState<FormStep>(FORM_STEP.ROOMS)
@@ -514,6 +524,9 @@ export function InspectionForm({
             <InspectionSummary
               inspectionData={inspectionData}
               rooms={rooms}
+              teams={workOrders.teams}
+              assignments={workOrders.assignments}
+              onAssignTeam={workOrders.assignTeam}
               onComponentCostByIdUpdate={handleComponentCostUpdateById}
               onComponentCostResponsibilityByIdUpdate={
                 handleComponentCostResponsibilityUpdateById
@@ -564,7 +577,14 @@ export function InspectionForm({
             </Button>
           )}
           {step === FORM_STEP.SUMMARY && (
-            <Button onClick={handleSubmit} disabled={!canComplete}>
+            <Button
+              onClick={() =>
+                workOrders.damaged.length > 0
+                  ? workOrders.openConfirm()
+                  : handleSubmit()
+              }
+              disabled={!canComplete}
+            >
               Slutför besiktning
             </Button>
           )}
@@ -575,6 +595,24 @@ export function InspectionForm({
         open={isDraftConfirmOpen}
         onOpenChange={setIsDraftConfirmOpen}
         onConfirm={handleConfirmSaveDraft}
+      />
+
+      <CreateInspectionWorkOrdersDialog
+        open={workOrders.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) workOrders.closeConfirm()
+        }}
+        groups={workOrders.groups}
+        unassignedCount={workOrders.unassignedCount}
+        createdTeamIds={workOrders.createdTeamIds}
+        isCreating={workOrders.isCreating}
+        onConfirm={async () => {
+          const ok = await workOrders.createWorkOrders()
+          if (ok) {
+            workOrders.closeConfirm()
+            handleSubmit()
+          }
+        }}
       />
 
       <RemoveInspectionRoomDialog

--- a/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionSummary.tsx
@@ -1,8 +1,16 @@
+import type { MaintenanceTeam } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
 import type { Room } from '@/services/types'
 
 import { Badge } from '@/shared/ui/Badge'
 import { Input } from '@/shared/ui/Input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/shared/ui/Select'
 import {
   Table,
   TableBody,
@@ -17,6 +25,7 @@ import {
   COST_RESPONSIBILITY,
   type CostResponsibility,
 } from '../constants/costResponsibility'
+import { componentAssignmentKey } from '../lib/buildInspectionWorkOrderGroups'
 import { CostResponsibilitySelect } from './CostResponsibilitySelect'
 
 type InspectionRoom = components['schemas']['InspectionRoom']
@@ -97,9 +106,42 @@ function CostInput({
   )
 }
 
+function ResursgruppSelect({
+  teams,
+  value,
+  onChange,
+  ariaLabel,
+}: {
+  teams: MaintenanceTeam[]
+  value: number | undefined
+  onChange: (teamId: number | null) => void
+  ariaLabel: string
+}) {
+  return (
+    <Select
+      value={value?.toString() ?? ''}
+      onValueChange={(v) => onChange(v ? Number(v) : null)}
+    >
+      <SelectTrigger aria-label={ariaLabel}>
+        <SelectValue placeholder="Välj resursgrupp" />
+      </SelectTrigger>
+      <SelectContent>
+        {teams.map((team) => (
+          <SelectItem key={team.id} value={team.id.toString()}>
+            {team.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
 interface RoomSectionProps {
   room: Room
   roomData: InspectionRoom | undefined
+  teams: MaintenanceTeam[]
+  assignments: Record<string, number>
+  onAssignTeam: (key: string, teamId: number | null) => void
   onComponentCostByIdUpdate: (
     roomId: string,
     componentId: string,
@@ -127,6 +169,9 @@ interface RoomSectionProps {
 function RoomSummarySection({
   room,
   roomData,
+  teams,
+  assignments,
+  onAssignTeam,
   onComponentCostByIdUpdate,
   onComponentCostResponsibilityByIdUpdate,
   onDetailComponentCostUpdate,
@@ -140,6 +185,11 @@ function RoomSummarySection({
   // desktop table can share the same conditional rules without diverging.
   const rows = remarks.map((remark) => {
     const conditionConfig = getConditionConfig(remark.condition)
+    const assignmentKey = componentAssignmentKey(
+      room.id,
+      remark.source,
+      remark.componentId
+    )
     let costValue: number
     let costResponsibility: CostResponsibility
     if (remark.source === 'detail') {
@@ -194,6 +244,7 @@ function RoomSummarySection({
     return {
       remark,
       conditionConfig,
+      assignmentKey,
       costValue,
       costResponsibility,
       showResponsibility,
@@ -214,6 +265,7 @@ function RoomSummarySection({
           ({
             remark,
             conditionConfig,
+            assignmentKey,
             costValue,
             costResponsibility,
             showResponsibility,
@@ -260,6 +312,19 @@ function RoomSummarySection({
                   />
                 </div>
               )}
+              {showResponsibility && (
+                <div className="space-y-1">
+                  <label className="text-xs text-muted-foreground">
+                    Resursgrupp
+                  </label>
+                  <ResursgruppSelect
+                    teams={teams}
+                    value={assignments[assignmentKey]}
+                    onChange={(teamId) => onAssignTeam(assignmentKey, teamId)}
+                    ariaLabel={`Resursgrupp för ${remark.label}`}
+                  />
+                </div>
+              )}
             </div>
           )
         )}
@@ -274,6 +339,7 @@ function RoomSummarySection({
               <TableHead>Status</TableHead>
               <TableHead className="w-40">Kostnad (kr)</TableHead>
               <TableHead className="w-44">Kostnadsansvar</TableHead>
+              <TableHead className="w-48">Resursgrupp</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -281,6 +347,7 @@ function RoomSummarySection({
               ({
                 remark,
                 conditionConfig,
+                assignmentKey,
                 costValue,
                 costResponsibility,
                 showResponsibility,
@@ -318,6 +385,18 @@ function RoomSummarySection({
                       />
                     )}
                   </TableCell>
+                  <TableCell>
+                    {showResponsibility && (
+                      <ResursgruppSelect
+                        teams={teams}
+                        value={assignments[assignmentKey]}
+                        onChange={(teamId) =>
+                          onAssignTeam(assignmentKey, teamId)
+                        }
+                        ariaLabel={`Resursgrupp för ${remark.label}`}
+                      />
+                    )}
+                  </TableCell>
                 </TableRow>
               )
             )}
@@ -331,6 +410,9 @@ function RoomSummarySection({
 interface InspectionSummaryProps {
   inspectionData: Record<string, InspectionRoom>
   rooms: Room[]
+  teams: MaintenanceTeam[]
+  assignments: Record<string, number>
+  onAssignTeam: (key: string, teamId: number | null) => void
   onComponentCostByIdUpdate: (
     roomId: string,
     componentId: string,
@@ -358,6 +440,9 @@ interface InspectionSummaryProps {
 export function InspectionSummary({
   inspectionData,
   rooms,
+  teams,
+  assignments,
+  onAssignTeam,
   onComponentCostByIdUpdate,
   onComponentCostResponsibilityByIdUpdate,
   onDetailComponentCostUpdate,
@@ -398,6 +483,9 @@ export function InspectionSummary({
           key={room.id}
           room={room}
           roomData={roomData}
+          teams={teams}
+          assignments={assignments}
+          onAssignTeam={onAssignTeam}
           onComponentCostByIdUpdate={onComponentCostByIdUpdate}
           onComponentCostResponsibilityByIdUpdate={
             onComponentCostResponsibilityByIdUpdate

--- a/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
+++ b/apps/property-tree/src/features/inspections/ui/RoomInspectionEditor.tsx
@@ -199,7 +199,6 @@ export function RoomInspectionEditor({
             return (
               <ComponentInspectionCard
                 key={componentId}
-                componentKey={componentId}
                 label={label}
                 condition={state.condition}
                 note={state.note}

--- a/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../constants/inspectionTypes'
 import { useInspectionForm } from '../../hooks/useInspectionForm'
 import { useInspectionWorkOrders } from '../../hooks/useInspectionWorkOrders'
-import { CreateInspectionWorkOrdersDialog } from '../CreateInspectionWorkOrdersDialog'
+import { InspectionWorkOrdersConfirmFlow } from '../CreateInspectionWorkOrdersDialog'
 import { InspectionChecklistStep } from '../InspectionChecklistStep'
 import { InspectionInfoSection } from '../InspectionInfoSection'
 import { InspectionMoreMenu } from '../InspectionMoreMenu'
@@ -626,22 +626,9 @@ export function MobileInspectionForm({
         onConfirm={handleConfirmSaveDraft}
       />
 
-      <CreateInspectionWorkOrdersDialog
-        open={workOrders.isConfirmOpen}
-        onOpenChange={(open) => {
-          if (!open) workOrders.closeConfirm()
-        }}
-        groups={workOrders.groups}
-        unassignedCount={workOrders.unassignedCount}
-        createdTeamIds={workOrders.createdTeamIds}
-        isCreating={workOrders.isCreating}
-        onConfirm={async () => {
-          const ok = await workOrders.createWorkOrders()
-          if (ok) {
-            workOrders.closeConfirm()
-            handleSubmit()
-          }
-        }}
+      <InspectionWorkOrdersConfirmFlow
+        workOrders={workOrders}
+        onCompleted={handleSubmit}
       />
     </div>
   )

--- a/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
+++ b/apps/property-tree/src/features/inspections/ui/mobile/MobileInspectionForm.tsx
@@ -21,6 +21,8 @@ import {
   type InspectionType,
 } from '../../constants/inspectionTypes'
 import { useInspectionForm } from '../../hooks/useInspectionForm'
+import { useInspectionWorkOrders } from '../../hooks/useInspectionWorkOrders'
+import { CreateInspectionWorkOrdersDialog } from '../CreateInspectionWorkOrdersDialog'
 import { InspectionChecklistStep } from '../InspectionChecklistStep'
 import { InspectionInfoSection } from '../InspectionInfoSection'
 import { InspectionMoreMenu } from '../InspectionMoreMenu'
@@ -135,6 +137,14 @@ export function MobileInspectionForm({
   const isLastRoom = currentRoomIndex >= rooms.length - 1
   // Delegates to the shared validation hook (includes checklist gating).
   const canComplete = validation.canComplete
+
+  // Resursgrupp assignment + work-order creation on the summary step.
+  const workOrders = useInspectionWorkOrders({
+    inspectionData,
+    rooms,
+    meta: { id: existingInspection.id, address },
+    rentalId,
+  })
 
   // Create tenant snapshot for saving
   const createTenantSnapshot = (): TenantSnapshot | undefined => {
@@ -488,6 +498,9 @@ export function MobileInspectionForm({
                 <InspectionSummary
                   inspectionData={inspectionData}
                   rooms={rooms}
+                  teams={workOrders.teams}
+                  assignments={workOrders.assignments}
+                  onAssignTeam={workOrders.assignTeam}
                   onComponentCostByIdUpdate={handleComponentCostUpdateById}
                   onComponentCostResponsibilityByIdUpdate={
                     handleComponentCostResponsibilityUpdateById
@@ -593,7 +606,14 @@ export function MobileInspectionForm({
             >
               Spara utkast
             </Button>
-            <Button onClick={handleSubmit} disabled={!canComplete}>
+            <Button
+              onClick={() =>
+                workOrders.damaged.length > 0
+                  ? workOrders.openConfirm()
+                  : handleSubmit()
+              }
+              disabled={!canComplete}
+            >
               Slutför besiktning
             </Button>
           </div>
@@ -604,6 +624,24 @@ export function MobileInspectionForm({
         open={isDraftConfirmOpen}
         onOpenChange={setIsDraftConfirmOpen}
         onConfirm={handleConfirmSaveDraft}
+      />
+
+      <CreateInspectionWorkOrdersDialog
+        open={workOrders.isConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open) workOrders.closeConfirm()
+        }}
+        groups={workOrders.groups}
+        unassignedCount={workOrders.unassignedCount}
+        createdTeamIds={workOrders.createdTeamIds}
+        isCreating={workOrders.isCreating}
+        onConfirm={async () => {
+          const ok = await workOrders.createWorkOrders()
+          if (ok) {
+            workOrders.closeConfirm()
+            handleSubmit()
+          }
+        }}
       />
     </div>
   )

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -3,9 +3,8 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "/auth/generatehash": {
+  '/auth/generatehash': {
     /**
      * Generates a salt and hashes the given password using that salt.
      * @description Generates a salt and hashes the given password using that salt. Pass cleartext password as query parameter.
@@ -14,18 +13,18 @@ export interface paths {
       parameters: {
         query: {
           /** @description The cleartext password that should be hashed */
-          password: string;
-        };
-      };
+          password: string
+        }
+      }
       responses: {
         /** @description Hashed password and salt */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/generatetoken": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/generatetoken': {
     /**
      * Generates a JWT token
      * @description Validates username and password from request body and returns a JWT token.
@@ -33,41 +32,41 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/x-www-form-urlencoded": {
-            username?: string;
-            password?: string;
-          };
-        };
-      };
+          'application/x-www-form-urlencoded': {
+            username?: string
+            password?: string
+          }
+        }
+      }
       responses: {
         /** @description A valid JWT token */
         200: {
           content: {
-            "application/json": {
-              token?: string;
-            };
-          };
-        };
+            'application/json': {
+              token?: string
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
-              errorMessage?: string;
-            };
-          };
-        };
+            'application/json': {
+              errorMessage?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/auth/login": {
+            'application/json': {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/auth/login': {
     /**
      * Redirects to Keycloak login
      * @description Redirects the user to the Keycloak login page
@@ -76,12 +75,12 @@ export interface paths {
       responses: {
         /** @description Redirect to Keycloak login */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/callback": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/callback': {
     /**
      * OAuth callback endpoint
      * @description Handles the OAuth callback from Keycloak
@@ -89,21 +88,21 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            code?: string;
-            redirectUri?: string;
-          };
-        };
-      };
+          'application/json': {
+            code?: string
+            redirectUri?: string
+          }
+        }
+      }
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/logout": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/logout': {
     /**
      * Logout endpoint
      * @description Clears authentication cookies and redirects to Keycloak logout
@@ -112,12 +111,12 @@ export interface paths {
       responses: {
         /** @description Redirect to login page */
         302: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/profile": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/profile': {
     /**
      * Get user profile
      * @description Returns the authenticated user's profile information
@@ -126,16 +125,16 @@ export interface paths {
       responses: {
         /** @description User profile information */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/refresh": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/refresh': {
     /**
      * Refresh access token
      * @description Uses refresh_token cookie to get new access_token
@@ -144,16 +143,16 @@ export interface paths {
       responses: {
         /** @description Token refreshed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid or expired refresh token */
         401: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/auth/roles/{roleName}/users": {
+          content: never
+        }
+      }
+    }
+  }
+  '/auth/roles/{roleName}/users': {
     /**
      * Get users by realm role (via group membership)
      * @description Returns all users that belong to groups assigned the given Keycloak realm role. Users are deduplicated across groups.
@@ -162,46 +161,44 @@ export interface paths {
       parameters: {
         path: {
           /** @description The name of the Keycloak realm role */
-          roleName: string;
-        };
-      };
+          roleName: string
+        }
+      }
       responses: {
         /** @description List of users with the given role */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeycloakUser"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeycloakUser'][]
+            }
+          }
+        }
         /** @description Unauthorized */
         401: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Forbidden — insufficient permissions to query role members */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Role not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Keycloak unreachable */
         502: {
-          content: never;
-        };
-      };
-    };
-  };
-  "openapi": {
-  };
-  "security": {
-  };
-  "/sendBulkSms": {
+          content: never
+        }
+      }
+    }
+  }
+  openapi: {}
+  security: {}
+  '/sendBulkSms': {
     /**
      * Send SMS to multiple contacts
      * @description Send SMS messages to multiple phone numbers
@@ -209,35 +206,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of phone numbers */
-            phoneNumbers: string[];
+            phoneNumbers: string[]
             /** @description SMS message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description SMS sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkSmsResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkSmsResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/sendBulkEmail": {
+          content: never
+        }
+      }
+    }
+  }
+  '/sendBulkEmail': {
     /**
      * Send email to multiple contacts
      * @description Send email messages to multiple email addresses
@@ -245,37 +242,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Array of email addresses */
-            emails: string[];
+            emails: string[]
             /** @description Email subject */
-            subject: string;
+            subject: string
             /** @description Email message content */
-            text: string;
-          };
-        };
-      };
+            text: string
+          }
+        }
+      }
       responses: {
         /** @description Email sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BulkEmailResult"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BulkEmailResult']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearTickets": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearTickets': {
     /**
      * Get Linear tickets with mimer-visible label
      * @description Fetch Linear issues that have the mimer-visible label
@@ -284,24 +281,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of tickets to fetch */
-          first?: number;
+          first?: number
           /** @description Cursor for pagination */
-          after?: string;
-        };
-      };
+          after?: string
+        }
+      }
       responses: {
         /** @description Linear tickets fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/createLinearErrand": {
+          content: never
+        }
+      }
+    }
+  }
+  '/createLinearErrand': {
     /**
      * Create a new Linear errand
      * @description Create a new issue in Linear with specified team, project, and labels
@@ -309,33 +306,33 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Errand title */
-            title: string;
+            title: string
             /** @description Errand description */
-            description: string;
+            description: string
             /** @description Label ID for category (Bug, Improvement, etc.) */
-            categoryLabelId: string;
-          };
-        };
-      };
+            categoryLabelId: string
+          }
+        }
+      }
       responses: {
         /** @description Linear errand created successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/getLinearLabels": {
+          content: never
+        }
+      }
+    }
+  }
+  '/getLinearLabels': {
     /**
      * Get Linear category labels
      * @description Fetch available category labels (Bug, Improvement, new feature)
@@ -344,16 +341,16 @@ export interface paths {
       responses: {
         /** @description Linear labels fetched successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/health": {
+          content: never
+        }
+      }
+    }
+  }
+  '/health': {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -363,35 +360,35 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /**
                * @description Name of the system.
                * @example core
                */
-              name?: string;
+              name?: string
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string;
-              subsystems?: ({
-                  /** @description Name of the subsystem. */
-                  name?: string;
-                  /**
-                   * @description Status of the subsystem.
-                   * @enum {string}
-                   */
-                  status?: "active" | "impaired" | "failure" | "unknown";
-                  /** @description Additional details about the subsystem status. */
-                  details?: string;
-                })[];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/search": {
+              status?: string
+              subsystems?: {
+                /** @description Name of the subsystem. */
+                name?: string
+                /**
+                 * @description Status of the subsystem.
+                 * @enum {string}
+                 */
+                status?: 'active' | 'impaired' | 'failure' | 'unknown'
+                /** @description Additional details about the subsystem status. */
+                details?: string
+              }[]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/search': {
     /**
      * Search and filter leases
      * @description Search leases with comprehensive filtering options including text search, object type, status, date ranges, and property hierarchy filters.
@@ -400,64 +397,70 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking)) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
+          buildingManager?: string[]
           /** @description Page number */
-          page?: number;
+          page?: number
           /** @description Items per page */
-          limit?: number;
+          limit?: number
           /** @description Include Upphört (ended) contracts. Excluded by default for performance. */
-          includeEnded?: boolean;
+          includeEnded?: boolean
           /** @description Sort field */
-          sortBy?: "leaseStartDate" | "lastDebitDate" | "leaseId" | "address" | "objectType" | "rentalObjectCode";
+          sortBy?:
+            | 'leaseStartDate'
+            | 'lastDebitDate'
+            | 'leaseId'
+            | 'address'
+            | 'objectType'
+            | 'rentalObjectCode'
           /** @description Sort direction */
-          sortOrder?: "asc" | "desc";
-        };
-      };
+          sortOrder?: 'asc' | 'desc'
+        }
+      }
       responses: {
         /** @description Successfully retrieved lease search results with pagination */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["LeaseSearchResult"][];
-              _meta?: components["schemas"]["PaginationMeta"];
-              _links?: components["schemas"]["PaginationLinks"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['LeaseSearchResult'][]
+              _meta?: components['schemas']['PaginationMeta']
+              _links?: components['schemas']['PaginationLinks'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/building-managers": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/building-managers': {
     /**
      * Get all building managers
      * @description Returns a list of all building managers (Kvartersvärd) with their code, name and district.
@@ -467,23 +470,23 @@ export interface paths {
         /** @description List of building managers */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  name?: string;
-                  district?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                name?: string
+                district?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/parking-space-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/parking-space-types': {
     /**
      * Get all parking space types
      * @description Returns a list of all parking space types (P-platstyper).
@@ -493,22 +496,22 @@ export interface paths {
         /** @description List of parking space types */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  code?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                code?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/export": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/export': {
     /**
      * Export leases to Excel
      * @description Export lease search results to Excel file. Uses same filters as /leases/search but without pagination.
@@ -517,44 +520,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/from-lease-search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/from-lease-search': {
     /**
      * Get contacts matching lease search filters
      * @description Retrieves contact information for tenants matching the given lease search filters.
@@ -563,48 +566,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string;
+          q?: string
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[];
+          objectType?: string[]
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ("0" | "1" | "2" | "3")[];
+          status?: ('0' | '1' | '2' | '3')[]
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string;
+          startDateFrom?: string
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string;
+          startDateTo?: string
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string;
+          endDateFrom?: string
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string;
+          endDateTo?: string
           /** @description Property/estate names */
-          property?: string[];
+          property?: string[]
           /** @description Building codes */
-          buildingCodes?: string[];
+          buildingCodes?: string[]
           /** @description Area codes (Område) */
-          areaCodes?: string[];
+          areaCodes?: string[]
           /** @description District names */
-          districtNames?: string[];
+          districtNames?: string[]
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[];
-        };
-      };
+          buildingManager?: string[]
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ContactInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ContactInfo'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/leases/by-rental-property-id/{rentalPropertyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/leases/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get leases with related entities for a specific rental property id
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified rental property id.
@@ -613,38 +616,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
+          includeTerminatedLeases?: boolean
           /** @description Whether to include contact information in the response */
-          includeContacts?: boolean;
+          includeContacts?: boolean
           /** @description Whether to include rent information in the response */
-          includeRentInfo?: boolean;
-        };
+          includeRentInfo?: boolean
+        }
         path: {
           /** @description Rental roperty id of the building/residence to fetch leases for. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-pnr/{pnr}': {
     /**
      * Get leases with related entities for a specific Personal Number (PNR)
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
@@ -653,28 +656,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Personal Number (PNR) of the individual to fetch leases for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/leases/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/leases/by-contact-code/{contactCode}': {
     /**
      * Get leases with related entities for a specific contact code
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified contact code.
@@ -683,28 +686,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean;
+          includeUpcomingLeases?: boolean
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean;
-        };
+          includeTerminatedLeases?: boolean
+        }
         path: {
           /** @description Contact code of the individual to fetch leases for. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/consumer-reports/by-pnr/{pnr}": {
+            'application/json': {
+              content?: components['schemas']['Lease'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/consumer-reports/by-pnr/{pnr}': {
     /**
      * Get consumer report for a specific Personal Number (PNR)
      * @description Retrieves credit information and consumer report for the specified Personal Number (PNR).
@@ -713,20 +716,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch credit information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with credit information and consumer report */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/by-pnr/{pnr}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/by-pnr/{pnr}': {
     /**
      * Get contact information for a specific Personal Number (PNR)
      * @description Retrieves contact information associated with the specified Personal Number (PNR).
@@ -735,20 +738,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch contact information for. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/offers": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/offers': {
     /**
      * Get offers for a contact
      * @description Retrieves all offers associated with a specific contact based on the provided contact code.
@@ -757,28 +760,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique code identifying the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with a list of offers for the contact. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description The contact was not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve offers. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/comments": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/comments': {
     /**
      * Get comments for a contact
      * @description Retrieves all comments/notes for a contact from Xpand
@@ -787,57 +790,57 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by comment type. If omitted, returns all comment types. */
-          commentType?: "Standard" | "Sökande";
-        };
+          commentType?: 'Standard' | 'Sökande'
+        }
         path: {
           /**
            * @description The unique code identifying the contact.
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved comments */
         200: {
           content: {
-            "application/json": {
-              content?: ({
-                  contactKey?: string;
-                  contactCode?: string;
-                  commentKey?: string;
-                  id?: number;
-                  commentType?: string | null;
-                  /** @description Array of individual notes parsed from comment text */
-                  notes?: ({
-                      /**
-                       * Format: date
-                       * @description Date in YYYY-MM-DD format
-                       */
-                      date?: string | null;
-                      /** @description Time in HH:MM format */
-                      time?: string | null;
-                      /** @description Author initials (6 letters) or "Notering utan signatur" */
-                      author?: string;
-                      /** @description Note content (plain text) */
-                      text?: string;
-                    })[];
-                  priority?: number | null;
-                  kind?: number | null;
-                })[];
-            };
-          };
-        };
+            'application/json': {
+              content?: {
+                contactKey?: string
+                contactCode?: string
+                commentKey?: string
+                id?: number
+                commentType?: string | null
+                /** @description Array of individual notes parsed from comment text */
+                notes?: {
+                  /**
+                   * Format: date
+                   * @description Date in YYYY-MM-DD format
+                   */
+                  date?: string | null
+                  /** @description Time in HH:MM format */
+                  time?: string | null
+                  /** @description Author initials (6 letters) or "Notering utan signatur" */
+                  author?: string
+                  /** @description Note content (plain text) */
+                  text?: string
+                }[]
+                priority?: number | null
+                kind?: number | null
+              }[]
+            }
+          }
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Create or append to contact comment
      * @description Creates a new comment if none exists for the contact, or appends to existing comment in Xpand
@@ -849,56 +852,56 @@ export interface paths {
            * @description The unique code identifying the contact
            * @example P086890
            */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /**
              * @description Plain text content of the note
              * @example Customer contacted regarding lease renewal
              */
-            content: string;
+            content: string
             /**
              * @description Author name or code (1-50 characters)
              * @example DAVLIN
              */
-            author: string;
+            author: string
             /**
              * @description Type of comment. Defaults to 'Standard' if not specified.
              * @default Standard
              * @enum {string}
              */
-            commentType?: "Standard" | "Sökande";
-          };
-        };
-      };
+            commentType?: 'Standard' | 'Sökande'
+          }
+        }
+      }
       responses: {
         /** @description Comment updated successfully (appended to existing comment) */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Comment created successfully (new comment) */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body (validation failed) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Contact not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/applicants/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/applicants/{contactCode}': {
     /**
      * Get a specific offer for an applicant
      * @description Retrieve details of a specific offer associated with an applicant using contact code and offer ID.
@@ -907,30 +910,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the offer. */
-          offerId: string;
+          offerId: string
           /** @description The unique code identifying the applicant. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Details of the specified offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Offer not found for the specified contact code and offer ID. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}': {
     /**
      * Get offers for a specific listing
      * @description Get all offers for a listing.
@@ -939,24 +942,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description A list of offers. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/by-listing-id/{listingId}/active": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/by-listing-id/{listingId}/active': {
     /**
      * Gets active offer for a specific listing
      * @description Get an offer for a listing.
@@ -965,24 +968,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description The active offer. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/search': {
     /**
      * Search contacts by name, PNR, contact code, or email
      * @description Search contacts by contact code, personal registration number, name, or email. Supports searching by full name or partial name (e.g., "john smith" or "smith"). Multiple search terms are matched with AND logic. Email search is triggered when query contains "@".
@@ -991,30 +994,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description Search query - can be contact code, personal registration number, name, or email (if query contains "@"). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successful response with search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Contact'][]
+            }
+          }
+        }
         /** @description Bad request. The query parameter 'q' must be a string. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve contacts. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/for-identity-check": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/for-identity-check': {
     /**
      * Get contacts for deceased/protected identity check
      * @description Returns paginated list of person contacts eligible for deceased/protected identity verification. Note - Results are validated using the personnummer package, so the actual count may be fewer than the requested limit if invalid personnummer are filtered out.
@@ -1023,38 +1026,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved contacts for identity check. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["IdentityCheckContact"][];
+            'application/json': {
+              content?: components['schemas']['IdentityCheckContact'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}': {
     /**
      * Get contact by contact code
      * @description Retrieves a contact based on the provided contact code.
@@ -1063,22 +1066,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Contact"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/tenants/by-contact-code/{contactCode}": {
+            'application/json': {
+              content?: components['schemas']['Contact']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/tenants/by-contact-code/{contactCode}': {
     /**
      * Get tenant by contact code
      * @description Retrieves a tenant based on the provided contact code.
@@ -1087,31 +1090,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant information. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The tenant data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve Tenant information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/by-phone-number/{pnr}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/by-phone-number/{pnr}': {
     /**
      * Get contact by phone number
      * @description Retrieves a contact based on the provided phone number.
@@ -1120,20 +1123,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The phone number used to identify the contact. */
-          pnr: string;
-        };
-      };
+          pnr: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/leases/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/leases/{id}': {
     /**
      * Get lease by ID
      * @description Retrieves lease details along with related entities based on the provided ID.
@@ -1142,22 +1145,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the lease to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested lease and related entities */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Lease"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/accept": {
+            'application/json': {
+              content?: components['schemas']['Lease']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/accept': {
     /**
      * Accept an offer
      * @description Accepts an offer for the contact of the contactCode provided
@@ -1166,22 +1169,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to accept */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer accepted successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to accept the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/deny": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/deny': {
     /**
      * Deny an offer
      * @description Denies an offer
@@ -1190,22 +1193,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to deny */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer denied successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to deny the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/offers/{offerId}/expire": {
+          content: never
+        }
+      }
+    }
+  }
+  '/offers/{offerId}/expire': {
     /**
      * Expire an offer
      * @description Expires an offer
@@ -1214,22 +1217,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to expire */
-          offerId: string;
-        };
-      };
+          offerId: string
+        }
+      }
       responses: {
         /** @description Offer expired successful. */
         202: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to expire the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/applicants": {
+          content: never
+        }
+      }
+    }
+  }
+  '/applicants': {
     /**
      * Get applicants by contact code
      * @description Retrieves applicants based on the contact code.
@@ -1238,20 +1241,20 @@ export interface paths {
       parameters: {
         query: {
           /** @description The contact code used to fetch applicants. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}': {
     /**
      * Validate property rental rules for applicant
      * @description Validate property rental rules for an applicant based on contact code and listing ID.
@@ -1260,61 +1263,61 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand rental object code of the property. */
-          rentalObjectCode: number;
-        };
-      };
+          rentalObjectCode: number
+        }
+      }
       responses: {
         /** @description No property rental rules apply to this property. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
+              applicationType?: string
               /** @example No property rental rules applies to this property. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Rental object code is not a parking space. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental object code entity is not a parking space. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the property based on property rental rules. */
         403: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description Listing, property info, or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating property rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating property rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}': {
     /**
      * Validate residential area rental rules for applicant
      * @description Validate residential area rental rules for an applicant based on contact code and district code.
@@ -1323,52 +1326,52 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The xpand district code of the residential area to validate against. */
-          districtCode: string;
-        };
-      };
+          districtCode: string
+        }
+      }
       responses: {
         /** @description Either no residential area rental rules apply or applicant is eligible to apply for parking space. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string;
-              reason?: string;
-            };
-          };
-        };
+              applicationType?: string
+              reason?: string
+            }
+          }
+        }
         /** @description Applicant is not eligible for the listing based on residential area rental rules. */
         403: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant does not have any current or upcoming housing contracts in the residential area. */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Listing or applicant not found. */
         404: {
           content: {
-            "application/json": {
-              reason?: string;
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+            }
+          }
+        }
         /** @description An error occurred while validating residential area rental rules. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example An error occurred while validating residential area rental rules. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants-with-listings/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants-with-listings/by-contact-code/{contactCode}': {
     /**
      * Get applicants with listings by contact code
      * @description Retrieves applicants along with their listings based on the contact code.
@@ -1377,20 +1380,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch applicants and their associated listings. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of applicants with their listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{contactCode}/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{contactCode}/{listingId}': {
     /**
      * Get applicant by contact code and listing ID
      * @description Retrieves an applicant by their contact code and listing ID.
@@ -1399,22 +1402,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string;
+          contactCode: string
           /** @description The ID of the listing associated with the applicant. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the applicant. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-manager": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-manager': {
     /**
      * Withdraw applicant by manager
      * @description Withdraws an applicant by the manager using the applicant ID.
@@ -1423,32 +1426,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
-        };
-      };
+          applicantId: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by manager. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by manager. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/applicants/{applicantId}/by-user/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/applicants/{applicantId}/by-user/{contactCode}': {
     /**
      * Withdraw applicant by user
      * @description Withdraws an applicant by the user identified by contact code and applicant ID.
@@ -1457,34 +1460,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string;
+          applicantId: string
           /** @description The contact code of the user initiating the withdrawal. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successful withdrawal of the applicant by user. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Applicant successfully withdrawn by user. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message describing the issue. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile': {
     /**
      * Gets an application profile by contact code
      * @description Retrieve application profile information by contact code.
@@ -1493,31 +1496,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/admin": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/admin': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1526,41 +1529,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/application-profile/client": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/application-profile/client': {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1569,41 +1572,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Successfully created application profile. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The application profile data. */
-              data?: Record<string, never>;
-            };
-          };
-        };
+              data?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/contacts/{contactCode}/{rentalObjectCode}/verify-application": {
+          content: never
+        }
+      }
+    }
+  }
+  '/contacts/{contactCode}/{rentalObjectCode}/verify-application': {
     /**
      * Validate max num residents.
      * @description Checks if application is allowed based on current number of residents.
@@ -1612,32 +1615,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string;
+          contactCode: string
           /** @description The rental object code associated with the rental property. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Application allowed. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Application not allowed. */
         403: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings': {
     /**
      * Get listings
      * @description Retrieves a list of listings.
@@ -1646,28 +1649,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The listing category, either PARKING_SPACE, APARTMENT or STORAGE. */
-          listingCategory?: string;
+          listingCategory?: string
           /** @description true for published listings, false for unpublished listings. */
-          published?: boolean;
+          published?: boolean
           /** @description The rental rule for the listings, either SCORED or NON_SCORED. */
-          rentalRule?: string;
+          rentalRule?: string
           /** @description A contact code to filter out listings that are not valid to rent for the contact. */
-          validToRentForContactCode?: string;
+          validToRentForContactCode?: string
           /** @description A Rental Object Code to filter the listings. */
-          rentalObjectCode?: string;
-        };
-      };
+          rentalObjectCode?: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested list of listings. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}': {
     /**
      * Delete a Listing by ID
      * @description Deletes a listing by it's ID.
@@ -1676,31 +1679,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       responses: {
         /** @description Successfully deleted listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Conflict. */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/status": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/status': {
     /**
      * Update a listings status by ID
      * @description Updates a listing status by it's ID.
@@ -1709,36 +1712,36 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number;
-        };
-      };
+          listingId: number
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Successfully updated listing. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/offers": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/offers': {
     /**
      * Create an offer for a listing
      * @description Creates an offer for the specified listing.
@@ -1747,22 +1750,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to create an offer for. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Offer creation successful. */
         201: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create the offer. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/{listingId}/applicants/details": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/{listingId}/applicants/details': {
     /**
      * Get listing by ID with detailed applicants
      * @description Retrieves a listing by ID along with detailed information about its applicants.
@@ -1771,20 +1774,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to fetch along with detailed applicant information. */
-          listingId: string;
-        };
-      };
+          listingId: string
+        }
+      }
       responses: {
         /** @description Successful retrieval of the listing with detailed applicant information. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings/{id}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings/{id}': {
     /**
      * Get listing by ID
      * @description Retrieves details of a listing based on the provided ID.
@@ -1793,20 +1796,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested listing details. */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/listings-with-applicants": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/listings-with-applicants': {
     /**
      * Get listings with applicants
      * @description Retrieves a list of listings along with their associated applicants.
@@ -1815,24 +1818,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filters listings by one of the above types. Must be one of the specified values. */
-          type?: "published" | "ready-for-offer" | "offered" | "historical";
-        };
-      };
+          type?: 'published' | 'ready-for-offer' | 'offered' | 'historical'
+        }
+      }
       responses: {
         /** @description Successful response with listings and their applicants. */
         200: {
           content: {
-            "application/json": Record<string, never>[];
-          };
-        };
+            'application/json': Record<string, never>[]
+          }
+        }
         /** @description Internal server error. Failed to retrieve listings with applicants. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listings/batch": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listings/batch': {
     /**
      * Create multiple listings
      * @description Create multiple listings in a single request.
@@ -1840,48 +1843,54 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            listings: ({
-                rentalObjectCode: string;
-                /** Format: date-time */
-                publishedFrom: string;
-                /** Format: date-time */
-                publishedTo: string;
-                /** @enum {string} */
-                status: "ACTIVE" | "INACTIVE" | "CLOSED" | "ASSIGNED" | "EXPIRED" | "NO_APPLICANTS";
-                /** @enum {string} */
-                rentalRule: "SCORED" | "NON_SCORED";
-                /** @enum {string} */
-                listingCategory: "PARKING_SPACE" | "APARTMENT" | "STORAGE";
-              })[];
-          };
-        };
-      };
+          'application/json': {
+            listings: {
+              rentalObjectCode: string
+              /** Format: date-time */
+              publishedFrom: string
+              /** Format: date-time */
+              publishedTo: string
+              /** @enum {string} */
+              status:
+                | 'ACTIVE'
+                | 'INACTIVE'
+                | 'CLOSED'
+                | 'ASSIGNED'
+                | 'EXPIRED'
+                | 'NO_APPLICANTS'
+              /** @enum {string} */
+              rentalRule: 'SCORED' | 'NON_SCORED'
+              /** @enum {string} */
+              listingCategory: 'PARKING_SPACE' | 'APARTMENT' | 'STORAGE'
+            }[]
+          }
+        }
+      }
       responses: {
         /** @description All listings created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Partial success. Some listings created, some failed. */
         207: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request. Invalid input data. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. Failed to create listings. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/vacant-parkingspaces": {
+          content: never
+        }
+      }
+    }
+  }
+  '/vacant-parkingspaces': {
     /**
      * Get all vacant parking spaces
      * @description Retrieves a list of all vacant parking spaces.
@@ -1891,39 +1900,39 @@ export interface paths {
         /** @description A list of vacant parking spaces. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve vacant parking spaces. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-objects/by-code/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-objects/by-code/{rentalObjectCode}': {
     /**
      * Get a rental object by code
      * @description Fetches a rental object by Rental Object Code.
@@ -1932,46 +1941,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the rental object to fetch. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rental object. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalObjectCode?: string;
-                  address?: string;
-                  monthlyRent?: number;
-                  propertyCaption?: string;
-                  propertyCode?: string;
-                  residentialAreaCode?: string;
-                  residentialAreaCaption?: string;
-                  objectTypeCaption?: string;
-                  objectTypeCode?: string;
-                  /** Format: date-time */
-                  vacantFrom?: string;
-                  districtCaption?: string;
-                  districtCode?: string;
-                  braArea?: number;
-                }[];
-            };
-          };
-        };
+                rentalObjectCode?: string
+                address?: string
+                monthlyRent?: number
+                propertyCaption?: string
+                propertyCode?: string
+                residentialAreaCode?: string
+                residentialAreaCaption?: string
+                objectTypeCaption?: string
+                objectTypeCode?: string
+                /** Format: date-time */
+                vacantFrom?: string
+                districtCaption?: string
+                districtCode?: string
+                braArea?: number
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. Failed to fetch rental object. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description The error message. */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/listing-text-content/{rentalObjectCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/listing-text-content/{rentalObjectCode}': {
     /**
      * Get listing text content by rental object code
      * @description Fetch the listing text content for a specific rental object.
@@ -1980,28 +1989,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to fetch text content for. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update listing text content
      * @description Update existing listing text content.
@@ -2010,37 +2019,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to update. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete listing text content
      * @description Delete listing text content.
@@ -2049,26 +2058,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to delete. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Listing text content deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/listing-text-content": {
+          content: never
+        }
+      }
+    }
+  }
+  '/listing-text-content': {
     /**
      * Create listing text content
      * @description Create new listing text content for a rental object.
@@ -2076,34 +2085,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateListingTextContentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateListingTextContentRequest']
+        }
+      }
       responses: {
         /** @description Listing text content created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListingTextContent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListingTextContent']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Listing text content already exists for rental object code */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/floorplan": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/floorplan': {
     /**
      * Get floor plan for a rental property
      * @description Returns the floor plan image for the specified rental property.
@@ -2112,100 +2121,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved floor plan image */
         200: {
           content: {
-            "image/jpeg": string;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options": {
+            'image/jpeg': string
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options': {
     /** Get room types with material options by rental property ID */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch room types for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with room types and their material options */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-options/{materialOptionId}": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-options/{materialOptionId}': {
     /** Get material option by ID for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material options from */
-          id: string;
+          id: string
           /** @description ID of the material option to fetch */
-          materialOptionId: string;
-        };
-      };
+          materialOptionId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material option */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{apartmentId}/contracts/{contractId}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{apartmentId}/contracts/{contractId}/material-choices': {
     /** Get material choices for a specific apartment and contract */
     get: {
       parameters: {
         path: {
           /** @description ID of the apartment to fetch material choices for */
-          apartmentId: string;
+          apartmentId: string
           /** @description ID of the contract to fetch material choices for */
-          contractId: string;
-        };
-      };
+          contractId: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/rooms-with-material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/rooms-with-material-choices': {
     /** Get rooms with material choices for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch rooms with material choices for */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested rooms and their material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}/material-choices": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}/material-choices': {
     /**
      * Get material choices for a specific rental property
      * @description Retrieve material choices associated with a rental property identified by {id}.
@@ -2214,18 +2223,18 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
     /**
      * Save material choices for a rental property
      * @description Saves material choices for a specific rental property.
@@ -2234,25 +2243,25 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to save material choices for. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": Record<string, never>;
-        };
-      };
+          'application/json': Record<string, never>
+        }
+      }
       responses: {
         /** @description Material choices successfully saved */
         200: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
-      };
-    };
-  };
-  "/material-choice-statuses": {
+            'application/json': Record<string, never>
+          }
+        }
+      }
+    }
+  }
+  '/material-choice-statuses': {
     /**
      * Get material choice statuses for rental properties
      * @description Retrieves statuses of material choices associated with rental properties. Optionally includes rental property details if specified in query parameter.
@@ -2261,20 +2270,20 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional parameter to include rental property details in response. */
-          includeRentalProperties?: "true";
-        };
-      };
+          includeRentalProperties?: 'true'
+        }
+      }
       responses: {
         /** @description Successful response with material choice statuses */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/{id}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/{id}': {
     /**
      * Get rental property by ID
      * @description Retrieves details of a rental property based on the provided ID.
@@ -2283,22 +2292,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successful response with rental property details */
         200: {
           content: {
-            "application/json": {
-              data?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/leases": {
+            'application/json': {
+              data?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/leases': {
     /**
      * Create lease for an external parking space
      * @description Creates a new lease for the specified external parking space.
@@ -2307,38 +2316,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the lease is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Lease successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space id is missing. It needs to be passed in the url. */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/parking-spaces/{parkingSpaceId}/note-of-interests": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/parking-spaces/{parkingSpaceId}/note-of-interests': {
     /**
      * Create a note of interest for an internal parking space
      * @description Creates a new note of interest for the specified internal parking space.
@@ -2347,38 +2356,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the note of interest is being created. */
-          parkingSpaceId: string;
-        };
-      };
+          parkingSpaceId: string
+        }
+      }
       responses: {
         /** @description Note of interest successfully created */
         201: {
           content: {
-            "application/json": Record<string, never>;
-          };
-        };
+            'application/json': Record<string, never>
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Contact code is missing. It needs to be passed in the body (contactCode) */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example A technical error has occured. */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rental-properties/by-rental-object-code/{rentalObjectCode}": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rental-properties/by-rental-object-code/{rentalObjectCode}': {
     /**
      * Get rental property information from Xpand
      * @description Retrieves detailed information about a rental property from Xpand based on the provided rental object code.
@@ -2387,32 +2396,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental object code used to identify the specific rental property in Xpand. */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental property information */
         200: {
           content: {
-            "application/json": components["schemas"]["RentalPropertyResponse"];
-          };
-        };
+            'application/json': components['schemas']['RentalPropertyResponse']
+          }
+        }
         /** @description Rental property not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}': {
     /**
      * Get maintenance units for a rental property
      * @description Retrieves maintenance units for a specific rental property, optionally filtered by type.
@@ -2421,22 +2430,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch maintenance units for. */
-          rentalPropertyId: string;
+          rentalPropertyId: string
           /** @description Optional type filter for maintenance units. */
-          type: string;
-        };
-      };
+          type: string
+        }
+      }
       responses: {
         /** @description Successful response with maintenance units */
         200: {
           content: {
-            "application/json": unknown[];
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-contact-code/{contactCode}": {
+            'application/json': unknown[]
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-contact-code/{contactCode}': {
     /**
      * Get maintenance units by contact code.
      * @description Returns all maintenance units belonging to a contact code.
@@ -2445,33 +2454,33 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code for which to retrieve maintenance units. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  ok?: boolean;
-                  data?: components["schemas"]["MaintenanceUnit"][];
-                }[];
-            };
-          };
-        };
+                ok?: boolean
+                data?: components['schemas']['MaintenanceUnit'][]
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/work-orders/data/{identifier}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/data/{identifier}': {
     /**
      * Get work order data by different identifiers
      * @description Retrieves work order data along with associated leases based on the provided identifier type.
@@ -2480,50 +2489,55 @@ export interface paths {
       parameters: {
         query: {
           /** @description The type of the identifier used to fetch work order data. */
-          handler: "rentalObjectId" | "leaseId" | "pnr" | "phoneNumber" | "contactCode";
-        };
+          handler:
+            | 'rentalObjectId'
+            | 'leaseId'
+            | 'pnr'
+            | 'phoneNumber'
+            | 'contactCode'
+        }
         path: {
           /** @description The identifier value for fetching work order data. */
-          identifier: string;
-        };
-      };
+          identifier: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order data. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  rentalPropertyId?: string;
-                  leases?: {
-                      leaseId?: string;
-                      rentalPropertyId?: string;
-                    }[];
-                }[];
-            };
-          };
-        };
+                rentalPropertyId?: string
+                leases?: {
+                  leaseId?: string
+                  rentalPropertyId?: string
+                }[]
+              }[]
+            }
+          }
+        }
         /** @description Invalid handler */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid handler */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -2532,34 +2546,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id
      * @description Retrieves work orders based on the provided rental property id.
@@ -2568,34 +2582,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -2604,34 +2618,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -2640,34 +2654,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2676,34 +2690,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-contact-code/{contactCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-contact-code/{contactCode}': {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -2712,42 +2726,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-rental-property-id/{rentalPropertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-rental-property-id/{rentalPropertyId}': {
     /**
      * Get work orders by rental property id from xpand
      * @description Retrieves work orders based on the provided rental property id.
@@ -2756,34 +2770,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string;
-        };
-      };
+          rentalPropertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-property-id/{propertyId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-property-id/{propertyId}': {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders based on the provided property id.
@@ -2792,34 +2806,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-building-id/{buildingId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-building-id/{buildingId}': {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders based on the provided building id.
@@ -2828,34 +2842,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2864,42 +2878,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                totalCount?: number;
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
-            };
-          };
-        };
+                totalCount?: number
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/xpand/{code}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/xpand/{code}': {
     /**
      * Get work order details by rental property id from xpand
      * @description Retrieves work order details.
@@ -2908,40 +2922,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["XpandWorkOrder"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['XpandWorkOrder']
+            }
+          }
+        }
         /** @description Work order not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders': {
     /**
      * Create a new work order
      * @description Creates a new work order.
@@ -2949,64 +2963,121 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The contact code of the tenant. */
-            ContactCode?: string;
+            ContactCode?: string
             /** @description The rental property ID. */
-            RentalObjectCode?: string;
+            RentalObjectCode?: string
             Rows?: {
-                /** @description The location code of the work order. */
-                LocationCode?: string;
-              }[];
+              /** @description The location code of the work order. */
+              LocationCode?: string
+            }[]
             /** @description Access options for the work order. */
-            AccessOptions?: Record<string, never>;
+            AccessOptions?: Record<string, never>
             /** @description Pet information for the work order. */
-            Pet?: Record<string, never>;
-            Images?: string[];
-          };
-        };
-      };
+            Pet?: Record<string, never>
+            Images?: string[]
+          }
+        }
+      }
       responses: {
         /** @description Successfully created the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order created */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example ContactCode is missing */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Not found. Rental property or active lease not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental property not found */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to create the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to create a new work order */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/update": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/maintenance-teams': {
+    /**
+     * List maintenance teams (resursgrupper)
+     * @description Returns the selectable Odoo maintenance teams (resursgrupper) for the inspection work-order picker.
+     */
+    get: {
+      responses: {
+        /** @description Maintenance teams retrieved successfully */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['MaintenanceTeam'][]
+            }
+          }
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/from-inspection': {
+    /**
+     * Create work orders from an inspection (one per resursgrupp)
+     * @description Resolves the apartment from rentalObjectCode, then creates one work order per resursgrupp group. Each group is an independent Odoo commit, so the response reports per-group success/failure.
+     */
+    post: {
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['CreateInspectionWorkOrdersRequest']
+        }
+      }
+      responses: {
+        /** @description Work orders processed (see per-group results) */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['CreateInspectionWorkOrdersResponse']
+            }
+          }
+        }
+        /** @description Bad request (invalid body or not an apartment). */
+        400: {
+          content: never
+        }
+        /** @description Rental property not found. */
+        404: {
+          content: never
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/update': {
     /**
      * Update a work order with a message
      * @description Adds a message to the specified work order.
@@ -3015,49 +3086,49 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be updated. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The message to be added to the work order. */
-            message?: string;
-          };
-        };
-      };
+            message?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully added the message to the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message added to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message is missing from the request body */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to add the message to the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to add message to work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/{workOrderId}/close": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/{workOrderId}/close': {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -3066,32 +3137,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       responses: {
         /** @description Successfully closed the work order. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order with ID {workOrderId} updated successfully */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to close the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-sms": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-sms': {
     /**
      * Send SMS for a work order
      * @description Sends an SMS message to the specified phone number for a work order.
@@ -3099,46 +3170,46 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The phone number to send the SMS to. */
-            phoneNumber?: string;
+            phoneNumber?: string
             /** @description The message to be sent via SMS. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the SMS. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Sms sent to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: phoneNumber and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the SMS. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Unexpected error sending sms to {phoneNumber} */
-              message?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/work-orders/send-email": {
+              message?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/work-orders/send-email': {
     /**
      * Send email for a work order
      * @description Sends an email to the specified recipient for a work order.
@@ -3146,48 +3217,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description The email address of the recipient. */
-            to?: string;
+            to?: string
             /** @description The subject of the email. */
-            subject?: string;
+            subject?: string
             /** @description The message to be sent in the email. */
-            text?: string;
-          };
-        };
-      };
+            text?: string
+          }
+        }
+      }
       responses: {
         /** @description Successfully sent the email. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Email sent to {to} */
-              message?: string;
-            };
-          };
-        };
+              message?: string
+            }
+          }
+        }
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Bad request: to, subject, and message are required */
-              reason?: string;
-            };
-          };
-        };
+              reason?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to send the email. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to send email to {to}, status: {statusCode} */
-              text?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/by-room/{roomId}": {
+              text?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/by-room/{roomId}': {
     /**
      * Get components by room ID
      * @description Returns all components currently installed in a specific space via their installation records.
@@ -3197,40 +3268,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the room */
-          roomId: string;
-        };
-      };
+          roomId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the components list */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component'][]
+            }
+          }
+        }
         /** @description Room not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Room not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories': {
     /**
      * Get all component categories
      * @description Top-level groupings for building components (e.g., Ventilation, VVS, Vitvaror, Tak). Use categoryId to filter component types.
@@ -3238,21 +3309,21 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?: number;
-          limit?: number;
-        };
-      };
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component categories */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component category
      * @description Creates a new top-level category for organizing component types.
@@ -3260,22 +3331,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-categories/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-categories/{id}': {
     /**
      * Get component category by ID
      * @description Returns a single category with its name and metadata.
@@ -3283,24 +3354,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
         /** @description Component category not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component category
      * @description Updates category name or metadata.
@@ -3308,25 +3379,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentCategoryRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentCategoryRequest']
+        }
+      }
       responses: {
         /** @description Component category updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentCategory"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentCategory']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component category
      * @description Removes a category. Will fail if category has associated types.
@@ -3334,18 +3405,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component category deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-types": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-types': {
     /**
      * Get all component types
      * @description Specific kinds of components within a category (e.g., Diskmaskin, Värmepump, Takbeläggning). Filter by categoryId to get types for a specific category.
@@ -3354,22 +3425,22 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter types by category ID */
-          categoryId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          categoryId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component types */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"][];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType'][]
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component type
      * @description Creates a new type within a category. Requires categoryId.
@@ -3377,22 +3448,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-types/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-types/{id}': {
     /**
      * Get component type by ID
      * @description Returns a single type with its category relationship.
@@ -3400,24 +3471,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
         /** @description Component type not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component type
      * @description Updates type name or category assignment.
@@ -3425,25 +3496,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentTypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentTypeRequest']
+        }
+      }
       responses: {
         /** @description Component type updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentType"];
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              content?: components['schemas']['ComponentType']
+            }
+          }
+        }
+      }
+    }
     /**
      * Delete a component type
      * @description Removes a type. Will fail if type has associated subtypes.
@@ -3451,18 +3522,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component type deleted */
         204: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-subtypes": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-subtypes': {
     /**
      * Get all component subtypes
      * @description Variants of a type with lifecycle data including depreciation price, technical/economic lifespan, and replacement interval. Filter by typeId or subtypeName.
@@ -3471,30 +3542,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter subtypes by type ID */
-          typeId?: string;
+          typeId?: string
           /** @description Search subtypes by name (case-insensitive) */
-          subtypeName?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          subtypeName?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component subtypes */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"][];
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component subtype
      * @description Creates a subtype with lifecycle parameters. Requires typeId.
@@ -3502,22 +3573,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-subtypes/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-subtypes/{id}': {
     /**
      * Get component subtype by ID
      * @description Returns subtype with full lifecycle and cost planning data.
@@ -3525,24 +3596,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component subtype
      * @description Updates subtype specifications or lifecycle data.
@@ -3550,29 +3621,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentSubtypeRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentSubtypeRequest']
+        }
+      }
       responses: {
         /** @description Component subtype updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentSubtype"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentSubtype']
+            }
+          }
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component subtype
      * @description Removes a subtype. Will fail if subtype has associated models.
@@ -3580,22 +3651,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component subtype deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component subtype not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models': {
     /**
      * Get all component models
      * @description Specific manufacturer products with pricing, warranty, specifications, and dimensions. Filter by subtypeId, manufacturer, or modelName.
@@ -3604,32 +3675,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter models by component type ID */
-          componentTypeId?: string;
+          componentTypeId?: string
           /** @description Filter models by subtype ID */
-          subtypeId?: string;
+          subtypeId?: string
           /** @description Filter models by manufacturer name */
-          manufacturer?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          manufacturer?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component models */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"][];
+            'application/json': {
+              content?: components['schemas']['ComponentModel'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component model
      * @description Creates a manufacturer product entry. Requires subtypeId.
@@ -3637,49 +3708,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/documents/component-models/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/documents/component-models/{id}': {
     /** Get all documents for a component model */
     get: {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}': {
     /**
      * Get component model by ID
      * @description Returns full model details including specs and current pricing.
@@ -3687,24 +3758,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component model
      * @description Updates model pricing, specs, or warranty info.
@@ -3712,29 +3783,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentModelRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentModelRequest']
+        }
+      }
       responses: {
         /** @description Component model updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel']
+            }
+          }
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component model
      * @description Removes a model. Will fail if model has associated components.
@@ -3742,22 +3813,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component model deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component model not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/surface": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/surface': {
     /**
      * Get surface component models (Ytskikt hierarchy)
      * @description Returns all ComponentModels under the Ytskikt category with full Subtype → Type → Category hierarchy populated. Subtypes whose name starts with "Ospecificera" sort first within each Type.
@@ -3767,19 +3838,19 @@ export interface paths {
         /** @description List of surface component models */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentModel"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentModel'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components': {
     /**
      * Get all components
      * @description Physical units with serial numbers and status. Filter by modelId, status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED), or serialNumber.
@@ -3787,31 +3858,31 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          modelId?: string;
-          status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+          modelId?: string
+          status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
           /** @description Search by serial number (case-insensitive partial match) */
-          serialNumber?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          serialNumber?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of components */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"][];
+            'application/json': {
+              content?: components['schemas']['Component'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component
      * @description Registers a new physical unit. Requires modelId and serialNumber.
@@ -3819,22 +3890,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/components/{id}": {
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/components/{id}': {
     /**
      * Get component by ID
      * @description Returns full component details including purchase info, warranty dates, and current status.
@@ -3842,24 +3913,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component
      * @description Updates component status, warranty dates, or other attributes.
@@ -3868,29 +3939,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentRequest']
+        }
+      }
       responses: {
         /** @description Component updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Component"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Component']
+            }
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component
      * @description Removes a component record. Automatically deletes associated installation records.
@@ -3898,22 +3969,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/{id}/inspection-state": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/{id}/inspection-state': {
     /**
      * Update component inspection state
      * @description Updates component condition and last inspection date
@@ -3922,40 +3993,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component instance ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @enum {string} */
-            condition: "GOOD" | "FAIR" | "DAMAGED";
+            condition: 'GOOD' | 'FAIR' | 'DAMAGED'
             /** Format: date-time */
-            lastInspectionDate: string;
-          };
-        };
-      };
+            lastInspectionDate: string
+          }
+        }
+      }
       responses: {
         /** @description Component inspection state updated */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-installations": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-installations': {
     /**
      * Get all component installations
      * @description Placement records linking components to property locations (spaceId). A component can be moved between locations over time. Filter by componentId, spaceId, or buildingPartId.
@@ -3963,30 +4034,30 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          componentId?: string;
-          spaceId?: string;
-          buildingPartId?: string;
-          page?: number;
-          limit?: number;
-        };
-      };
+          componentId?: string
+          spaceId?: string
+          buildingPartId?: string
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description List of component installations */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"][];
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation'][]
               pagination?: {
-                page?: number;
-                limit?: number;
-                total?: number;
-                totalPages?: number;
-              };
-            };
-          };
-        };
-      };
-    };
+                page?: number
+                limit?: number
+                total?: number
+                totalPages?: number
+              }
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new component installation
      * @description Records a component being installed at a location. Requires componentId and spaceId.
@@ -3994,22 +4065,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/component-installations/{id}": {
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
+      }
+    }
+  }
+  '/component-installations/{id}': {
     /**
      * Get component installation by ID
      * @description Returns installation record with dates, location, order number, and cost.
@@ -4017,24 +4088,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a component installation
      * @description Updates installation details or records deinstallation date.
@@ -4043,29 +4114,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component installation ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateComponentInstallationRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateComponentInstallationRequest']
+        }
+      }
       responses: {
         /** @description Component installation updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ComponentInstallation"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ComponentInstallation']
+            }
+          }
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a component installation
      * @description Removes an installation record.
@@ -4073,22 +4144,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Component installation deleted */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Component installation not found */
         404: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/{id}/upload': {
     /**
      * Upload a file to a component
      * @description Attach photos or documents to a specific component (e.g., installation photos, receipts).
@@ -4097,92 +4168,92 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
+            contentType: string
             /** @description Optional caption for the file */
-            caption?: string;
-          };
-        };
-      };
+            caption?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/component-instances/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/component-instances/{id}': {
     /** Get all documents for a component */
     get: {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            "application/json": components["schemas"]["DocumentWithUrl"][];
-          };
-        };
+            'application/json': components['schemas']['DocumentWithUrl'][]
+          }
+        }
         /** @description Component not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/documents/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/documents/{id}': {
     /** Delete a document by ID */
     delete: {
       parameters: {
         path: {
           /** @description Document ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Document deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Document not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/component-models/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/component-models/{id}/upload': {
     /**
      * Upload a document to a component model
      * @description Attach product documentation, manuals, or spec sheets to a model for reference.
@@ -4191,38 +4262,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
+            fileData: string
             /** @description Original file name */
-            fileName: string;
+            fileName: string
             /** @description MIME type of the file */
-            contentType: string;
-          };
-        };
-      };
+            contentType: string
+          }
+        }
+      }
       responses: {
         /** @description Document uploaded successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Bad request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/components/analyze-image": {
+          content: never
+        }
+      }
+    }
+  }
+  '/components/analyze-image': {
     /**
      * Analyze component image(s) using AI
      * @description Upload photos to identify component type, model, or condition using AI image analysis. Can accept a typeplate/label image, product photo, or both for improved accuracy.
@@ -4230,30 +4301,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["AnalyzeComponentImageRequest"];
-        };
-      };
+          'application/json': components['schemas']['AnalyzeComponentImageRequest']
+        }
+      }
       responses: {
         /** @description Component analysis successful */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["AIComponentAnalysis"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['AIComponentAnalysis']
+            }
+          }
+        }
         /** @description Invalid request (e.g., image too large, missing required fields) */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description AI analysis failed */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/processes/add-component": {
+          content: never
+        }
+      }
+    }
+  }
+  '/processes/add-component': {
     /**
      * Add a component with model, instance, and installation
      * @description Unified process to add a component. This handles:
@@ -4269,99 +4340,99 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Model name (used to find existing model or create new one) */
-            modelName: string;
+            modelName: string
             /**
              * Format: uuid
              * @description Subtype ID (must exist)
              */
-            componentSubtypeId: string;
+            componentSubtypeId: string
             /** @description Required if model doesn't exist */
-            manufacturer?: string;
+            manufacturer?: string
             /** @description Required if model doesn't exist */
-            currentPrice?: number;
+            currentPrice?: number
             /** @description Required if model doesn't exist */
-            currentInstallPrice?: number;
+            currentInstallPrice?: number
             /** @description Required if model doesn't exist */
-            modelWarrantyMonths?: number;
-            technicalSpecification?: string;
-            dimensions?: string;
-            coclassCode?: string;
-            serialNumber: string;
-            specifications?: string;
-            additionalInformation?: string;
+            modelWarrantyMonths?: number
+            technicalSpecification?: string
+            dimensions?: string
+            coclassCode?: string
+            serialNumber: string
+            specifications?: string
+            additionalInformation?: string
             /**
              * Format: date-time
              * @description ISO-8601 DateTime format (e.g., 2026-01-01T00:00:00.000Z)
              */
-            warrantyStartDate?: string;
-            componentWarrantyMonths: number;
-            priceAtPurchase: number;
-            depreciationPriceAtPurchase: number;
-            economicLifespan: number;
+            warrantyStartDate?: string
+            componentWarrantyMonths: number
+            priceAtPurchase: number
+            depreciationPriceAtPurchase: number
+            economicLifespan: number
             /** @default 1 */
-            quantity?: number;
+            quantity?: number
             /** @description NCS color code */
-            ncsCode?: string;
+            ncsCode?: string
             /**
              * @default ACTIVE
              * @enum {string}
              */
-            status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+            status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
             /**
              * @description Physical condition of the component (optional)
              * @enum {string|null}
              */
-            condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+            condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
             /** @description Where to install the component */
-            spaceId: string;
+            spaceId: string
             /** @enum {string} */
-            spaceType: "OBJECT" | "PropertyObject";
-            installationDate: string;
-            orderNumber?: string;
-            installationCost: number;
-          };
-        };
-      };
+            spaceType: 'OBJECT' | 'PropertyObject'
+            installationDate: string
+            orderNumber?: string
+            installationCost: number
+          }
+        }
+      }
       responses: {
         /** @description Component added successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                modelCreated?: boolean;
+                modelCreated?: boolean
                 model?: {
-                  id?: string;
-                  modelName?: string;
-                  manufacturer?: string;
-                };
+                  id?: string
+                  modelName?: string
+                  manufacturer?: string
+                }
                 component?: {
-                  id?: string;
-                  serialNumber?: string;
-                  status?: string;
-                };
+                  id?: string
+                  serialNumber?: string
+                  status?: string
+                }
                 installation?: {
-                  id?: string;
-                  spaceId?: string;
-                  installationDate?: string;
-                };
-              };
-            };
-          };
-        };
+                  id?: string
+                  spaceId?: string
+                  installationDate?: string
+                }
+              }
+            }
+          }
+        }
         /** @description Validation error or missing required model fields */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings': {
     /**
      * Get all buildings for a specific property
      * @description Retrieves all buildings associated with a given property code.
@@ -4372,30 +4443,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the property. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the buildings. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/buildings/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/buildings/{id}': {
     /**
      * Get detailed information about a specific building
      * @description Retrieves comprehensive information about a building using its unique building id.
@@ -4406,40 +4477,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique id of the building */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-building-code/{buildingCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-building-code/{buildingCode}': {
     /**
      * Get building by building code
      * @description Retrieves building data by building code
@@ -4448,40 +4519,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved building */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building']
+            }
+          }
+        }
         /** @description Building not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Building not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/buildings/by-property-code/{propertyCode}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/buildings/by-property-code/{propertyCode}': {
     /**
      * Get buildings by property code
      * @description Retrieves buildings by property code
@@ -4490,31 +4561,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property to fetch buildings for */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved buildings */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Building"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Building'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies': {
     /**
      * Get all companies
      * @description Retrieves companies from property base
@@ -4524,24 +4595,24 @@ export interface paths {
         /** @description Successfully retrieved companies */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Company"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Company'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/companies/{organizationNumber}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/companies/{organizationNumber}': {
     /**
      * Get detailed information about a specific company
      * @description Retrieves comprehensive information about a company using its organization number.
@@ -4550,40 +4621,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The organization number of the company. */
-          organizationNumber: string;
-        };
-      };
+          organizationNumber: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved company information */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CompanyDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['CompanyDetails']
+            }
+          }
+        }
         /** @description Company not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Company not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences': {
     /**
      * Get residences by building code and (optional) staircase code
      * @description Retrieves residences by building code and (optional) staircase code
@@ -4592,41 +4663,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch residences from */
-          buildingCode: string;
+          buildingCode: string
           /** @description Code for the staircase to fetch residences from */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Residence"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Residence'][]
+            }
+          }
+        }
         /** @description Missing building code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties': {
     /**
      * Get properties by company code and (optional) tract
      * @description Retrieves properties by company code and (optional) tract
@@ -4635,41 +4706,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the company that owns the properties. */
-          companyCode: string;
+          companyCode: string
           /** @description Optional filter to get properties in a specific tract. */
-          tract?: string;
-        };
-      };
+          tract?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved properties */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Missing company code or invalid query parameters */
         400: {
           content: {
-            "application/json": {
-              error?: Record<string, never>;
-            };
-          };
-        };
+            'application/json': {
+              error?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/properties/search": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/properties/search': {
     /**
      * Search properties
      * @description Retrieves a list of all real estate properties by name.
@@ -4678,30 +4749,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The search query. */
-          q?: string;
-        };
-      };
+          q?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved list of properties. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/properties/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/properties/{propertyCode}': {
     /**
      * Get property by property code
      * @description Retrieves property by property code
@@ -4710,40 +4781,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved property */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Property"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Property']
+            }
+          }
+        }
         /** @description Property not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Property not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/by-rental-id/{rentalId}': {
     /**
      * Get residence data by residence rental id
      * @description Retrieves residence data by residence rental id
@@ -4752,40 +4823,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id for the residence to fetch */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residence. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceDetails']
+            }
+          }
+        }
         /** @description Residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Residence not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve residence data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/by-rental-id/{rentalId}': {
     /**
      * Get rental blocks by rental ID
      * @description Retrieves rental blocks by rental ID
@@ -4794,44 +4865,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
-        };
+          active?: boolean
+        }
         path: {
           /** @description Rental id to fetch rental blocks for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlock"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['RentalBlock'][]
+            }
+          }
+        }
         /** @description Rental ID not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Rental ID not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve rental blocks. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/export": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/export': {
     /**
      * Export rental blocks to Excel
      * @description Generates and downloads an Excel file with all rental blocks matching the filters
@@ -4840,36 +4911,36 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term */
-          q?: string;
+          q?: string
           /** @description Filter by category (supports multiple values) */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter by start date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter by end date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-        };
-      };
+          active?: boolean
+        }
+      }
       responses: {
         /** @description Excel file download */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/search': {
     /**
      * Search rental blocks with server-side filtering
      * @description Search and filter rental blocks. Searches by rentalId and address.
@@ -4878,55 +4949,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term (searches rentalId, address) */
-          q?: string;
+          q?: string
           /** @description Comma-separated fields to search (default rentalId,address,propertyName,blockReason) */
-          fields?: string;
+          fields?: string
           /** @description Filter by category (Bostad, Bilplats, Lokal, Förråd) - supports multiple values */
-          kategori?: string[];
+          kategori?: string[]
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[];
+          distrikt?: string[]
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[];
+          blockReason?: string[]
           /** @description Filter by property code/name (supports multiple values) */
-          fastighet?: string[];
+          fastighet?: string[]
           /** @description Filter blocks starting on or after this date */
-          fromDateGte?: string;
+          fromDateGte?: string
           /** @description Filter blocks ending on or before this date */
-          toDateLte?: string;
+          toDateLte?: string
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean;
-          page?: number;
-          limit?: number;
-        };
-      };
+          active?: boolean
+          page?: number
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully searched rental blocks */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/rental-blocks/all": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/rental-blocks/all': {
     /**
      * Get all rental blocks (paginated)
      * @description Retrieves all rental blocks for residences across the system with pagination support
@@ -4935,46 +5006,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean;
+          active?: boolean
           /** @description Page number (1-indexed) */
-          page?: number;
+          page?: number
           /** @description Number of items per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved all rental blocks. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["RentalBlockWithRentalObject"][];
+            'application/json': {
+              content?: components['schemas']['RentalBlockWithRentalObject'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
-              _links?: ({
-                  href?: string;
-                  /** @enum {string} */
-                  rel?: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
+              _links?: {
+                href?: string
+                /** @enum {string} */
+                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/residences/block-reasons": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/residences/block-reasons': {
     /**
      * Get all block reasons
      * @description Returns all available block reasons for rental blocks. Used for filtering dropdowns.
@@ -4984,22 +5055,22 @@ export interface paths {
         /** @description Successfully retrieved block reasons */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                  id?: string;
-                  caption?: string;
-                }[];
-            };
-          };
-        };
+                id?: string
+                caption?: string
+              }[]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/search': {
     /**
      * Search residences
      * @description Searches for residences by rental object id.
@@ -5008,30 +5079,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental object id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved residences matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/residences/summary/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/residences/summary/by-building-code/{buildingCode}': {
     /**
      * Get residences by building code, optionally filtered by staircase code.
      * @description Returns all residences belonging to a specific building, optionally filtered by staircase code.
@@ -5040,34 +5111,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
+          staircaseCode?: string
+        }
         path: {
           /** @description The building code of the building. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the residences. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ResidenceSummary"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ResidenceSummary'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/staircases": {
+          content: never
+        }
+      }
+    }
+  }
+  '/staircases': {
     /**
      * Get staircases for a building
      * @description Retrieves staircases for a building
@@ -5076,42 +5147,42 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch staircases for */
-          buildingCode: string;
+          buildingCode: string
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string;
-        };
-      };
+          staircaseCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved staircases. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Staircase"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Staircase'][]
+            }
+          }
+        }
         /** @description Missing buildingCode */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Missing buildingCode */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/rooms": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/rooms': {
     /**
      * Get rooms by rental id.
      * @description Returns all rooms belonging to a residence.
@@ -5120,30 +5191,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The rental id of the residence. */
-          rentalId: string;
+          rentalId: string
           /** @description The code of the room (optional). */
-          roomCode?: string;
-        };
-      };
+          roomCode?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Create a room for a residence.
      * @description Forwards to property-base-service which performs a transactional
@@ -5153,34 +5224,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateRoomRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateRoomRequest']
+        }
+      }
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Residence not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/rooms/by-facility-id/{facilityId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/rooms/by-facility-id/{facilityId}': {
     /**
      * Get rooms by facility id.
      * @description Returns all rooms belonging to a facility.
@@ -5189,26 +5260,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The id of the facility. */
-          facilityId: string;
-        };
-      };
+          facilityId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Room"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Room'][]
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/by-rental-id/{rentalId}': {
     /**
      * Get parking space data by rentalId
      * @description Retrieves parking space data by rentalId
@@ -5217,40 +5288,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id to fetch parking space for */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking space. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpace"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpace']
+            }
+          }
+        }
         /** @description Parking space not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Parking space not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve parking space data. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-rental-id/{rentalId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-rental-id/{rentalId}': {
     /**
      * Get maintenance units by rental id.
      * @description Returns all maintenance units belonging to a rental property.
@@ -5259,30 +5330,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property for which to retrieve maintenance units. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-building-code/{buildingCode}': {
     /**
      * Get maintenance units by building code.
      * @description Returns all maintenance units belonging to a building.
@@ -5291,30 +5362,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve maintenance units. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-rental-id/{rentalId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-rental-id/{rentalId}': {
     /**
      * Get facility by rental id.
      * @description Returns facility.
@@ -5323,30 +5394,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental id of the facility. */
-          rentalId: string;
-        };
-      };
+          rentalId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facility. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilityDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilityDetails']
+            }
+          }
+        }
         /** @description Not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-property-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-property-code/{code}': {
     /**
      * Get maintenance units by property code.
      * @description Returns all maintenance units belonging to a property.
@@ -5355,30 +5426,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve maintenance units. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/by-code/{code}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/by-code/{code}': {
     /**
      * Get a maintenance unit by its code
      * @description Returns a single maintenance unit by its unique code.
@@ -5387,30 +5458,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the maintenance unit to retrieve. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the maintenance unit. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit']
+            }
+          }
+        }
         /** @description Maintenance unit not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/maintenance-units/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/maintenance-units/search': {
     /**
      * Search maintenance units
      * @description Searches for maintenance units by code.
@@ -5419,30 +5490,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (maintenance unit code). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved maintenance units matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["MaintenanceUnit"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['MaintenanceUnit'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-property-code/{propertyCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-property-code/{propertyCode}': {
     /**
      * Get facilities by property code.
      * @description Returns all facilities belonging to a property.
@@ -5451,30 +5522,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve facilities. */
-          propertyCode: string;
-        };
-      };
+          propertyCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/by-building-code/{buildingCode}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/by-building-code/{buildingCode}': {
     /**
      * Get facilities by building code.
      * @description Returns all facilities belonging to a building.
@@ -5483,30 +5554,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve facilities. */
-          buildingCode: string;
-        };
-      };
+          buildingCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            "application/json": {
-              content?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              content?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Facilities not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/facilities/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/facilities/search': {
     /**
      * Search facilities
      * @description Searches for facilities by rental id.
@@ -5515,30 +5586,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved facilities matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FacilitySearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FacilitySearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/parking-spaces/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/parking-spaces/search': {
     /**
      * Search parking spaces
      * @description Searches for parking spaces by rental id.
@@ -5547,30 +5618,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved parking spaces matching the search query. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ParkingSpaceSearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ParkingSpaceSearchResult'][]
+            }
+          }
+        }
         /** @description Invalid query provided */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/apartments/{objectNumber}/temperatures": {
+          content: never
+        }
+      }
+    }
+  }
+  '/apartments/{objectNumber}/temperatures': {
     /**
      * Get indoor temperatures for an apartment
      * @description Fetches indoor temperature time series for an apartment by its object
@@ -5583,42 +5654,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Unix timestamp (seconds) for range start. Defaults to `to - 86400`. */
-          from?: number;
+          from?: number
           /** @description Unix timestamp (seconds) for range end. Defaults to now. */
-          to?: number;
+          to?: number
           /** @description Aggregation bucket size. Defaults to "H" (hourly). */
-          interval?: "H" | "D";
-        };
+          interval?: 'H' | 'D'
+        }
         path: {
           /** @description Apartment object number (e.g. "806-032-01-0101"). */
-          objectNumber: string;
-        };
-      };
+          objectNumber: string
+        }
+      }
       responses: {
         /** @description Temperature series successfully retrieved. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ApartmentTemperaturesResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ApartmentTemperaturesResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description No apartment node found for the given object number. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/search': {
     /**
      * Omni-search for different entities
      * @description Search for properties, buildings, residences, parking spaces, and maintenance units.
@@ -5635,30 +5706,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query string */
-          q: string;
-        };
-      };
+          q: string
+        }
+      }
       responses: {
         /** @description A list of search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SearchResult"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SearchResult'][]
+            }
+          }
+        }
         /** @description Bad request - invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/inspections": {
+          content: never
+        }
+      }
+    }
+  }
+  '/inspections': {
     /**
      * Retrieve inspections from all sources
      * @description Retrieves inspections from both the local database and Xpand, merged with a source indicator per item.
@@ -5667,58 +5738,58 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections from all sources. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["InspectionWithSource"][];
+            'application/json': {
+              content?: components['schemas']['InspectionWithSource'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Create a new inspection
      * @description Creates a new inspection in the local inspection database
@@ -5726,40 +5797,40 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateInspectionRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateInspectionRequest']
+        }
+      }
       responses: {
         /** @description Inspection created successfully */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["DetailedInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['DetailedInspection']
+              }
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/residence/{residenceId}": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from all sources
      * @description Retrieves inspections associated with a specific residence ID from both the local database and Xpand.
@@ -5768,37 +5839,37 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["InspectionWithSource"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['InspectionWithSource'][]
+              }
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand': {
     /**
      * Retrieve inspections from Xpand
      * @description Retrieves inspections from Xpand with pagination and status filtering support.
@@ -5807,60 +5878,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number;
+          page?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
+          statusFilter?: 'ongoing' | 'completed'
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false;
+          sortAscending?: true | false
           /** @description Filter inspections by inspector name. */
-          inspector?: string;
+          inspector?: string
           /** @description Filter inspections by address. */
-          address?: string;
-        };
-      };
+          address?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Inspection"][];
+            'application/json': {
+              content?: components['schemas']['Inspection'][]
               _meta?: {
-                totalRecords?: number;
-                page?: number;
-                limit?: number;
-                count?: number;
-              };
+                totalRecords?: number
+                page?: number
+                limit?: number
+                count?: number
+              }
               _links?: {
-                  href?: string;
-                  rel?: string;
-                }[];
-            };
-          };
-        };
+                href?: string
+                rel?: string
+              }[]
+            }
+          }
+        }
         /** @description Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid query parameters */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/residence/{residenceId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/residence/{residenceId}': {
     /**
      * Retrieve inspections by residence ID from Xpand
      * @description Retrieves inspections associated with a specific residence ID from Xpand.
@@ -5869,46 +5940,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: "ongoing" | "completed";
-        };
+          statusFilter?: 'ongoing' | 'completed'
+        }
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspections?: components["schemas"]["Inspection"][];
-              };
-            };
-          };
-        };
+                inspections?: components['schemas']['Inspection'][]
+              }
+            }
+          }
+        }
         /** @description No inspections found for the specified residence ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}': {
     /**
      * Retrieve an inspection by ID from Xpand
      * @description Retrieves a specific inspection by its ID from Xpand.
@@ -5917,40 +5988,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["DetailedInspection"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['DetailedInspection']
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve the inspection. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/xpand/{inspectionId}/pdf": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/xpand/{inspectionId}/pdf': {
     /**
      * Generate PDF protocol for an inspection
      * @description Generates and returns a PDF protocol for a specific inspection by its ID.
@@ -5959,47 +6030,47 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean;
-        };
+          includeCosts?: boolean
+        }
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string;
-              };
-            };
-          };
-        };
+                pdfBase64?: string
+              }
+            }
+          }
+        }
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example not-found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to generate PDF. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/details": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/details': {
     /**
      * Retrieve an enriched internal inspection by ID
      * @description Retrieves a specific internal inspection by its ID, normalized into the same shape as Xpand inspections (with lease, residence, and flattened room remarks) so it can be rendered by the protocol UI without source-specific branching.
@@ -6008,38 +6079,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["DetailedInspection"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['DetailedInspection']
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/pdf": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/pdf': {
     /**
      * Generate PDF protocol for an internal inspection
      * @description Generates and returns a PDF protocol for a specific internal inspection by its ID.
@@ -6048,45 +6119,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean;
-        };
+          includeCosts?: boolean
+        }
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string;
-              };
-            };
-          };
-        };
+                pdfBase64?: string
+              }
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/tenant-contacts": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/tenant-contacts': {
     /**
      * Get tenant contacts for an internal inspection
      * @description Retrieves contact information for new and previous tenants associated with an internal inspection's residence.
@@ -6094,38 +6165,38 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant contacts. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["TenantContactsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['TenantContactsResponse']
+            }
+          }
+        }
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/send-protocol": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/send-protocol': {
     /**
      * Send inspection protocol to tenant for an internal inspection
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous) for an internal inspection.
@@ -6133,51 +6204,51 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SendProtocolRequest"];
-        };
-      };
+          'application/json': components['schemas']['SendProtocolRequest']
+        }
+      }
       responses: {
         /** @description Protocol sent successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SendProtocolResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SendProtocolResponse']
+            }
+          }
+        }
         /** @description Invalid request or no contract found. */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/tenant-contacts": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/tenant-contacts': {
     /**
      * Get tenant contacts for inspection protocol modal
      * @description Retrieves contact information for new and previous tenants to display in confirmation modal before sending protocol
@@ -6186,40 +6257,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved tenant contacts */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["TenantContactsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['TenantContactsResponse']
+            }
+          }
+        }
         /** @description Inspection or residence not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/{inspectionId}/send-protocol": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/{inspectionId}/send-protocol': {
     /**
      * Send inspection protocol to tenant
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous)
@@ -6228,90 +6299,90 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SendProtocolRequest"];
-        };
-      };
+          'application/json': components['schemas']['SendProtocolRequest']
+        }
+      }
       responses: {
         /** @description Protocol sent successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["SendProtocolResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['SendProtocolResponse']
+            }
+          }
+        }
         /** @description Invalid request or no contract found */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Invalid request body */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Inspection not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}": {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}': {
     /** Get internal inspection by ID including draft room data */
     get: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       responses: {
         /** @description Internal inspection with draft room data */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["InternalInspection"];
-              };
-            };
-          };
-        };
+                inspection?: components['schemas']['InternalInspection']
+              }
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
     /**
      * Update internal inspection
      * @description Updates an internal inspection. Supports updating status (with valid transitions Registrerad → Påbörjad → Genomförd) and/or inspector. At least one field must be provided.
@@ -6320,100 +6391,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to update */
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateInspectionStatusRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateInspectionStatusRequest']
+        }
+      }
       responses: {
         /** @description Inspection updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                inspection?: components["schemas"]["InternalInspection"];
+                inspection?: components['schemas']['InternalInspection']
                 /** @description Per-component write-back errors recorded when transitioning to "Genomförd". Empty for other status transitions. */
-                componentWriteBackErrors?: components["schemas"]["ComponentWriteBackError"][];
-              };
-            };
-          };
-        };
+                componentWriteBackErrors?: components['schemas']['ComponentWriteBackError'][]
+              }
+            }
+          }
+        }
         /** @description Invalid request body or invalid status transition */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/draft": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/draft': {
     /** Save inspection draft data (rooms and inspector name) */
     patch: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SaveInspectionDraftRequest"];
-        };
-      };
+          'application/json': components['schemas']['SaveInspectionDraftRequest']
+        }
+      }
       responses: {
         /** @description Draft saved successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Invalid request body */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection not found */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/rooms": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/rooms': {
     /**
      * Add a room to a residence during an inspection.
      * @description Creates a new room in Xpand (via property-base) for the residence
@@ -6429,53 +6500,53 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string;
-        };
-      };
+          inspectionId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["AddInspectionRoomRequest"];
-        };
-      };
+          'application/json': components['schemas']['AddInspectionRoomRequest']
+        }
+      }
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                room?: components["schemas"]["Room"];
-              };
-            };
-          };
-        };
+                room?: components['schemas']['Room']
+              }
+            }
+          }
+        }
         /** @description Invalid request body or no residence linked to the inspection. */
         400: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
+            'application/json': {
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. */
         500: {
           content: {
-            "application/json": {
-              error?: string;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/inspections/internal/{inspectionId}/rooms/{roomId}": {
+            'application/json': {
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
+  '/inspections/internal/{inspectionId}/rooms/{roomId}': {
     /**
      * Remove a room that was added during the current inspection.
      * @description Symmetric to POST /inspections/internal/{inspectionId}/rooms.
@@ -6491,206 +6562,206 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          inspectionId: string;
-          roomId: string;
-        };
-      };
+          inspectionId: string
+          roomId: string
+        }
+      }
       responses: {
         /** @description Room removed. */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /**
          * @description Inspection not found, room not found in Xpand, or the room was
          * not added during this inspection.
          */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Room has installed components and cannot be removed. */
         409: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files': {
     /** List files with optional prefix */
     get: {
       parameters: {
         query?: {
-          prefix?: string;
-        };
-      };
+          prefix?: string
+        }
+      }
       responses: {
         /** @description List of files with metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["ListFilesResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['ListFilesResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/upload': {
     /** Upload a file */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["FileUploadRequest"];
-        };
-      };
+          'application/json': components['schemas']['FileUploadRequest']
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUploadResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUploadResponse']
+            }
+          }
+        }
         /** @description Invalid request */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/url": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/url': {
     /** Get presigned URL for file download */
     get: {
       parameters: {
         query?: {
           /** @description URL expiry time in seconds */
-          expirySeconds?: number;
-        };
+          expirySeconds?: number
+        }
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description Presigned URL generated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileUrlResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileUrlResponse']
+            }
+          }
+        }
         /** @description Invalid query parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/metadata": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/metadata': {
     /** Get file metadata */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File metadata */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileMetadata"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileMetadata']
+            }
+          }
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}': {
     /** Delete a file */
     delete: {
       parameters: {
         path: {
           /** @description Name of the file to delete */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description File not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/files/{fileName}/exists": {
+          content: never
+        }
+      }
+    }
+  }
+  '/files/{fileName}/exists': {
     /** Check if file exists */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string;
-        };
-      };
+          fileName: string
+        }
+      }
       responses: {
         /** @description File existence status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["FileExistsResponse"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['FileExistsResponse']
+            }
+          }
+        }
         /** @description Server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/dax/card-owners": {
+          content: never
+        }
+      }
+    }
+  }
+  '/dax/card-owners': {
     /**
      * Search card owners from DAX
      * @description Search for card owners in the DAX access control system
@@ -6699,44 +6770,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by name (rental object ID / object code) */
-          nameFilter?: string;
+          nameFilter?: string
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
+          expand?: string
           /** @description Filter by ID */
-          idfilter?: string;
+          idfilter?: string
           /** @description Filter by attribute */
-          attributeFilter?: string;
+          attributeFilter?: string
           /** @description Select specific attributes to return */
-          selectedAttributes?: string;
+          selectedAttributes?: string
           /** @description Filter by folder */
-          folderFilter?: string;
+          folderFilter?: string
           /** @description Filter by organisation */
-          organisationFilter?: string;
+          organisationFilter?: string
           /** @description Pagination offset */
-          offset?: number;
+          offset?: number
           /** @description Maximum number of results */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Card owners retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwners?: Record<string, never>[];
-            };
-          };
-        };
+            'application/json': {
+              cardOwners?: Record<string, never>[]
+            }
+          }
+        }
         /** @description Failed to fetch card owners */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/card-owners/{cardOwnerId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/card-owners/{cardOwnerId}': {
     /**
      * Get a specific card owner from DAX
      * @description Retrieve a card owner by ID from the DAX access control system
@@ -6745,38 +6816,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card owner ID */
-          cardOwnerId: string;
-        };
-      };
+          cardOwnerId: string
+        }
+      }
       responses: {
         /** @description Card owner retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              cardOwner?: components["schemas"]["CardOwner"];
-            };
-          };
-        };
+            'application/json': {
+              cardOwner?: components['schemas']['CardOwner']
+            }
+          }
+        }
         /** @description Card owner not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card owner */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/dax/cards/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/dax/cards/{cardId}': {
     /**
      * Get a specific card from DAX
      * @description Retrieve a card by ID from the DAX access control system
@@ -6785,38 +6856,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "codes") */
-          expand?: string;
-        };
+          expand?: string
+        }
         path: {
           /** @description The card ID */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card retrieved successfully */
         200: {
           content: {
-            "application/json": {
-              card?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              card?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Failed to fetch card */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-bundles": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-bundles': {
     /**
      * List key bundles with pagination
      * @description Fetches a paginated list of all key bundles ordered by name.
@@ -6825,28 +6896,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description A paginated list of key bundles. */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key bundle
      * @description Create a new key bundle record.
@@ -6854,30 +6925,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while creating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/search": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/search': {
     /**
      * Search key bundles with pagination
      * @description Search key bundles with flexible filtering and pagination.
@@ -6886,35 +6957,35 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. */
-          fields?: string;
-        };
-      };
+          fields?: string
+        }
+      }
       responses: {
         /** @description Paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Invalid search parameters */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-key/{keyId}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-key/{keyId}': {
     /**
      * Get all bundles containing a specific key
      * @description Returns all bundle records containing the specified key ID
@@ -6923,26 +6994,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to search for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of bundles containing this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}': {
     /**
      * Get key bundle by ID
      * @description Fetch a specific key bundle by its ID.
@@ -6951,28 +7022,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key bundle object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while fetching the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Delete a key bundle
      * @description Delete a key bundle by ID.
@@ -6981,24 +7052,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key bundle deleted successfully. */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while deleting the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
+          content: never
+        }
+      }
+    }
     /**
      * Update a key bundle
      * @description Partially update an existing key bundle.
@@ -7007,39 +7078,39 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyBundleRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyBundleRequest']
+        }
+      }
       responses: {
         /** @description Key bundle updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundle"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyBundle']
+            }
+          }
+        }
         /** @description Invalid request body */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key bundle not found. */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description An error occurred while updating the key bundle. */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/{id}/keys-with-loan-status": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/{id}/keys-with-loan-status': {
     /**
      * Get keys in bundle with maintenance loan status
      * @description Fetches all keys in a key bundle along with their active maintenance loan information
@@ -7053,38 +7124,38 @@ export interface paths {
            * Soft fails — if the contacts service errors, the response is
            * returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The key bundle ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Bundle information and keys with loan status */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyBundleDetailsResponse"];
+            'application/json': {
+              content?: components['schemas']['KeyBundleDetailsResponse']
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Key bundle not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-bundles/by-contact/{contactCode}/with-loaned-keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-bundles/by-contact/{contactCode}/with-loaned-keys': {
     /**
      * Get key bundles with keys loaned to a contact
      * @description Fetches all key bundles that have keys currently loaned to a specific contact.
@@ -7093,28 +7164,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code (F-number) to find bundles for */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description A list of bundles with loaned keys info. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["BundleWithLoanedKeysInfo"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['BundleWithLoanedKeysInfo'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching bundles. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events': {
     /**
      * Get all key events
      * @description Returns all key events ordered by creation date.
@@ -7124,19 +7195,19 @@ export interface paths {
         /** @description List of key events. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a key event
      * @description Create a new key event record. Will fail with 409 if any of the keys have an incomplete event (status not COMPLETED).
@@ -7144,43 +7215,43 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Conflict - one or more keys have incomplete events. */
         409: {
           content: {
-            "application/json": {
-              reason?: string;
-              conflictingKeys?: string[];
-            };
-          };
-        };
+            'application/json': {
+              reason?: string
+              conflictingKeys?: string[]
+            }
+          }
+        }
         /** @description An error occurred while creating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/by-key/{keyId}': {
     /**
      * Get all key events for a specific key
      * @description Returns all key events associated with a specific key ID. Optionally limit results to get only the latest event(s).
@@ -7189,32 +7260,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional limit on number of results (e.g., 1 for latest event only). */
-          limit?: number;
-        };
+          limit?: number
+        }
         path: {
           /** @description The key ID to filter events by. */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description List of key events for the key. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent'][]
+            }
+          }
+        }
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-events/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-events/{id}': {
     /**
      * Get key event by ID
      * @description Fetch a specific key event by its ID.
@@ -7223,32 +7294,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key event object. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key event
      * @description Update an existing key event.
@@ -7257,45 +7328,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyEventRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyEventRequest']
+        }
+      }
       responses: {
         /** @description Key event updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyEvent"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyEvent']
+            }
+          }
+        }
         /** @description Invalid request body. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key event not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key event. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans': {
     /**
      * List all key loans
      * @description Fetches a list of all key loans ordered by creation date.
@@ -7305,19 +7376,19 @@ export interface paths {
         /** @description A list of key loans. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
         /** @description An error occurred while listing key loans. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key loan
      * @description Create a new key loan record.
@@ -7325,34 +7396,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan created successfully. */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description An error occurred while creating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/search': {
     /**
      * Search key loans
      * @description Search key loans with flexible filtering.
@@ -7365,69 +7436,69 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to contact and contact2. */
-          fields?: string;
+          fields?: string
           /** @description Search by key name or rental object code (requires JOIN with keys table) */
-          keyNameOrObjectCode?: string;
+          keyNameOrObjectCode?: string
           /** @description Minimum number of keys in loan */
-          minKeys?: number;
+          minKeys?: number
           /** @description Maximum number of keys in loan */
-          maxKeys?: number;
+          maxKeys?: number
           /** @description Filter by pickedUpAt null status (true = NOT NULL, false = NULL) */
-          hasPickedUp?: boolean;
+          hasPickedUp?: boolean
           /** @description Filter by returnedAt null status (true = NOT NULL, false = NULL) */
-          hasReturned?: boolean;
-          id?: string;
-          keys?: string;
-          contact?: string;
-          contact2?: string;
-          loanType?: "TENANT" | "MAINTENANCE";
+          hasReturned?: boolean
+          id?: string
+          keys?: string
+          contact?: string
+          contact2?: string
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          returnedAt?: string;
-          availableToNextTenantFrom?: string;
+          returnedAt?: string
+          availableToNextTenantFrom?: string
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          pickedUpAt?: string;
-          createdAt?: string;
-          updatedAt?: string;
+          pickedUpAt?: string
+          createdAt?: string
+          updatedAt?: string
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Successfully retrieved search results */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-key/{keyId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-key/{keyId}': {
     /**
      * Get all loans for a specific key
      * @description Returns all loan records for the specified key ID, ordered by creation date DESC
@@ -7441,36 +7512,36 @@ export interface paths {
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The key ID to fetch loans for */
-          keyId: string;
-        };
-      };
+          keyId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this key */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-card/{cardId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-card/{cardId}': {
     /**
      * Get all loans for a specific card
      * @description Returns all loan records for the specified card ID, ordered by creation date DESC
@@ -7479,23 +7550,23 @@ export interface paths {
       parameters: {
         path: {
           /** @description The card ID to fetch loans for */
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Array of loans for this card */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"][];
-            };
-          };
-        };
-        500: components["responses"]["InternalServerError"];
-      };
-    };
-  };
-  "/key-loans/by-rental-object/{rentalObjectCode}": {
+            'application/json': {
+              content?: components['schemas']['KeyLoan'][]
+            }
+          }
+        }
+        500: components['responses']['InternalServerError']
+      }
+    }
+  }
+  '/key-loans/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key loans by rental object code
      * @description Returns all key loans for a specific rental object with keys and optional receipts
@@ -7504,43 +7575,43 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by contact code */
-          contact?: string;
+          contact?: string
           /** @description Filter by second contact code */
-          contact2?: string;
+          contact2?: string
           /** @description Include receipts in the response */
-          includeReceipts?: boolean;
+          includeReceipts?: boolean
           /**
            * @description Filter by return status:
            * - true: Only returned loans (returnedAt IS NOT NULL)
            * - false: Only active loans (returnedAt IS NULL)
            * - omitted: All loans (no filter)
            */
-          returned?: boolean;
-        };
+          returned?: boolean
+        }
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description A list of key loans with details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-contact/{contact}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-contact/{contact}/with-keys': {
     /**
      * Get key loans by contact with keys
      * @description Returns all key loans for a specific contact with full key details, optionally filtered by loan type and return status
@@ -7549,45 +7620,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
+          returned?: boolean
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The contact identifier to search for */
-          contact: string;
-        };
-      };
+          contact: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/by-bundle/{bundleId}/with-keys": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/by-bundle/{bundleId}/with-keys': {
     /**
      * Get key loans by bundle with keys
      * @description Returns all key loans for a specific bundle with full key details, optionally filtered by loan type and return status
@@ -7596,45 +7667,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: "TENANT" | "MAINTENANCE";
+          loanType?: 'TENANT' | 'MAINTENANCE'
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean;
+          returned?: boolean
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean;
-        };
+          includeContacts?: boolean
+        }
         path: {
           /** @description The bundle ID to search for */
-          bundleId: string;
-        };
-      };
+          bundleId: string
+        }
+      }
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoanWithDetails"][];
+            'application/json': {
+              content?: components['schemas']['KeyLoanWithDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-loans/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-loans/{id}': {
     /**
      * Get key loan by ID
      * @description Fetch a specific key loan by its ID.
@@ -7647,42 +7718,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description When true, includes keysArray with keySystem data attached to each key. */
-          includeKeySystem?: boolean;
+          includeKeySystem?: boolean
           /** @description When true, includes keyCardsArray with card data from DAX. Auto-implies key fetching. */
-          includeCards?: boolean;
+          includeCards?: boolean
           /** @description When true, includes loan history attached to each key in keysArray. */
-          includeLoans?: boolean;
+          includeLoans?: boolean
           /** @description When true, includes event history attached to each key in keysArray. */
-          includeEvents?: boolean;
-        };
+          includeEvents?: boolean
+        }
         path: {
           /** @description The unique ID of the key loan to retrieve. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description A key loan object. Returns KeyLoanWithDetails if includeKeySystem or includeCards is true. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"] | components["schemas"]["KeyLoanWithDetails"];
-            };
-          };
-        };
+            'application/json': {
+              content?:
+                | components['schemas']['KeyLoan']
+                | components['schemas']['KeyLoanWithDetails']
+            }
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while fetching the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key loan
      * @description Delete an existing key loan by ID.
@@ -7691,28 +7764,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to delete. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key loan deleted successfully. */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while deleting the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key loan
      * @description Partially update an existing key loan.
@@ -7721,45 +7794,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to update. */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyLoanRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyLoanRequest']
+        }
+      }
       responses: {
         /** @description Key loan updated successfully. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyLoan"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyLoan']
+            }
+          }
+        }
         /** @description Invalid request data. */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key loan not found. */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description An error occurred while updating the key loan. */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/{id}': {
     /**
      * Get key note by ID
      * @description Retrieve a specific key note by its ID
@@ -7768,32 +7841,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key note
      * @description Update the description of an existing key note
@@ -7802,45 +7875,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes/by-rental-object/{rentalObjectCode}': {
     /**
      * Get key note by rental object code
      * @description Retrieve the key note for a specific rental object
@@ -7849,34 +7922,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Key note not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-notes": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-notes': {
     /**
      * Create a new key note
      * @description Create a new key note for a rental object
@@ -7884,34 +7957,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyNoteRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyNoteRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeyNote"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeyNote']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems': {
     /**
      * List all key systems with pagination
      * @description Retrieve a paginated list of all key systems
@@ -7920,28 +7993,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated key systems */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Create a new key system
      * @description Create a new key system
@@ -7949,34 +8022,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/search': {
     /**
      * Search key systems
      * @description Search key systems with flexible filtering.
@@ -7993,54 +8066,54 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Search query for OR search across fields specified in 'fields' parameter */
-          q?: string;
+          q?: string
           /** @description Comma-separated list of fields for OR search (e.g., "systemCode,manufacturer"). Defaults to systemCode. */
-          fields?: string;
-          id?: string;
-          systemCode?: string;
-          name?: string;
-          manufacturer?: string;
-          managingSupplier?: string;
-          type?: string;
-          propertyIds?: string;
-          installationDate?: string;
-          isActive?: string;
-          notes?: string;
-          createdAt?: string;
-          updatedAt?: string;
-          createdBy?: string;
-          updatedBy?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          systemCode?: string
+          name?: string
+          manufacturer?: string
+          managingSupplier?: string
+          type?: string
+          propertyIds?: string
+          installationDate?: string
+          isActive?: string
+          notes?: string
+          createdAt?: string
+          updatedAt?: string
+          createdBy?: string
+          updatedBy?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeySystem"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeySystem'][]
+            }
+          }
+        }
         /** @description Bad request. Invalid parameters or field names */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}': {
     /**
      * Get key system by ID
      * @description Retrieve a specific key system by its ID
@@ -8049,32 +8122,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved key system */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a key system
      * @description Delete a key system by ID
@@ -8083,28 +8156,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key system deleted successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a key system
      * @description Partially update a key system
@@ -8113,139 +8186,139 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeySystemRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeySystemRequest']
+        }
+      }
       responses: {
         /** @description Key system updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["KeySystem"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['KeySystem']
+            }
+          }
+        }
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Key system not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/upload-schema": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/upload-schema': {
     /** Upload a schema file for a key system */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-            fileName?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+            fileName?: string
+          }
+        }
+      }
       responses: {
         /** @description Schema file uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/download-schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/download-schema': {
     /** Get presigned download URL for a key system schema file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": components["schemas"]["SchemaDownloadUrlResponse"];
-          };
-        };
+            'application/json': components['schemas']['SchemaDownloadUrlResponse']
+          }
+        }
         /** @description Key system or schema file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/key-systems/{id}/schema": {
+          content: never
+        }
+      }
+    }
+  }
+  '/key-systems/{id}/schema': {
     /** Delete the schema file for a key system */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Schema deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Key system not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/keys": {
+          content: never
+        }
+      }
+    }
+  }
+  '/keys': {
     /**
      * List keys with pagination
      * @description Returns paginated keys ordered by createdAt (desc).
@@ -8254,71 +8327,71 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Paginated list of keys */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a key */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateKeyRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/search': {
     /**
      * Search keys
      * @description Search keys with flexible filtering.
@@ -8331,59 +8404,59 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to keyName. */
-          fields?: string;
-          id?: string;
-          keyName?: string;
-          keySequenceNumber?: string;
-          flexNumber?: string;
-          rentalObjectCode?: string;
-          keyType?: string;
-          keySystemId?: string;
-          createdAt?: string;
-          updatedAt?: string;
+          fields?: string
+          id?: string
+          keyName?: string
+          keySequenceNumber?: string
+          flexNumber?: string
+          rentalObjectCode?: string
+          keyType?: string
+          keySystemId?: string
+          createdAt?: string
+          updatedAt?: string
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean;
-        };
-      };
+          includeContacts?: boolean
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["KeyDetails"][];
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['KeyDetails'][]
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components["schemas"]["ContactV1"];
-              };
-            };
-          };
-        };
+                [key: string]: components['schemas']['ContactV1']
+              }
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/by-rental-object/{rentalObjectCode}': {
     /**
      * Get all keys by rental object code
      * @description Returns all keys associated with a specific rental object code without pagination
@@ -8392,182 +8465,182 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to filter keys by */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved keys */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/cards/by-rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/cards/by-rental-object/{rentalObjectCode}': {
     /** Get cards by rental object code */
     get: {
       parameters: {
         query?: {
-          includeLoans?: boolean;
-        };
+          includeLoans?: boolean
+        }
         path: {
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Cards for the rental object */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["CardDetails"][];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/cards/{cardId}": {
+            'application/json': {
+              content?: components['schemas']['CardDetails'][]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/cards/{cardId}': {
     /** Get card by ID */
     get: {
       parameters: {
         path: {
-          cardId: string;
-        };
-      };
+          cardId: string
+        }
+      }
       responses: {
         /** @description Card found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Card"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Card']
+            }
+          }
+        }
         /** @description Card not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/{id}': {
     /** Get key by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Key found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Delete a key */
     delete: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Deleted */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Update a key (partial) */
     patch: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateKeyRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateKeyRequest']
+        }
+      }
       responses: {
         /** @description Updated */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Key"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Key']
+            }
+          }
+        }
         /** @description Invalid key_type */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update': {
     /**
      * Bulk update keys
      * @description Update multiple keys with the same values. Maximum 100 keys per request.
@@ -8575,35 +8648,35 @@ export interface paths {
     patch: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateKeysRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateKeysRequest']
+        }
+      }
       responses: {
         /** @description Keys updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-update-flex": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-update-flex': {
     /**
      * Bulk update flex number for all keys on a rental object
      * @description Update the flex number for all keys associated with a specific rental object code. Flex numbers range from 1-3.
@@ -8611,35 +8684,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["BulkUpdateFlexRequest"];
-        };
-      };
+          'application/json': components['schemas']['BulkUpdateFlexRequest']
+        }
+      }
       responses: {
         /** @description Flex numbers updated successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys updated */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/keys/bulk-delete": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/keys/bulk-delete': {
     /**
      * Bulk delete keys
      * @description Delete multiple keys by their IDs. Maximum 100 keys per request.
@@ -8647,37 +8720,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
-            keyIds: string[];
-          };
-        };
-      };
+          'application/json': {
+            keyIds: string[]
+          }
+        }
+      }
       responses: {
         /** @description Keys deleted successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Number of keys deleted */
-              content?: number;
-            };
-          };
-        };
+              content?: number
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs': {
     /**
      * List logs with pagination
      * @description Returns paginated logs (most recent per objectId) ordered by eventTime (desc).
@@ -8686,60 +8759,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description Paginated list of logs */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /** Create a log */
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateLogRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateLogRequest']
+        }
+      }
       responses: {
         /** @description Created */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Invalid or missing fields */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/search": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/search': {
     /**
      * Search logs with pagination
      * @description Search logs with flexible filtering and pagination.
@@ -8752,46 +8825,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-          q?: string;
+          limit?: number
+          q?: string
           /** @description Comma-separated list of fields for OR search. Defaults to objectId. */
-          fields?: string;
-          id?: string;
-          userName?: string;
-          eventType?: string;
-          eventTime?: string;
-          objectType?: string;
-          objectId?: string;
-          description?: string;
-        };
-      };
+          fields?: string
+          id?: string
+          userName?: string
+          eventType?: string
+          eventTime?: string
+          objectType?: string
+          objectId?: string
+          description?: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Bad request */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/object/{objectId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/object/{objectId}': {
     /**
      * Get all logs for a specific objectId
      * @description Returns all log entries for a given objectId, ordered by most recent first
@@ -8799,60 +8872,60 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          objectId: string;
-        };
-      };
+          objectId: string
+        }
+      }
       responses: {
         /** @description List of logs for the objectId */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/{id}': {
     /** Get log by ID */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Log found */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Log"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Log']
+            }
+          }
+        }
         /** @description Not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/rental-object/{rentalObjectCode}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/rental-object/{rentalObjectCode}': {
     /**
      * Get all logs for a specific rental object
      * @description Returns all log entries for a given rental object code by JOINing across multiple tables.
@@ -8869,40 +8942,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The rental object code (e.g., "705-011-03-0102") */
-          rentalObjectCode: string;
-        };
-      };
+          rentalObjectCode: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the rental object */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/logs/contact/{contactId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/logs/contact/{contactId}': {
     /**
      * Get all logs for a specific contact
      * @description Returns all log entries for a given contact code by JOINing across keyLoans and receipts.
@@ -8919,40 +8992,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
+          limit?: number
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string;
+          eventType?: string
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string;
+          objectType?: string
           /** @description Filter by user name */
-          userName?: string;
-        };
+          userName?: string
+        }
         path: {
           /** @description The contact code (e.g., "P079586", "F123456") */
-          contactId: string;
-        };
-      };
+          contactId: string
+        }
+      }
       responses: {
         /** @description Paginated list of logs for the contact */
         200: {
           content: {
-            "application/json": components["schemas"]["PaginatedResponse"] & {
-              content?: components["schemas"]["Log"][];
-            };
-          };
-        };
+            'application/json': components['schemas']['PaginatedResponse'] & {
+              content?: components['schemas']['Log'][]
+            }
+          }
+        }
         /** @description Server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts': {
     /**
      * Create a receipt
      * @description Create a new receipt record for a key loan
@@ -8960,34 +9033,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['CreateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/{id}': {
     /**
      * Get a receipt by ID
      * @description Retrieve a specific receipt by its ID
@@ -8996,32 +9069,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The receipt ID */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved receipt */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Delete a receipt
      * @description Delete a receipt by ID (and associated file from MinIO)
@@ -9030,28 +9103,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to delete */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Receipt deleted successfully */
         204: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
     /**
      * Update a receipt
      * @description Update a receipt (e.g., set fileId after upload)
@@ -9060,144 +9133,144 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to update */
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": components["schemas"]["UpdateReceiptRequest"];
-        };
-      };
+          'application/json': components['schemas']['UpdateReceiptRequest']
+        }
+      }
       responses: {
         /** @description Receipt updated successfully */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Receipt not found */
         404: {
           content: {
-            "application/json": components["schemas"]["NotFoundResponse"];
-          };
-        };
+            'application/json': components['schemas']['NotFoundResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/receipts/by-key-loan/{keyLoanId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/receipts/by-key-loan/{keyLoanId}': {
     /** Get receipts by key loan ID */
     get: {
       parameters: {
         path: {
-          keyLoanId: string;
-        };
-      };
+          keyLoanId: string
+        }
+      }
       responses: {
         /** @description Receipts for the key loan */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Receipt"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Receipt'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/upload": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/upload': {
     /** Upload a file for a receipt */
     post: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @description Base64 encoded file data */
-            fileData: string;
-            fileContentType?: string;
-          };
-        };
-      };
+            fileData: string
+            fileContentType?: string
+          }
+        }
+      }
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                fileId?: string;
-              };
-            };
-          };
-        };
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Missing fileData */
         400: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Receipt not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/receipts/{id}/download": {
+          content: never
+        }
+      }
+    }
+  }
+  '/receipts/{id}/download': {
     /** Get presigned download URL for a receipt file */
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                url?: string;
-                expiresIn?: number;
-                fileId?: string;
-              };
-            };
-          };
-        };
+                url?: string
+                expiresIn?: number
+                fileId?: string
+              }
+            }
+          }
+        }
         /** @description Receipt or file not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/signatures/send": {
+          content: never
+        }
+      }
+    }
+  }
+  '/signatures/send': {
     /**
      * Send a document for digital signature via SimpleSign
      * @description Send a PDF document to SimpleSign for digital signature
@@ -9205,49 +9278,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /** @enum {string} */
-            resourceType: "receipt";
+            resourceType: 'receipt'
             /** Format: uuid */
-            resourceId: string;
+            resourceId: string
             /** Format: email */
-            recipientEmail: string;
-            recipientName?: string;
-            pdfBase64: string;
-          };
-        };
-      };
+            recipientEmail: string
+            recipientName?: string
+            pdfBase64: string
+          }
+        }
+      }
       responses: {
         /** @description Signature request sent successfully */
         201: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Invalid request data */
         400: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Resource not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/{id}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/{id}': {
     /**
      * Get a signature by ID
      * @description Retrieve a specific signature by its ID
@@ -9255,34 +9328,34 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string;
-        };
-      };
+          id: string
+        }
+      }
       responses: {
         /** @description Signature details */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature']
+            }
+          }
+        }
         /** @description Signature not found */
         404: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/signatures/resource/{resourceType}/{resourceId}": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/signatures/resource/{resourceType}/{resourceId}': {
     /**
      * Get all signatures for a resource
      * @description Retrieve all signatures associated with a specific resource
@@ -9290,29 +9363,29 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          resourceType: "receipt";
-          resourceId: string;
-        };
-      };
+          resourceType: 'receipt'
+          resourceId: string
+        }
+      }
       responses: {
         /** @description List of signatures */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["Signature"][];
-            };
-          };
-        };
+            'application/json': {
+              content?: components['schemas']['Signature'][]
+            }
+          }
+        }
         /** @description Internal server error */
         500: {
           content: {
-            "application/json": components["schemas"]["ErrorResponse"];
-          };
-        };
-      };
-    };
-  };
-  "/webhooks/simplesign": {
+            'application/json': components['schemas']['ErrorResponse']
+          }
+        }
+      }
+    }
+  }
+  '/webhooks/simplesign': {
     /**
      * Webhook endpoint for SimpleSign status updates
      * @description Receives webhook notifications from SimpleSign when document status changes (e.g., signed, declined)
@@ -9320,26 +9393,26 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["SimpleSignWebhookPayload"];
-        };
-      };
+          'application/json': components['schemas']['SimpleSignWebhookPayload']
+        }
+      }
       responses: {
         /** @description Webhook processed successfully */
         200: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Signature not found */
         404: {
-          content: never;
-        };
+          content: never
+        }
         /** @description Internal server error */
         500: {
-          content: never;
-        };
-      };
-    };
-  };
-  "/v1/contacts": {
+          content: never
+        }
+      }
+    }
+  }
+  '/v1/contacts': {
     /**
      * List and filter(search) for contact information
      * @description Filtering can be done by wildcard search
@@ -9348,55 +9421,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Wildcard search string */
-          q?: string[];
+          q?: string[]
           /** @description Filter on contact type */
-          type?: "individual" | "organisation";
+          type?: 'individual' | 'organisation'
           /** @description Page number for paginated results (1-based) */
-          page?: number;
+          page?: number
           /** @description Number of records per page */
-          limit?: number;
-        };
-      };
+          limit?: number
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              content: components["schemas"]["ContactV1"][];
+            'application/json': {
+              content: components['schemas']['ContactV1'][]
               _meta: {
-                totalRecords: number;
-                page: number;
-                limit: number;
-                count: number;
-              };
-              _links: ({
-                  href: string;
-                  /** @enum {string} */
-                  rel: "self" | "first" | "last" | "prev" | "next";
-                })[];
-            };
-          };
-        };
+                totalRecords: number
+                page: number
+                limit: number
+                count: number
+              }
+              _links: {
+                href: string
+                /** @enum {string} */
+                rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+              }[]
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
         /** @description Internal Server Error */
         500: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/batch": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/batch': {
     /**
      * Batch lookup of contacts by contact code
      * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, or `includeAddress` to include those joins. Missing contact codes are simply absent from the response.
@@ -9405,2848 +9478,3014 @@ export interface paths {
       parameters: {
         query: {
           /** @description Contact code(s) to look up. Repeat the parameter for multiple codes, e.g. ?code=P123&code=P456. */
-          code: string[];
+          code: string[]
           /** @description Include phone numbers in the response. */
-          includePhone?: boolean;
+          includePhone?: boolean
           /** @description Include email addresses in the response. */
-          includeEmail?: boolean;
+          includeEmail?: boolean
           /** @description Include addresses in the response. */
-          includeAddress?: boolean;
-        };
-      };
+          includeAddress?: boolean
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"][];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1'][]
+            }
+          }
+        }
         /** @description Internal Server Error */
         500: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}': {
     /** Get a single contact by canonical id (contact code) */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/{contactCode}/trustee": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/{contactCode}/trustee': {
     /** Get the trustee of a contact */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-phone-number/{phoneNumber}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-phone-number/{phoneNumber}': {
     /** List contacts by phone number */
     get: {
       parameters: {
         path: {
           /** @description Phone Number */
-          phoneNumber: string;
-        };
-      };
+          phoneNumber: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-email-address/{emailAddress}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-email-address/{emailAddress}': {
     /** List contacts by email address */
     get: {
       parameters: {
         path: {
           /** @description Email Address */
-          emailAddress: string;
-        };
-      };
+          emailAddress: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/v1/contacts/by-national-id/{nid}": {
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
+  '/v1/contacts/by-national-id/{nid}': {
     /** List contacts by national id (Personnummer / Org.nr) */
     get: {
       parameters: {
         path: {
           /** @description National ID */
-          nid: string;
-        };
-      };
+          nid: string
+        }
+      }
       responses: {
         /** @description OK */
         200: {
           content: {
-            "application/json": {
-              _links?: unknown;
-              content: components["schemas"]["ContactV1"];
-            };
-          };
-        };
+            'application/json': {
+              _links?: unknown
+              content: components['schemas']['ContactV1']
+            }
+          }
+        }
         /** @description Not Found */
         404: {
           content: {
-            "application/json": {
-              _links?: unknown;
-            };
-          };
-        };
-      };
-    };
-  };
+            'application/json': {
+              _links?: unknown
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
     Lease: {
-      leaseId: string;
-      leaseNumber: string;
+      leaseId: string
+      leaseNumber: string
       /** Format: date-time */
-      leaseStartDate: string;
+      leaseStartDate: string
       /** Format: date-time */
-      leaseEndDate?: string;
+      leaseEndDate?: string
       /** @enum {string} */
-      status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-      tenantContactIds?: string[];
-      rentalPropertyId: string;
+      status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+      tenantContactIds?: string[]
+      rentalPropertyId: string
       rentalProperty?: {
-        rentalPropertyId: string;
-        apartmentNumber: number;
-        size: number;
-        type: string;
+        rentalPropertyId: string
+        apartmentNumber: number
+        size: number
+        type: string
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        rentalPropertyType: string;
-        additionsIncludedInRent: string;
-        otherInfo?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        rentalPropertyType: string
+        additionsIncludedInRent: string
+        otherInfo?: string
         roomTypes?: {
-            roomTypeId: string;
-            name: string;
-          }[];
+          roomTypeId: string
+          name: string
+        }[]
         /** Format: date-time */
-        lastUpdated?: string;
-      };
-      type: string;
+        lastUpdated?: string
+      }
+      type: string
       rentInfo?: {
         currentRent: {
-          rentId?: string;
-          leaseId?: string;
-          currentRent: number;
-          vat: number;
-          additionalChargeDescription?: string;
-          additionalChargeAmount?: number;
+          rentId?: string
+          leaseId?: string
+          currentRent: number
+          vat: number
+          additionalChargeDescription?: string
+          additionalChargeAmount?: number
           /** Format: date-time */
-          rentStartDate?: string;
+          rentStartDate?: string
           /** Format: date-time */
-          rentEndDate?: string;
-        };
-      };
+          rentEndDate?: string
+        }
+      }
       address?: {
-        street?: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      };
-      noticeGivenBy?: string;
+        street?: string
+        number: string
+        postalCode: string
+        city: string
+      }
+      noticeGivenBy?: string
       /** Format: date-time */
-      noticeDate?: string;
-      noticeTimeTenant?: string | number;
+      noticeDate?: string
+      noticeTimeTenant?: string | number
       /** Format: date-time */
-      preferredMoveOutDate?: string;
+      preferredMoveOutDate?: string
       /** Format: date-time */
-      terminationDate?: string;
+      terminationDate?: string
       /** Format: date-time */
-      contractDate?: string;
+      contractDate?: string
       /** Format: date-time */
-      lastDebitDate?: string;
+      lastDebitDate?: string
       /** Format: date-time */
-      approvalDate?: string;
+      approvalDate?: string
       residentialArea?: {
-        code: string;
-        caption: string;
-      };
+        code: string
+        caption: string
+      }
       tenants?: {
-          contactCode: string;
-          contactKey: string;
-          leaseIds?: string[];
-          firstName: string;
-          lastName: string;
-          fullName: string;
-          nationalRegistrationNumber: string;
+        contactCode: string
+        contactKey: string
+        leaseIds?: string[]
+        firstName: string
+        lastName: string
+        fullName: string
+        nationalRegistrationNumber: string
+        /** Format: date-time */
+        birthDate: string
+        address?: {
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        phoneNumbers?: {
+          phoneNumber: string
+          type: string
+          isMainNumber: boolean
+        }[]
+        emailAddress?: string
+        isTenant: boolean
+        parkingSpaceWaitingList?: {
           /** Format: date-time */
-          birthDate: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          phoneNumbers?: {
-              phoneNumber: string;
-              type: string;
-              isMainNumber: boolean;
-            }[];
-          emailAddress?: string;
-          isTenant: boolean;
-          parkingSpaceWaitingList?: {
-            /** Format: date-time */
-            queueTime: string;
-            queuePoints: number;
-            type: number;
-          };
-          specialAttention?: boolean;
-          leaseContactType?: string;
-        }[];
-    };
+          queueTime: string
+          queuePoints: number
+          type: number
+        }
+        specialAttention?: boolean
+        leaseContactType?: string
+      }[]
+    }
     IdentityCheckContact: {
-      contactCode: string;
-      nationalRegistrationNumber: string;
-    };
+      contactCode: string
+      nationalRegistrationNumber: string
+    }
     LeaseSearchResult: {
-      leaseId: string;
-      objectTypeCode: string;
-      leaseType: string;
-      contacts: ({
-          name: string;
-          contactCode: string;
-          email: string | null;
-          phone: string | null;
-        })[];
-      address: string | null;
+      leaseId: string
+      objectTypeCode: string
+      leaseType: string
+      contacts: {
+        name: string
+        contactCode: string
+        email: string | null
+        phone: string | null
+      }[]
+      address: string | null
       /** Format: date-time */
-      startDate: string | null;
+      startDate: string | null
       /** Format: date-time */
-      lastDebitDate: string | null;
+      lastDebitDate: string | null
       /** @enum {number} */
-      status: 0 | 1 | 2 | 3;
-      rentalObjectCode: string | null;
-      property?: string | null;
-      buildingCode?: string | null;
-      area?: string | null;
-      buildingManager?: string | null;
-      districtName?: string | null;
-      parkingSpaceType?: string | null;
-    };
+      status: 0 | 1 | 2 | 3
+      rentalObjectCode: string | null
+      property?: string | null
+      buildingCode?: string | null
+      area?: string | null
+      buildingManager?: string | null
+      districtName?: string | null
+      parkingSpaceType?: string | null
+    }
     ContactInfo: {
-      name: string;
-      contactCode: string;
-      email: string | null;
-      phone: string | null;
-    };
+      name: string
+      contactCode: string
+      email: string | null
+      phone: string | null
+    }
     PaginationMeta: {
-      totalRecords: number;
-      page: number;
-      limit: number;
-      count: number;
-    };
+      totalRecords: number
+      page: number
+      limit: number
+      count: number
+    }
     PaginationLinks: {
-      href: string;
+      href: string
       /** @enum {string} */
-      rel: "self" | "first" | "last" | "prev" | "next";
-    };
+      rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+    }
     Contact: {
-      contactCode: string;
-      contactKey: string;
-      leaseIds?: string[];
-      firstName: string | null;
-      lastName: string | null;
-      fullName: string | null;
-      nationalRegistrationNumber: string;
+      contactCode: string
+      contactKey: string
+      leaseIds?: string[]
+      firstName: string | null
+      lastName: string | null
+      fullName: string | null
+      nationalRegistrationNumber: string
       /** Format: date-time */
-      birthDate: string | null;
+      birthDate: string | null
       address: {
-        street: string;
-        number: string;
-        postalCode: string;
-        city: string;
-      } | null;
+        street: string
+        number: string
+        postalCode: string
+        city: string
+      } | null
       phoneNumbers: {
-          phoneNumber: string;
-          type: string;
-          isMainNumber: boolean;
-        }[];
-      emailAddress: string | null;
-      isTenant: boolean;
-      specialAttention?: boolean;
-    };
+        phoneNumber: string
+        type: string
+        isMainNumber: boolean
+      }[]
+      emailAddress: string | null
+      isTenant: boolean
+      specialAttention?: boolean
+    }
     ListingTextContent: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
+      id: string
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     CreateListingTextContentRequest: {
-      rentalObjectCode: string;
-      contentBlocks: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      rentalObjectCode: string
+      contentBlocks: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     UpdateListingTextContentRequest: {
-      contentBlocks?: ({
-          /** @enum {string} */
-          type: "preamble";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "headline";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "subtitle";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bullet_list";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "bold_text";
-          content: string;
-        } | {
-          /** @enum {string} */
-          type: "link";
-          name: string;
-          /** Format: uri */
-          url: string;
-        })[];
-    };
+      contentBlocks?: (
+        | {
+            /** @enum {string} */
+            type: 'preamble'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'headline'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'subtitle'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bullet_list'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'bold_text'
+            content: string
+          }
+        | {
+            /** @enum {string} */
+            type: 'link'
+            name: string
+            /** Format: uri */
+            url: string
+          }
+      )[]
+    }
     WorkOrder: {
-      accessCaption: string;
-      caption: string;
-      code: string;
-      contactCode: string;
-      description: string;
-      detailsCaption: string;
-      externalResource: boolean;
-      id: string;
+      accessCaption: string
+      caption: string
+      code: string
+      contactCode: string
+      description: string
+      detailsCaption: string
+      externalResource: boolean
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string;
+      lastChanged: string
+      priority: string
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-      hiddenFromMyPages?: boolean;
-      workOrderRows: ({
-          description: string | null;
-          locationCode: string | null;
-          equipmentCode: string | null;
-        })[];
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+      hiddenFromMyPages?: boolean
+      workOrderRows: {
+        description: string | null
+        locationCode: string | null
+        equipmentCode: string | null
+      }[]
       messages?: {
-          id: number;
-          body: string;
-          messageType: string;
-          author: string;
-          /** Format: date-time */
-          createDate: string;
-        }[];
-      url?: string;
-    };
+        id: number
+        body: string
+        messageType: string
+        author: string
+        /** Format: date-time */
+        createDate: string
+      }[]
+      url?: string
+    }
     XpandWorkOrder: {
-      accessCaption: string;
-      caption: string | null;
-      code: string;
-      contactCode: string | null;
-      id: string;
+      accessCaption: string
+      caption: string | null
+      code: string
+      contactCode: string | null
+      id: string
       /** Format: date-time */
-      lastChanged: string;
-      priority: string | null;
+      lastChanged: string
+      priority: string | null
       /** Format: date-time */
-      registered: string;
-      dueDate: ("null" | null) | string;
-      rentalObjectCode: string;
-      status: string;
-    };
+      registered: string
+      dueDate: ('null' | null) | string
+      rentalObjectCode: string
+      status: string
+    }
+    MaintenanceTeam: {
+      id: number
+      name: string
+    }
+    CreateInspectionWorkOrdersRequest: {
+      rentalObjectCode: string
+      groups: {
+        maintenanceTeamId: number
+        maintenanceTeamName: string
+        descriptionHtml: string
+      }[]
+    }
+    CreateInspectionWorkOrdersResponse: {
+      results: {
+        maintenanceTeamId: number
+        ok: boolean
+        workOrderId?: number
+        err?: string
+      }[]
+    }
     Building: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       buildingType: {
-        id: string | null;
-        code: string | null;
-        name: string | null;
-      };
+        id: string | null
+        code: string | null
+        name: string | null
+      }
       construction: {
-        constructionYear: number | null;
-        renovationYear: number | null;
-        valueYear: number | null;
-      };
+        constructionYear: number | null
+        renovationYear: number | null
+        valueYear: number | null
+      }
       features: {
-        heating?: string | null;
-        fireRating?: string | null;
-      };
+        heating?: string | null
+        fireRating?: string | null
+      }
       insurance: {
-        class: string | null;
-        value: number | null;
-      };
-      quantityValues?: ({
-          id: string;
-          value: number;
-          name: string;
-          unitId: string | null;
-        })[];
-      deleted: boolean;
-      property?: ({
-        name: string | null;
-        code: string;
-        id: string;
-      }) | null;
-    };
+        class: string | null
+        value: number | null
+      }
+      quantityValues?: {
+        id: string
+        value: number
+        name: string
+        unitId: string | null
+      }[]
+      deleted: boolean
+      property?: {
+        name: string | null
+        code: string
+        id: string
+      } | null
+    }
     Company: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+    }
     CompanyDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string;
-      organizationNumber: string | null;
-      phone: string | null;
-      fax: string | null;
-      vatNumber?: string | null;
-      internalExternal: number;
-      fTax: number;
-      cooperativeHousingAssociation: number;
-      differentiatedAdditionalCapital: number;
-      rentAdministered: number;
-      blocked: number;
-      rentDaysPerMonth: number;
-      economicPlanApproved: number;
-      vatObligationPercent: number;
-      vatRegistered: number;
-      energyOptimization: number;
-      ownedCompany: number;
-      interestInvoice: number;
-      errorReportAdministration: number;
-      mediaBilling: number;
-      ownResponsibilityForInternalMaintenance: number;
-      subletPercentage: number;
-      subletFeeAmount: number;
-      disableQuantitiesBelowCompany: number;
-      timestamp: string;
-    };
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string
+      organizationNumber: string | null
+      phone: string | null
+      fax: string | null
+      vatNumber?: string | null
+      internalExternal: number
+      fTax: number
+      cooperativeHousingAssociation: number
+      differentiatedAdditionalCapital: number
+      rentAdministered: number
+      blocked: number
+      rentDaysPerMonth: number
+      economicPlanApproved: number
+      vatObligationPercent: number
+      vatRegistered: number
+      energyOptimization: number
+      ownedCompany: number
+      interestInvoice: number
+      errorReportAdministration: number
+      mediaBilling: number
+      ownResponsibilityForInternalMaintenance: number
+      subletPercentage: number
+      subletFeeAmount: number
+      disableQuantitiesBelowCompany: number
+      timestamp: string
+    }
     Property: {
-      id: string;
-      propertyObjectId: string;
-      marketAreaId: string | null;
-      districtId: string | null;
-      propertyDesignationId: string | null;
-      valueAreaId: string | null;
-      code: string;
-      designation: string;
-      municipality: string;
-      tract: string;
-      block: string;
-      sector: string | null;
-      propertyIndexNumber: string | null;
-      congregation: string | null;
-      builtStatus: number;
-      separateAssessmentUnit: number;
-      consolidationNumber: string | null;
-      ownershipType: string;
-      registrationDate: string | null;
-      acquisitionDate: string | null;
-      isLeasehold: number;
-      leaseholdTerminationDate: string | null;
-      area: string | null;
-      purpose: string | null;
-      buildingType: string | null;
-      propertyTaxNumber: string | null;
-      mainPartAssessedValue: number;
-      includeInAssessedValue: number;
-      grading: number;
-      deleteMark: number;
+      id: string
+      propertyObjectId: string
+      marketAreaId: string | null
+      districtId: string | null
+      propertyDesignationId: string | null
+      valueAreaId: string | null
+      code: string
+      designation: string
+      municipality: string
+      tract: string
+      block: string
+      sector: string | null
+      propertyIndexNumber: string | null
+      congregation: string | null
+      builtStatus: number
+      separateAssessmentUnit: number
+      consolidationNumber: string | null
+      ownershipType: string
+      registrationDate: string | null
+      acquisitionDate: string | null
+      isLeasehold: number
+      leaseholdTerminationDate: string | null
+      area: string | null
+      purpose: string | null
+      buildingType: string | null
+      propertyTaxNumber: string | null
+      mainPartAssessedValue: number
+      includeInAssessedValue: number
+      grading: number
+      deleteMark: number
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string;
-      timestamp: string;
-    };
+      toDate: string
+      timestamp: string
+    }
     Residence: {
-      id: string;
-      code: string;
-      name: string;
-      deleted: boolean;
+      id: string
+      code: string
+      name: string
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
-    };
+        toDate: string
+      }
+    }
     ResidenceDetails: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       /** @enum {string|null} */
-      status: "VACANT" | "LEASED" | null;
-      entrance: string | null;
-      location: string | null;
-      floor: string | null;
-      partNo: number | null;
-      part: string | null;
-      deleted: boolean;
+      status: 'VACANT' | 'LEASED' | null
+      entrance: string | null
+      location: string | null
+      floor: string | null
+      partNo: number | null
+      part: string | null
+      deleted: boolean
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string;
+        fromDate: string
         /** Format: date-time */
-        toDate: string;
-      };
+        toDate: string
+      }
       accessibility: {
-        wheelchairAccessible: boolean;
-        elevator: boolean;
-        residenceAdapted: boolean;
-      };
+        wheelchairAccessible: boolean
+        elevator: boolean
+        residenceAdapted: boolean
+      }
       features: {
-        hygieneFacility: string | null;
+        hygieneFacility: string | null
         balcony1?: {
-          location: string;
-          type: string;
-        };
+          location: string
+          type: string
+        }
         balcony2?: {
-          location: string;
-          type: string;
-        };
-        patioLocation: string | null;
-        sauna: boolean;
-        extraToilet: boolean;
-        sharedKitchen: boolean;
-        petAllergyFree: boolean;
+          location: string
+          type: string
+        }
+        patioLocation: string | null
+        sauna: boolean
+        extraToilet: boolean
+        sharedKitchen: boolean
+        petAllergyFree: boolean
         /** @description Is the apartment checked for electric allergy intolerance? */
-        electricAllergyIntolerance: boolean;
-        smokeFree: boolean;
-        asbestos: boolean;
-      };
+        electricAllergyIntolerance: boolean
+        smokeFree: boolean
+        asbestos: boolean
+      }
       type: {
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-      };
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+      }
       residenceType: {
-        residenceTypeId: string;
-        code: string;
-        name: string | null;
-        roomCount: number | null;
-        kitchen: number;
-        systemStandard: number;
-        checklistId: string | null;
-        componentTypeActionId: string | null;
-        statisticsGroupSCBId: string | null;
-        statisticsGroup2Id: string | null;
-        statisticsGroup3Id: string | null;
-        statisticsGroup4Id: string | null;
-        timestamp: string;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        residenceTypeId: string
+        code: string
+        name: string | null
+        roomCount: number | null
+        kitchen: number
+        systemStandard: number
+        checklistId: string | null
+        componentTypeActionId: string | null
+        statisticsGroupSCBId: string | null
+        statisticsGroup2Id: string | null
+        statisticsGroup3Id: string | null
+        statisticsGroup4Id: string | null
+        timestamp: string
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       propertyObject: {
         energy: {
-          energyClass: number;
+          energyClass: number
           /** Format: date-time */
-          energyRegistered?: string;
+          energyRegistered?: string
           /** Format: date-time */
-          energyReceived?: string;
-          energyIndex?: number;
-        };
-        rentalId: string | null;
-        rentalInformation: ({
+          energyReceived?: string
+          energyIndex?: number
+        }
+        rentalId: string | null
+        rentalInformation: {
           type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
-        rentalBlocks: ({
-            id: string;
-            blockReasonId: string | null;
-            blockReason: string | null;
-            /** Format: date-time */
-            fromDate: string;
-            /** Format: date-time */
-            toDate: string | null;
-            amount: number | null;
-          })[];
-      };
+            code: string
+            name: string | null
+          }
+        } | null
+        rentalBlocks: {
+          id: string
+          blockReasonId: string | null
+          blockReason: string | null
+          /** Format: date-time */
+          fromDate: string
+          /** Format: date-time */
+          toDate: string | null
+          amount: number | null
+        }[]
+      }
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      staircase: ({
-        id: string;
-        code: string;
-        name: string | null;
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      staircase: {
+        id: string
+        code: string
+        name: string | null
         features: {
-          floorPlan: string | null;
-          accessibleByElevator: boolean;
-        };
+          floorPlan: string | null
+          accessibleByElevator: boolean
+        }
         dates: {
           /** Format: date-time */
-          from: string;
+          from: string
           /** Format: date-time */
-          to: string;
-        };
+          to: string
+        }
         property?: {
-          propertyId: string | null;
-          propertyName: string | null;
-          propertyCode: string | null;
-        };
+          propertyId: string | null
+          propertyName: string | null
+          propertyCode: string | null
+        }
         building?: {
-          buildingId: string | null;
-          buildingName: string | null;
-          buildingCode: string | null;
-        };
-        deleted: boolean;
-        timestamp: string;
-      }) | null;
-      areaSize: number | null;
-      malarEnergiFacilityId: string | null;
-    };
+          buildingId: string | null
+          buildingName: string | null
+          buildingCode: string | null
+        }
+        deleted: boolean
+        timestamp: string
+      } | null
+      areaSize: number | null
+      malarEnergiFacilityId: string | null
+    }
     ResidenceSummary: {
-      id: string;
-      code: string;
-      name: string | null;
-      deleted: boolean;
-      rentalId: string;
-      buildingCode: string;
-      buildingName: string;
-      staircaseCode: string;
-      staircaseName: string;
-      elevator: number | null;
-      floor: string;
-      hygieneFacility: string | null;
-      wheelchairAccessible: number;
+      id: string
+      code: string
+      name: string | null
+      deleted: boolean
+      rentalId: string
+      buildingCode: string
+      buildingName: string
+      staircaseCode: string
+      staircaseName: string
+      elevator: number | null
+      floor: string
+      hygieneFacility: string | null
+      wheelchairAccessible: number
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string | null;
+        fromDate: string | null
         /** Format: date-time */
-        toDate: string | null;
-      };
+        toDate: string | null
+      }
       residenceType: {
-        code: string;
-        name: string;
-        roomCount: number;
-        kitchen: number;
-      };
-      quantityValues: ({
-          value: number;
-          quantityTypeId: string;
-          quantityType: {
-            name: string;
-            unitId: string | null;
-          };
-        })[];
-    };
+        code: string
+        name: string
+        roomCount: number
+        kitchen: number
+      }
+      quantityValues: {
+        value: number
+        quantityTypeId: string
+        quantityType: {
+          name: string
+          unitId: string | null
+        }
+      }[]
+    }
     Staircase: {
-      id: string;
-      code: string;
-      name: string | null;
+      id: string
+      code: string
+      name: string | null
       features: {
-        floorPlan: string | null;
-        accessibleByElevator: boolean;
-      };
+        floorPlan: string | null
+        accessibleByElevator: boolean
+      }
       dates: {
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
-      };
+        to: string
+      }
       property?: {
-        propertyId: string | null;
-        propertyName: string | null;
-        propertyCode: string | null;
-      };
+        propertyId: string | null
+        propertyName: string | null
+        propertyCode: string | null
+      }
       building?: {
-        buildingId: string | null;
-        buildingName: string | null;
-        buildingCode: string | null;
-      };
-      deleted: boolean;
-      timestamp: string;
-    };
+        buildingId: string | null
+        buildingName: string | null
+        buildingCode: string | null
+      }
+      deleted: boolean
+      timestamp: string
+    }
     Room: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
       usage: {
-        shared: boolean;
-        allowPeriodicWorks: boolean;
-        spaceType: number;
-      };
+        shared: boolean
+        allowPeriodicWorks: boolean
+        spaceType: number
+      }
       features: {
-        hasToilet: boolean;
-        isHeated: boolean;
-        hasThermostatValve: boolean;
-        orientation: number;
-      };
+        hasToilet: boolean
+        isHeated: boolean
+        hasThermostatValve: boolean
+        orientation: number
+      }
       dates: {
         /** Format: date-time */
-        installation: string | null;
+        installation: string | null
         /** Format: date-time */
-        from: string;
+        from: string
         /** Format: date-time */
-        to: string;
+        to: string
         /** Format: date-time */
-        availableFrom: string | null;
+        availableFrom: string | null
         /** Format: date-time */
-        availableTo: string | null;
-      };
-      sortingOrder: number;
-      deleted: boolean;
-      timestamp: string;
-      roomType: ({
-        id: string;
-        code: string;
-        name: string | null;
-        use: number;
-        optionAllowed: number;
-        isSystemStandard: number;
-        allowSmallRoomsInValuation: number;
-        timestamp: string;
-      }) | null;
-      area?: number;
-    };
+        availableTo: string | null
+      }
+      sortingOrder: number
+      deleted: boolean
+      timestamp: string
+      roomType: {
+        id: string
+        code: string
+        name: string | null
+        use: number
+        optionAllowed: number
+        isSystemStandard: number
+        allowSmallRoomsInValuation: number
+        timestamp: string
+      } | null
+      area?: number
+    }
     CreateRoomRequest: {
-      rentalId: string;
+      rentalId: string
       /** @enum {string} */
-      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
-      code?: string;
-      caption?: string;
+      roomTypeCode:
+        | 'BAD'
+        | 'BAL'
+        | 'BRS'
+        | 'DUSCH'
+        | 'FÖR'
+        | 'GROV'
+        | 'HALL'
+        | 'KLÄD'
+        | 'KÖK'
+        | 'KOV'
+        | 'KV'
+        | 'MAT'
+        | 'PA'
+        | 'RUM'
+        | 'TRAPP'
+        | 'UP'
+        | 'VARD'
+        | 'WC'
+        | 'WC/DU1'
+      code?: string
+      caption?: string
       features?: {
-        hasToilet?: boolean;
-        isHeated?: boolean;
-        hasThermostatValve?: boolean;
-        orientation?: number;
-      };
+        hasToilet?: boolean
+        isHeated?: boolean
+        hasThermostatValve?: boolean
+        orientation?: number
+      }
       usage?: {
-        shared?: boolean;
-        allowPeriodicWorks?: boolean;
-        spaceType?: number;
-      };
-    };
+        shared?: boolean
+        allowPeriodicWorks?: boolean
+        spaceType?: number
+      }
+    }
     ParkingSpace: {
-      rentalId: string;
-      companyCode: string;
-      companyName: string;
-      managementUnitCode: string;
-      managementUnitName: string;
-      propertyCode: string;
-      propertyName: string;
-      buildingCode: string | null;
-      buildingName: string | null;
+      rentalId: string
+      companyCode: string
+      companyName: string
+      managementUnitCode: string
+      managementUnitName: string
+      propertyCode: string
+      propertyName: string
+      buildingCode: string | null
+      buildingName: string | null
       parkingSpace: {
-        propertyObjectId: string;
-        code: string;
-        name: string;
-        parkingNumber: string;
+        propertyObjectId: string
+        code: string
+        name: string
+        parkingNumber: string
         parkingSpaceType: {
-          code: string;
-          name: string;
-        };
-      };
+          code: string
+          name: string
+        }
+      }
       address: {
-        streetAddress: string | null;
-        streetAddress2: string | null;
-        postalCode: string | null;
-        city: string | null;
-      };
-    };
+        streetAddress: string | null
+        streetAddress2: string | null
+        postalCode: string | null
+        city: string | null
+      }
+    }
     MaintenanceUnit: {
-      id: string;
-      propertyObjectId: string;
-      rentalPropertyId?: string;
-      code: string;
-      caption: string | null;
-      type?: string | null;
-      estateCode: string | null;
-      estate: string | null;
-    };
+      id: string
+      propertyObjectId: string
+      rentalPropertyId?: string
+      code: string
+      caption: string | null
+      type?: string | null
+      estateCode: string | null
+      estate: string | null
+    }
     FacilityDetails: {
-      id: string;
-      propertyObjectId: string;
-      code: string;
-      name: string | null;
-      entrance: string | null;
-      deleted: boolean;
+      id: string
+      propertyObjectId: string
+      code: string
+      name: string | null
+      entrance: string | null
+      deleted: boolean
       type: {
-        code: string;
-        name: string | null;
-      };
-      rentalInformation: ({
-        apartmentNumber: string | null;
-        rentalId: string | null;
+        code: string
+        name: string | null
+      }
+      rentalInformation: {
+        apartmentNumber: string | null
+        rentalId: string | null
         type: {
-          code: string;
-          name: string | null;
-        };
-      }) | null;
+          code: string
+          name: string | null
+        }
+      } | null
       property: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
       building: {
-        id: string | null;
-        name: string | null;
-        code: string | null;
-      };
-      areaSize: number | null;
-    };
+        id: string | null
+        name: string | null
+        code: string | null
+      }
+      areaSize: number | null
+    }
     RentalBlock: {
-      id: string;
-      blockReasonId: string;
-      blockReason: string;
+      id: string
+      blockReasonId: string
+      blockReason: string
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-    };
+      toDate: string | null
+      amount: number | null
+    }
     RentalBlockWithRentalObject: {
-      id: string;
-      blockReasonId: string | null;
-      blockReason: string | null;
+      id: string
+      blockReasonId: string | null
+      blockReason: string | null
       /** Format: date-time */
-      fromDate: string;
+      fromDate: string
       /** Format: date-time */
-      toDate: string | null;
-      amount: number | null;
-      distrikt: string | null;
+      toDate: string | null
+      amount: number | null
+      distrikt: string | null
       rentalObject: {
-        code: string | null;
-        name: string | null;
+        code: string | null
+        name: string | null
         /** @enum {string} */
-        category: "Bostad" | "Bilplats" | "Lokal" | "Förråd" | "Övrigt";
-        address: string | null;
-        rentalId: string | null;
-        residenceId: string | null;
-        yearlyRent: number;
-        type: string | null;
-      };
+        category: 'Bostad' | 'Bilplats' | 'Lokal' | 'Förråd' | 'Övrigt'
+        address: string | null
+        rentalId: string | null
+        residenceId: string | null
+        yearlyRent: number
+        type: string | null
+      }
       building: {
-        code: string | null;
-        name: string | null;
-      };
+        code: string | null
+        name: string | null
+      }
       property: {
-        code: string | null;
-        name: string | null;
-      };
-    };
+        code: string | null
+        name: string | null
+      }
+    }
     FacilitySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a facility result
        * @enum {string}
        */
-      type: "facility";
+      type: 'facility'
       /** @description Name of the facility */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the facility */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the facility */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the facility */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ResidenceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a residence result
        * @enum {string}
        */
-      type: "residence";
+      type: 'residence'
       /** @description Name of the residence */
-      name: string | null;
+      name: string | null
       /** @description Rental object ID of the residence */
-      rentalId: string | null;
+      rentalId: string | null
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the residence */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     ParkingSpaceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a parking space result
        * @enum {string}
        */
-      type: "parking-space";
+      type: 'parking-space'
       /** @description Name of the parking space */
-      name: string | null;
+      name: string | null
       /** @description Rental ID of the parking space */
-      rentalId: string;
+      rentalId: string
       /** @description Code of the parking space */
-      code: string;
+      code: string
       property: {
-        code: string | null;
+        code: string | null
         /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string | null;
+        code: string | null
         /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     Component: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      modelId: string;
-      serialNumber: string | null;
-      specifications?: string | null;
-      additionalInformation?: string | null;
-      warrantyStartDate: string | null;
-      warrantyMonths: number;
-      priceAtPurchase: number;
-      depreciationPriceAtPurchase: number;
-      ncsCode?: string | null;
+      modelId: string
+      serialNumber: string | null
+      specifications?: string | null
+      additionalInformation?: string | null
+      warrantyStartDate: string | null
+      warrantyMonths: number
+      priceAtPurchase: number
+      depreciationPriceAtPurchase: number
+      ncsCode?: string | null
       /** @enum {string} */
-      status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      lastInspectionDate?: string | null;
-      quantity: number;
-      economicLifespan: number;
-      createdAt: string;
-      updatedAt: string;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      lastInspectionDate?: string | null
+      quantity: number
+      economicLifespan: number
+      createdAt: string
+      updatedAt: string
       model?: {
         /** Format: uuid */
-        id: string;
-        modelName: string;
+        id: string
+        modelName: string
         /** Format: uuid */
-        componentSubtypeId: string;
-        currentPrice: number;
-        currentInstallPrice: number;
-        warrantyMonths: number;
-        manufacturer: string;
-        technicalSpecification: string | null;
-        installationInstructions: string | null;
-        dimensions: string | null;
-        coclassCode: string | null;
-        createdAt: string;
-        updatedAt: string;
+        componentSubtypeId: string
+        currentPrice: number
+        currentInstallPrice: number
+        warrantyMonths: number
+        manufacturer: string
+        technicalSpecification: string | null
+        installationInstructions: string | null
+        dimensions: string | null
+        coclassCode: string | null
+        createdAt: string
+        updatedAt: string
         subtype?: {
           /** Format: uuid */
-          id: string;
-          subTypeName: string;
+          id: string
+          subTypeName: string
           /** Format: uuid */
-          typeId: string;
-          xpandCode: string | null;
-          depreciationPrice: number;
-          technicalLifespan: number;
-          economicLifespan: number;
-          replacementIntervalMonths: number;
+          typeId: string
+          xpandCode: string | null
+          depreciationPrice: number
+          technicalLifespan: number
+          economicLifespan: number
+          replacementIntervalMonths: number
           /** @enum {string} */
-          quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-          createdAt: string;
-          updatedAt: string;
+          quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+          createdAt: string
+          updatedAt: string
           componentType?: {
             /** Format: uuid */
-            id: string;
-            typeName: string;
+            id: string
+            typeName: string
             /** Format: uuid */
-            categoryId: string;
-            description: string | null;
-            createdAt: string;
-            updatedAt: string;
+            categoryId: string
+            description: string | null
+            createdAt: string
+            updatedAt: string
             category?: {
               /** Format: uuid */
-              id: string;
-              categoryName: string;
-              description: string;
-              createdAt: string;
-              updatedAt: string;
-            };
-          };
-        };
-      };
-      componentInstallations?: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          componentId: string;
-          spaceId: string | null;
-          /** @enum {string} */
-          spaceType: "OBJECT" | "PropertyObject";
-          installationDate: string | null;
-          deinstallationDate: string | null;
-          orderNumber?: string | null;
-          cost: number;
-          createdAt: string;
-          updatedAt: string;
-          propertyObject?: ({
-            id: string;
-            propertyStructures?: ({
-                roomId?: string | null;
-                roomCode?: string | null;
-                roomName?: string | null;
-                residenceId?: string | null;
-                residenceCode?: string | null;
-                residenceName?: string | null;
-                rentalId?: string | null;
-                buildingCode?: string | null;
-                buildingName?: string | null;
-                residence?: {
-                  id: string;
-                } | null;
-              })[];
-          }) | null;
-        })[];
-    };
+              id: string
+              categoryName: string
+              description: string
+              createdAt: string
+              updatedAt: string
+            }
+          }
+        }
+      }
+      componentInstallations?: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        componentId: string
+        spaceId: string | null
+        /** @enum {string} */
+        spaceType: 'OBJECT' | 'PropertyObject'
+        installationDate: string | null
+        deinstallationDate: string | null
+        orderNumber?: string | null
+        cost: number
+        createdAt: string
+        updatedAt: string
+        propertyObject?: {
+          id: string
+          propertyStructures?: {
+            roomId?: string | null
+            roomCode?: string | null
+            roomName?: string | null
+            residenceId?: string | null
+            residenceCode?: string | null
+            residenceName?: string | null
+            rentalId?: string | null
+            buildingCode?: string | null
+            buildingName?: string | null
+            residence?: {
+              id: string
+            } | null
+          }[]
+        } | null
+      }[]
+    }
     ComponentCategory: {
       /** Format: uuid */
-      id: string;
-      categoryName: string;
-      description: string;
-      createdAt: string;
-      updatedAt: string;
-    };
+      id: string
+      categoryName: string
+      description: string
+      createdAt: string
+      updatedAt: string
+    }
     ComponentType: {
       /** Format: uuid */
-      id: string;
-      typeName: string;
+      id: string
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description: string | null;
-      createdAt: string;
-      updatedAt: string;
+      categoryId: string
+      description: string | null
+      createdAt: string
+      updatedAt: string
       category?: {
         /** Format: uuid */
-        id: string;
-        categoryName: string;
-        description: string;
-        createdAt: string;
-        updatedAt: string;
-      };
-    };
+        id: string
+        categoryName: string
+        description: string
+        createdAt: string
+        updatedAt: string
+      }
+    }
     ComponentSubtype: {
       /** Format: uuid */
-      id: string;
-      subTypeName: string;
+      id: string
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode: string | null;
-      depreciationPrice: number;
-      technicalLifespan: number;
-      economicLifespan: number;
-      replacementIntervalMonths: number;
+      typeId: string
+      xpandCode: string | null
+      depreciationPrice: number
+      technicalLifespan: number
+      economicLifespan: number
+      replacementIntervalMonths: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-      createdAt: string;
-      updatedAt: string;
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+      createdAt: string
+      updatedAt: string
       componentType?: {
         /** Format: uuid */
-        id: string;
-        typeName: string;
+        id: string
+        typeName: string
         /** Format: uuid */
-        categoryId: string;
-        description: string | null;
-        createdAt: string;
-        updatedAt: string;
+        categoryId: string
+        description: string | null
+        createdAt: string
+        updatedAt: string
         category?: {
           /** Format: uuid */
-          id: string;
-          categoryName: string;
-          description: string;
-          createdAt: string;
-          updatedAt: string;
-        };
-      };
-    };
+          id: string
+          categoryName: string
+          description: string
+          createdAt: string
+          updatedAt: string
+        }
+      }
+    }
     ComponentModel: {
       /** Format: uuid */
-      id: string;
-      modelName: string;
+      id: string
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
-      currentPrice: number;
-      currentInstallPrice: number;
-      warrantyMonths: number;
-      manufacturer: string;
-      technicalSpecification: string | null;
-      installationInstructions: string | null;
-      dimensions: string | null;
-      coclassCode: string | null;
-      createdAt: string;
-      updatedAt: string;
+      componentSubtypeId: string
+      currentPrice: number
+      currentInstallPrice: number
+      warrantyMonths: number
+      manufacturer: string
+      technicalSpecification: string | null
+      installationInstructions: string | null
+      dimensions: string | null
+      coclassCode: string | null
+      createdAt: string
+      updatedAt: string
       subtype?: {
         /** Format: uuid */
-        id: string;
-        subTypeName: string;
+        id: string
+        subTypeName: string
         /** Format: uuid */
-        typeId: string;
-        xpandCode: string | null;
-        depreciationPrice: number;
-        technicalLifespan: number;
-        economicLifespan: number;
-        replacementIntervalMonths: number;
+        typeId: string
+        xpandCode: string | null
+        depreciationPrice: number
+        technicalLifespan: number
+        economicLifespan: number
+        replacementIntervalMonths: number
         /** @enum {string} */
-        quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-        createdAt: string;
-        updatedAt: string;
+        quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+        createdAt: string
+        updatedAt: string
         componentType?: {
           /** Format: uuid */
-          id: string;
-          typeName: string;
+          id: string
+          typeName: string
           /** Format: uuid */
-          categoryId: string;
-          description: string | null;
-          createdAt: string;
-          updatedAt: string;
+          categoryId: string
+          description: string | null
+          createdAt: string
+          updatedAt: string
           category?: {
             /** Format: uuid */
-            id: string;
-            categoryName: string;
-            description: string;
-            createdAt: string;
-            updatedAt: string;
-          };
-        };
-      };
-    };
+            id: string
+            categoryName: string
+            description: string
+            createdAt: string
+            updatedAt: string
+          }
+        }
+      }
+    }
     ComponentInstallation: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      componentId: string;
-      spaceId: string | null;
+      componentId: string
+      spaceId: string | null
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
-      installationDate: string | null;
-      deinstallationDate: string | null;
-      orderNumber?: string | null;
-      cost: number;
-      createdAt: string;
-      updatedAt: string;
+      spaceType: 'OBJECT' | 'PropertyObject'
+      installationDate: string | null
+      deinstallationDate: string | null
+      orderNumber?: string | null
+      cost: number
+      createdAt: string
+      updatedAt: string
       component?: {
         /** Format: uuid */
-        id: string;
+        id: string
         /** Format: uuid */
-        modelId: string;
-        serialNumber: string | null;
-        specifications?: string | null;
-        additionalInformation?: string | null;
-        warrantyStartDate: string | null;
-        warrantyMonths: number;
-        priceAtPurchase: number;
-        depreciationPriceAtPurchase: number;
-        ncsCode?: string | null;
+        modelId: string
+        serialNumber: string | null
+        specifications?: string | null
+        additionalInformation?: string | null
+        warrantyStartDate: string | null
+        warrantyMonths: number
+        priceAtPurchase: number
+        depreciationPriceAtPurchase: number
+        ncsCode?: string | null
         /** @enum {string} */
-        status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+        status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
         /** @enum {string|null} */
-        condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-        lastInspectionDate?: string | null;
-        quantity: number;
-        economicLifespan: number;
-        createdAt: string;
-        updatedAt: string;
+        condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+        lastInspectionDate?: string | null
+        quantity: number
+        economicLifespan: number
+        createdAt: string
+        updatedAt: string
         model?: {
           /** Format: uuid */
-          id: string;
-          modelName: string;
+          id: string
+          modelName: string
           /** Format: uuid */
-          componentSubtypeId: string;
-          currentPrice: number;
-          currentInstallPrice: number;
-          warrantyMonths: number;
-          manufacturer: string;
-          technicalSpecification: string | null;
-          installationInstructions: string | null;
-          dimensions: string | null;
-          coclassCode: string | null;
-          createdAt: string;
-          updatedAt: string;
+          componentSubtypeId: string
+          currentPrice: number
+          currentInstallPrice: number
+          warrantyMonths: number
+          manufacturer: string
+          technicalSpecification: string | null
+          installationInstructions: string | null
+          dimensions: string | null
+          coclassCode: string | null
+          createdAt: string
+          updatedAt: string
           subtype?: {
             /** Format: uuid */
-            id: string;
-            subTypeName: string;
+            id: string
+            subTypeName: string
             /** Format: uuid */
-            typeId: string;
-            xpandCode: string | null;
-            depreciationPrice: number;
-            technicalLifespan: number;
-            economicLifespan: number;
-            replacementIntervalMonths: number;
+            typeId: string
+            xpandCode: string | null
+            depreciationPrice: number
+            technicalLifespan: number
+            economicLifespan: number
+            replacementIntervalMonths: number
             /** @enum {string} */
-            quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-            createdAt: string;
-            updatedAt: string;
+            quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+            createdAt: string
+            updatedAt: string
             componentType?: {
               /** Format: uuid */
-              id: string;
-              typeName: string;
+              id: string
+              typeName: string
               /** Format: uuid */
-              categoryId: string;
-              description: string | null;
-              createdAt: string;
-              updatedAt: string;
+              categoryId: string
+              description: string | null
+              createdAt: string
+              updatedAt: string
               category?: {
                 /** Format: uuid */
-                id: string;
-                categoryName: string;
-                description: string;
-                createdAt: string;
-                updatedAt: string;
-              };
-            };
-          };
-        };
-        componentInstallations?: ({
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            componentId: string;
-            spaceId: string | null;
-            spaceType: components["schemas"]["ComponentInstallation"]["spaceType"];
-            installationDate: string | null;
-            deinstallationDate: string | null;
-            orderNumber?: string | null;
-            cost: number;
-            createdAt: string;
-            updatedAt: string;
-            propertyObject?: ({
-              id: string;
-              propertyStructures?: ({
-                  roomId?: string | null;
-                  roomCode?: string | null;
-                  roomName?: string | null;
-                  residenceId?: string | null;
-                  residenceCode?: string | null;
-                  residenceName?: string | null;
-                  rentalId?: string | null;
-                  buildingCode?: string | null;
-                  buildingName?: string | null;
-                  residence?: {
-                    id: string;
-                  } | null;
-                })[];
-            }) | null;
-          })[];
-      };
-    };
+                id: string
+                categoryName: string
+                description: string
+                createdAt: string
+                updatedAt: string
+              }
+            }
+          }
+        }
+        componentInstallations?: {
+          /** Format: uuid */
+          id: string
+          /** Format: uuid */
+          componentId: string
+          spaceId: string | null
+          spaceType: components['schemas']['ComponentInstallation']['spaceType']
+          installationDate: string | null
+          deinstallationDate: string | null
+          orderNumber?: string | null
+          cost: number
+          createdAt: string
+          updatedAt: string
+          propertyObject?: {
+            id: string
+            propertyStructures?: {
+              roomId?: string | null
+              roomCode?: string | null
+              roomName?: string | null
+              residenceId?: string | null
+              residenceCode?: string | null
+              residenceName?: string | null
+              rentalId?: string | null
+              buildingCode?: string | null
+              buildingName?: string | null
+              residence?: {
+                id: string
+              } | null
+            }[]
+          } | null
+        }[]
+      }
+    }
     CreateComponentCategoryRequest: {
-      categoryName: string;
-      description: string;
-    };
+      categoryName: string
+      description: string
+    }
     UpdateComponentCategoryRequest: {
-      categoryName?: string;
-      description?: string;
-    };
+      categoryName?: string
+      description?: string
+    }
     CreateComponentTypeRequest: {
-      typeName: string;
+      typeName: string
       /** Format: uuid */
-      categoryId: string;
-      description?: string;
-    };
+      categoryId: string
+      description?: string
+    }
     UpdateComponentTypeRequest: {
-      typeName?: string;
+      typeName?: string
       /** Format: uuid */
-      categoryId?: string;
-      description?: string;
-    };
+      categoryId?: string
+      description?: string
+    }
     CreateComponentSubtypeRequest: {
-      subTypeName: string;
+      subTypeName: string
       /** Format: uuid */
-      typeId: string;
-      xpandCode?: string;
+      typeId: string
+      xpandCode?: string
       /** @default 0 */
-      depreciationPrice?: number;
+      depreciationPrice?: number
       /** @default 0 */
-      technicalLifespan?: number;
+      technicalLifespan?: number
       /** @default 0 */
-      economicLifespan?: number;
+      economicLifespan?: number
       /** @default 0 */
-      replacementIntervalMonths?: number;
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     UpdateComponentSubtypeRequest: {
-      subTypeName?: string;
+      subTypeName?: string
       /** Format: uuid */
-      typeId?: string;
-      xpandCode?: string;
-      depreciationPrice?: number;
-      technicalLifespan?: number;
-      economicLifespan?: number;
-      replacementIntervalMonths?: number;
+      typeId?: string
+      xpandCode?: string
+      depreciationPrice?: number
+      technicalLifespan?: number
+      economicLifespan?: number
+      replacementIntervalMonths?: number
       /** @enum {string} */
-      quantityType?: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
-    };
+      quantityType?: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
+    }
     CreateComponentModelRequest: {
-      modelName: string;
+      modelName: string
       /** Format: uuid */
-      componentSubtypeId: string;
+      componentSubtypeId: string
       /** @default 0 */
-      currentPrice?: number;
+      currentPrice?: number
       /** @default 0 */
-      currentInstallPrice?: number;
+      currentInstallPrice?: number
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default */
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     UpdateComponentModelRequest: {
-      modelName?: string;
+      modelName?: string
       /** Format: uuid */
-      componentSubtypeId?: string;
-      currentPrice?: number;
-      currentInstallPrice?: number;
-      warrantyMonths?: number;
-      manufacturer?: string;
-      technicalSpecification?: string;
-      installationInstructions?: string;
-      dimensions?: string;
-      coclassCode?: string;
-    };
+      componentSubtypeId?: string
+      currentPrice?: number
+      currentInstallPrice?: number
+      warrantyMonths?: number
+      manufacturer?: string
+      technicalSpecification?: string
+      installationInstructions?: string
+      dimensions?: string
+      coclassCode?: string
+    }
     CreateComponentRequest: {
       /** Format: uuid */
-      modelId: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
+      warrantyStartDate?: string
       /** @default 0 */
-      warrantyMonths?: number;
+      warrantyMonths?: number
       /** @default 0 */
-      priceAtPurchase?: number;
+      priceAtPurchase?: number
       /** @default 0 */
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /**
        * @default ACTIVE
        * @enum {string}
        */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
       /** @default 1 */
-      quantity?: number;
+      quantity?: number
       /** @default 0 */
-      economicLifespan?: number;
-      files?: string;
-    };
+      economicLifespan?: number
+      files?: string
+    }
     UpdateComponentRequest: {
       /** Format: uuid */
-      modelId?: string;
-      serialNumber?: string | null;
-      specifications?: string;
-      additionalInformation?: string;
+      modelId?: string
+      serialNumber?: string | null
+      specifications?: string
+      additionalInformation?: string
       /** Format: date-time */
-      warrantyStartDate?: string;
-      warrantyMonths?: number;
-      priceAtPurchase?: number;
-      depreciationPriceAtPurchase?: number;
-      ncsCode?: string;
+      warrantyStartDate?: string
+      warrantyMonths?: number
+      priceAtPurchase?: number
+      depreciationPriceAtPurchase?: number
+      ncsCode?: string
       /** @enum {string} */
-      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
+      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
       /** @enum {string|null} */
-      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
-      quantity?: number;
-      economicLifespan?: number;
-      files?: string;
-    };
+      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      quantity?: number
+      economicLifespan?: number
+      files?: string
+    }
     CreateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId: string;
-      spaceId?: string;
+      componentId: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType: "OBJECT" | "PropertyObject";
+      spaceType: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string | null;
+      installationDate?: string | null
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost: number
+    }
     UpdateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId?: string;
-      spaceId?: string;
+      componentId?: string
+      spaceId?: string
       /** @enum {string} */
-      spaceType?: "OBJECT" | "PropertyObject";
+      spaceType?: 'OBJECT' | 'PropertyObject'
       /** Format: date-time */
-      installationDate?: string;
+      installationDate?: string
       /** Format: date-time */
-      deinstallationDate?: string;
-      orderNumber?: string;
-      cost?: number;
-    };
+      deinstallationDate?: string
+      orderNumber?: string
+      cost?: number
+    }
     DocumentWithUrl: {
-      id: string;
-      fileId: string;
-      originalName: string;
-      mimeType: string;
-      size: number;
-      createdAt: string;
-      url: string;
-      uploadedAt?: string;
-      caption?: string;
-    };
+      id: string
+      fileId: string
+      originalName: string
+      mimeType: string
+      size: number
+      createdAt: string
+      url: string
+      uploadedAt?: string
+      caption?: string
+    }
     AnalyzeComponentImageRequest: {
-      image: string;
-      additionalImage?: string;
-    };
+      image: string
+      additionalImage?: string
+    }
     AIComponentAnalysis: {
-      componentType: string | null;
-      componentSubtype: string | null;
-      manufacturer: string | null;
-      model: string | null;
-      serialNumber: string | null;
-      estimatedAge: string | null;
-      condition: string | null;
-      specifications: string | null;
-      dimensions: string | null;
-      warrantyMonths: number | null;
-      ncsCode: string | null;
-      additionalInformation: string | null;
-      confidence: number;
-    };
+      componentType: string | null
+      componentSubtype: string | null
+      manufacturer: string | null
+      model: string | null
+      serialNumber: string | null
+      estimatedAge: string | null
+      condition: string | null
+      specifications: string | null
+      dimensions: string | null
+      warrantyMonths: number | null
+      ncsCode: string | null
+      additionalInformation: string | null
+      confidence: number
+    }
     ApartmentTemperaturePoint: {
-      time: number;
-      avg: number | null;
-      min: number | null;
-      max: number | null;
-    };
+      time: number
+      avg: number | null
+      min: number | null
+      max: number | null
+    }
     ApartmentTemperatureSeries: {
-      subNodeId: number;
-      subNodeName: string;
-      points: ({
-          time: number;
-          avg: number | null;
-          min: number | null;
-          max: number | null;
-        })[];
-    };
+      subNodeId: number
+      subNodeName: string
+      points: {
+        time: number
+        avg: number | null
+        min: number | null
+        max: number | null
+      }[]
+    }
     ApartmentTemperaturesResponse: {
-      objectNumber: string;
-      nodeId: number;
-      from: number;
-      to: number;
+      objectNumber: string
+      nodeId: number
+      from: number
+      to: number
       /** @enum {string} */
-      interval: "H" | "D";
-      unit: string;
-      series: ({
-          subNodeId: number;
-          subNodeName: string;
-          points: ({
-              time: number;
-              avg: number | null;
-              min: number | null;
-              max: number | null;
-            })[];
-        })[];
-    };
+      interval: 'H' | 'D'
+      unit: string
+      series: {
+        subNodeId: number
+        subNodeName: string
+        points: {
+          time: number
+          avg: number | null
+          min: number | null
+          max: number | null
+        }[]
+      }[]
+    }
     Key: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeySystem: {
       /** Format: uuid */
-      id: string;
-      systemCode: string;
-      name: string;
-      manufacturer: string;
-      managingSupplier?: string | null;
+      id: string
+      systemCode: string
+      name: string
+      manufacturer: string
+      managingSupplier?: string | null
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+    }
     KeyLoan: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-    };
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+    }
     KeyDetails: {
       /** Format: uuid */
-      id: string;
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      id: string
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
+      keySystemId?: string | null
       /** @default false */
-      disposed?: boolean;
-      notes?: string | null;
+      disposed?: boolean
+      notes?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      keySystem?: components["schemas"]["KeySystem"] | null;
-      loans?: components["schemas"]["KeyLoan"][] | null;
-      events?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
-          /** @enum {string} */
-          status: "ORDERED" | "RECEIVED" | "COMPLETED";
-          /** Format: uuid */
-          workOrderId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[]) | null;
-      activeLoanContact?: string | null;
-    };
+      updatedAt: string
+      keySystem?: components['schemas']['KeySystem'] | null
+      loans?: components['schemas']['KeyLoan'][] | null
+      events?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+            /** @enum {string} */
+            status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+            /** Format: uuid */
+            workOrderId?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+          }[]
+        | null
+      activeLoanContact?: string | null
+    }
     KeyLoanWithDetails: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-      createdBy?: string | null;
-      updatedBy?: string | null;
-      keyCount?: number;
-      cardCount?: number;
-      keysArray: ({
+      updatedAt: string
+      createdBy?: string | null
+      updatedBy?: string | null
+      keyCount?: number
+      cardCount?: number
+      keysArray: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: {
-              id: components["schemas"]["KeyLoanWithDetails"]["id"];
-              loanType: components["schemas"]["KeyLoanWithDetails"]["loanType"];
-              contact?: components["schemas"]["KeyLoanWithDetails"]["contact"];
-              contact2?: components["schemas"]["KeyLoanWithDetails"]["contact2"];
-              contactPerson?: components["schemas"]["KeyLoanWithDetails"]["contactPerson"];
-              notes?: components["schemas"]["KeyLoanWithDetails"]["notes"];
-              returnedAt?: components["schemas"]["KeyLoanWithDetails"]["returnedAt"];
-              availableToNextTenantFrom?: components["schemas"]["KeyLoanWithDetails"]["availableToNextTenantFrom"];
-              pickedUpAt?: components["schemas"]["KeyLoanWithDetails"]["pickedUpAt"];
-              createdAt: components["schemas"]["KeyLoanWithDetails"]["createdAt"];
-              updatedAt: components["schemas"]["KeyLoanWithDetails"]["updatedAt"];
-              createdBy?: components["schemas"]["KeyLoanWithDetails"]["createdBy"];
-              updatedBy?: components["schemas"]["KeyLoanWithDetails"]["updatedBy"];
-              keyCount?: components["schemas"]["KeyLoanWithDetails"]["keyCount"];
-              cardCount?: components["schemas"]["KeyLoanWithDetails"]["cardCount"];
-            }[] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?:
+          | {
+              id: components['schemas']['KeyLoanWithDetails']['id']
+              loanType: components['schemas']['KeyLoanWithDetails']['loanType']
+              contact?: components['schemas']['KeyLoanWithDetails']['contact']
+              contact2?: components['schemas']['KeyLoanWithDetails']['contact2']
+              contactPerson?: components['schemas']['KeyLoanWithDetails']['contactPerson']
+              notes?: components['schemas']['KeyLoanWithDetails']['notes']
+              returnedAt?: components['schemas']['KeyLoanWithDetails']['returnedAt']
+              availableToNextTenantFrom?: components['schemas']['KeyLoanWithDetails']['availableToNextTenantFrom']
+              pickedUpAt?: components['schemas']['KeyLoanWithDetails']['pickedUpAt']
+              createdAt: components['schemas']['KeyLoanWithDetails']['createdAt']
+              updatedAt: components['schemas']['KeyLoanWithDetails']['updatedAt']
+              createdBy?: components['schemas']['KeyLoanWithDetails']['createdBy']
+              updatedBy?: components['schemas']['KeyLoanWithDetails']['updatedBy']
+              keyCount?: components['schemas']['KeyLoanWithDetails']['keyCount']
+              cardCount?: components['schemas']['KeyLoanWithDetails']['cardCount']
+            }[]
+          | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-      keyCardsArray: ({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[];
-      receipts: ({
-          /** Format: uuid */
-          id: string;
-          /** Format: uuid */
-          keyLoanId: string;
-          /** @enum {string} */
-          receiptType: "LOAN" | "RETURN";
-          /** @enum {string} */
-          type: "DIGITAL" | "PHYSICAL";
-          fileId?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+      keyCardsArray: {
+        cardId: string
+        name?: string | null
+        owner?: unknown
+        appearanceCode?: string | null
+        classification?: string | null
+        disabled?: boolean
+        startTime?: string | null
+        stopTime?: string | null
+        createTime: string
+        pinCode?: string | null
+        state?: string | null
+        archivedAt?: string | null
+        codes?: unknown[] | null
+      }[]
+      receipts: {
+        /** Format: uuid */
+        id: string
+        /** Format: uuid */
+        keyLoanId: string
+        /** @enum {string} */
+        receiptType: 'LOAN' | 'RETURN'
+        /** @enum {string} */
+        type: 'DIGITAL' | 'PHYSICAL'
+        fileId?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+      }[]
+    }
     Log: {
       /** Format: uuid */
-      id: string;
-      userName: string;
+      id: string
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
+      objectId?: string | null
       /** Format: date-time */
-      eventTime: string;
-      description?: string | null;
-      eventTypeLabel?: string;
-      objectTypeLabel?: string;
-    };
+      eventTime: string
+      description?: string | null
+      eventTypeLabel?: string
+      objectTypeLabel?: string
+    }
     KeyNote: {
       /** Format: uuid */
-      id: string;
-      rentalObjectCode: string;
-      description: string;
-    };
+      id: string
+      rentalObjectCode: string
+      description: string
+    }
     Receipt: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type: "DIGITAL" | "PHYSICAL";
-      fileId?: string | null;
+      type: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     KeyEvent: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
+      workOrderId?: string | null
       /** Format: date-time */
-      createdAt: string;
+      createdAt: string
       /** Format: date-time */
-      updatedAt: string;
-    };
+      updatedAt: string
+    }
     Signature: {
       /** Format: uuid */
-      id: string;
+      id: string
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
-      status: string;
+      recipientEmail: string
+      recipientName?: string | null
+      status: string
       /** Format: date-time */
-      sentAt: string;
+      sentAt: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     CreateKeyRequest: {
-      keyName: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      notes?: string | null
+    }
     UpdateKeyRequest: {
-      keyName?: string;
-      keySequenceNumber?: number | null;
-      flexNumber?: number | null;
-      rentalObjectCode?: string | null;
+      keyName?: string
+      keySequenceNumber?: number | null
+      flexNumber?: number | null
+      rentalObjectCode?: string | null
       /** @enum {string} */
-      keyType?: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+      keyType?:
+        | 'HN'
+        | 'FS'
+        | 'MV'
+        | 'LGH'
+        | 'PB'
+        | 'GAR'
+        | 'LOK'
+        | 'HL'
+        | 'FÖR'
+        | 'SOP'
+        | 'ÖVR'
       /** Format: uuid */
-      keySystemId?: string | null;
-      disposed?: boolean;
-      notes?: string | null;
-    };
+      keySystemId?: string | null
+      disposed?: boolean
+      notes?: string | null
+    }
     BulkUpdateFlexRequest: {
-      rentalObjectCode: string;
-      flexNumber: number;
-    };
+      rentalObjectCode: string
+      flexNumber: number
+    }
     BulkUpdateKeysRequest: {
-      keyIds: string[];
+      keyIds: string[]
       updates: {
-        keyName?: string;
-        flexNumber?: number | null;
+        keyName?: string
+        flexNumber?: number | null
         /** Format: uuid */
-        keySystemId?: string | null;
-        rentalObjectCode?: string;
-        disposed?: boolean;
-        notes?: string | null;
-        clearNotes?: boolean;
-      };
-    };
+        keySystemId?: string | null
+        rentalObjectCode?: string
+        disposed?: boolean
+        notes?: string | null
+        clearNotes?: boolean
+      }
+    }
     CreateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
+      pickedUpAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
-      createdBy?: string | null;
-    };
+      availableToNextTenantFrom?: string | null
+      createdBy?: string | null
+    }
     UpdateKeyLoanRequest: {
-      keys?: string[];
-      keyCards?: string[];
+      keys?: string[]
+      keyCards?: string[]
       /** @enum {string} */
-      loanType?: "TENANT" | "MAINTENANCE";
-      contact?: string | null;
-      contact2?: string | null;
-      contactPerson?: string | null;
-      notes?: string | null;
+      loanType?: 'TENANT' | 'MAINTENANCE'
+      contact?: string | null
+      contact2?: string | null
+      contactPerson?: string | null
+      notes?: string | null
       /** Format: date-time */
-      returnedAt?: string | null;
+      returnedAt?: string | null
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null;
+      availableToNextTenantFrom?: string | null
       /** Format: date-time */
-      pickedUpAt?: string | null;
-      updatedBy?: string | null;
-    };
+      pickedUpAt?: string | null
+      updatedBy?: string | null
+    }
     CreateKeySystemRequest: {
-      systemCode: string;
-      name: string;
-      manufacturer: string;
+      systemCode: string
+      name: string
+      manufacturer: string
       /** @enum {string} */
-      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+    }
     UpdateKeySystemRequest: {
-      systemCode?: string;
-      name?: string;
-      manufacturer?: string;
+      systemCode?: string
+      name?: string
+      manufacturer?: string
       /** @enum {string} */
-      type?: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-      propertyIds?: string;
+      type?: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+      propertyIds?: string
       /** Format: date-time */
-      installationDate?: string | null;
-      isActive?: boolean;
-      notes?: string | null;
-      schemaFileId?: string | null;
-    };
+      installationDate?: string | null
+      isActive?: boolean
+      notes?: string | null
+      schemaFileId?: string | null
+    }
     CreateLogRequest: {
-      userName: string;
+      userName: string
       /** @enum {string} */
-      eventType: "creation" | "update" | "delete";
+      eventType: 'creation' | 'update' | 'delete'
       /** @enum {string} */
-      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
+      objectType:
+        | 'key'
+        | 'keySystem'
+        | 'keyLoan'
+        | 'keyBundle'
+        | 'receipt'
+        | 'keyEvent'
+        | 'signature'
+        | 'keyNote'
       /** Format: uuid */
-      objectId?: string | null;
-      description?: string | null;
-      autoGenerateDescription?: boolean;
-      entityData?: unknown;
+      objectId?: string | null
+      description?: string | null
+      autoGenerateDescription?: boolean
+      entityData?: unknown
       /** @enum {string} */
-      action?: "Skapad" | "Uppdaterad" | "Kasserad" | "Raderad";
+      action?: 'Skapad' | 'Uppdaterad' | 'Kasserad' | 'Raderad'
       /** Format: date-time */
-      eventTime?: string;
-    };
+      eventTime?: string
+    }
     CreateKeyNoteRequest: {
-      rentalObjectCode: string;
-      description: string;
-    };
+      rentalObjectCode: string
+      description: string
+    }
     UpdateKeyNoteRequest: {
-      rentalObjectCode?: string;
-      description?: string;
-    };
+      rentalObjectCode?: string
+      description?: string
+    }
     KeyBundle: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description?: string | null;
-      keyCount?: number;
-    };
+      id: string
+      name: string
+      description?: string | null
+      keyCount?: number
+    }
     BundleWithLoanedKeysInfo: {
       /** Format: uuid */
-      id: string;
-      name: string;
-      description: string | null;
-      loanedKeyCount: number;
-      totalKeyCount: number;
-    };
+      id: string
+      name: string
+      description: string | null
+      loanedKeyCount: number
+      totalKeyCount: number
+    }
     CreateKeyBundleRequest: {
-      name: string;
-      keys: string[];
-      description?: string | null;
-    };
+      name: string
+      keys: string[]
+      description?: string | null
+    }
     UpdateKeyBundleRequest: {
-      name?: string;
-      keys?: string[];
-      description?: string | null;
-    };
+      name?: string
+      keys?: string[]
+      description?: string | null
+    }
     KeyBundleDetailsResponse: {
       bundle: {
         /** Format: uuid */
-        id: string;
-        name: string;
-        description?: string | null;
-        keyCount?: number;
-      };
-      keys: ({
+        id: string
+        name: string
+        description?: string | null
+        keyCount?: number
+      }
+      keys: {
+        /** Format: uuid */
+        id: string
+        keyName: string
+        keySequenceNumber?: number | null
+        flexNumber?: number | null
+        rentalObjectCode?: string | null
+        /** @enum {string} */
+        keyType:
+          | 'HN'
+          | 'FS'
+          | 'MV'
+          | 'LGH'
+          | 'PB'
+          | 'GAR'
+          | 'LOK'
+          | 'HL'
+          | 'FÖR'
+          | 'SOP'
+          | 'ÖVR'
+        /** Format: uuid */
+        keySystemId?: string | null
+        /** @default false */
+        disposed?: boolean
+        notes?: string | null
+        /** Format: date-time */
+        createdAt: string
+        /** Format: date-time */
+        updatedAt: string
+        keySystem?: {
           /** Format: uuid */
-          id: string;
-          keyName: string;
-          keySequenceNumber?: number | null;
-          flexNumber?: number | null;
-          rentalObjectCode?: string | null;
+          id: string
+          systemCode: string
+          name: string
+          manufacturer: string
+          managingSupplier?: string | null
           /** @enum {string} */
-          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
-          /** Format: uuid */
-          keySystemId?: string | null;
-          /** @default false */
-          disposed?: boolean;
-          notes?: string | null;
+          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
+          propertyIds?: string
           /** Format: date-time */
-          createdAt: string;
+          installationDate?: string | null
+          isActive?: boolean
+          notes?: string | null
+          schemaFileId?: string | null
           /** Format: date-time */
-          updatedAt: string;
-          keySystem?: ({
-            /** Format: uuid */
-            id: string;
-            systemCode: string;
-            name: string;
-            manufacturer: string;
-            managingSupplier?: string | null;
-            /** @enum {string} */
-            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
-            propertyIds?: string;
-            /** Format: date-time */
-            installationDate?: string | null;
-            isActive?: boolean;
-            notes?: string | null;
-            schemaFileId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            createdBy?: string | null;
-            updatedBy?: string | null;
-          }) | null;
-          loans?: components["schemas"]["KeyLoan"][] | null;
-          events?: (({
+          createdAt: string
+          /** Format: date-time */
+          updatedAt: string
+          createdBy?: string | null
+          updatedBy?: string | null
+        } | null
+        loans?: components['schemas']['KeyLoan'][] | null
+        events?:
+          | {
               /** Format: uuid */
-              id: string;
+              id: string
               /** @enum {string} */
-              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
               /** @enum {string} */
-              status: "ORDERED" | "RECEIVED" | "COMPLETED";
+              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
               /** Format: uuid */
-              workOrderId?: string | null;
+              workOrderId?: string | null
               /** Format: date-time */
-              createdAt: string;
+              createdAt: string
               /** Format: date-time */
-              updatedAt: string;
-            })[]) | null;
-          activeLoanContact?: string | null;
-        })[];
-    };
+              updatedAt: string
+            }[]
+          | null
+        activeLoanContact?: string | null
+      }[]
+    }
     CreateKeyEventRequest: {
-      keys: string[];
+      keys: string[]
       /** @enum {string} */
-      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     UpdateKeyEventRequest: {
-      keys?: string[];
+      keys?: string[]
       /** @enum {string} */
-      type?: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+      type?: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
       /** @enum {string} */
-      status?: "ORDERED" | "RECEIVED" | "COMPLETED";
+      status?: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
       /** Format: uuid */
-      workOrderId?: string | null;
-    };
+      workOrderId?: string | null
+    }
     CreateSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
-      simpleSignDocumentId: number;
+      resourceId: string
+      simpleSignDocumentId: number
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string | null;
+      recipientEmail: string
+      recipientName?: string | null
       /** @default sent */
-      status?: string;
-    };
+      status?: string
+    }
     UpdateSignatureRequest: {
-      status?: string;
+      status?: string
       /** Format: date-time */
-      completedAt?: string | null;
+      completedAt?: string | null
       /** Format: date-time */
-      lastSyncedAt?: string | null;
-    };
+      lastSyncedAt?: string | null
+    }
     SendSignatureRequest: {
       /** @enum {string} */
-      resourceType: "receipt";
+      resourceType: 'receipt'
       /** Format: uuid */
-      resourceId: string;
+      resourceId: string
       /** Format: email */
-      recipientEmail: string;
-      recipientName?: string;
-      pdfBase64: string;
-    };
+      recipientEmail: string
+      recipientName?: string
+      pdfBase64: string
+    }
     SimpleSignWebhookPayload: {
-      id: number;
-      status: string;
-      status_updated_at: string;
-    };
+      id: number
+      status: string
+      status_updated_at: string
+    }
     CreateReceiptRequest: {
       /** Format: uuid */
-      keyLoanId: string;
+      keyLoanId: string
       /** @enum {string} */
-      receiptType: "LOAN" | "RETURN";
+      receiptType: 'LOAN' | 'RETURN'
       /** @enum {string} */
-      type?: "DIGITAL" | "PHYSICAL";
-      fileId?: string;
-      fileData?: string;
-      fileContentType?: string;
-    };
+      type?: 'DIGITAL' | 'PHYSICAL'
+      fileId?: string
+      fileData?: string
+      fileContentType?: string
+    }
     UpdateReceiptRequest: {
-      fileId?: string;
-    };
+      fileId?: string
+    }
     /** @enum {string} */
-    ReceiptType: "LOAN" | "RETURN";
+    ReceiptType: 'LOAN' | 'RETURN'
     /** @enum {string} */
-    ReceiptFormat: "DIGITAL" | "PHYSICAL";
+    ReceiptFormat: 'DIGITAL' | 'PHYSICAL'
     ErrorResponse: {
       /** @example Internal server error */
-      error?: string;
-      reason?: string;
-    };
+      error?: string
+      reason?: string
+    }
     NotFoundResponse: {
       /** @example Resource not found */
-      reason: string;
-    };
+      reason: string
+    }
     BadRequestResponse: {
-      reason: string;
-    };
+      reason: string
+    }
     SchemaDownloadUrlResponse: {
-      url: string;
-      expiresIn: number;
-    };
+      url: string
+      expiresIn: number
+    }
     CardOwner: {
-      cardOwnerId: string;
-      cardOwnerType?: string | null;
-      familyName?: string | null;
-      specificName?: string | null;
-      primaryOrganization?: unknown;
-      cards?: (({
-          cardId: string;
-          name?: string | null;
-          owner?: unknown;
-          appearanceCode?: string | null;
-          classification?: string | null;
-          disabled?: boolean;
-          startTime?: string | null;
-          stopTime?: string | null;
-          createTime: string;
-          pinCode?: string | null;
-          state?: string | null;
-          archivedAt?: string | null;
-          codes?: unknown[] | null;
-        })[]) | null;
-      comment?: string | null;
-      folderId?: number | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      pinCode?: string | null;
+      cardOwnerId: string
+      cardOwnerType?: string | null
+      familyName?: string | null
+      specificName?: string | null
+      primaryOrganization?: unknown
+      cards?:
+        | {
+            cardId: string
+            name?: string | null
+            owner?: unknown
+            appearanceCode?: string | null
+            classification?: string | null
+            disabled?: boolean
+            startTime?: string | null
+            stopTime?: string | null
+            createTime: string
+            pinCode?: string | null
+            state?: string | null
+            archivedAt?: string | null
+            codes?: unknown[] | null
+          }[]
+        | null
+      comment?: string | null
+      folderId?: number | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      pinCode?: string | null
       attributes?: {
-        [key: string]: string;
-      } | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      createTime?: string;
-    };
+        [key: string]: string
+      } | null
+      state?: string | null
+      archivedAt?: string | null
+      createTime?: string
+    }
     Card: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+    }
     CardDetails: {
-      cardId: string;
-      name?: string | null;
-      owner?: unknown;
-      appearanceCode?: string | null;
-      classification?: string | null;
-      disabled?: boolean;
-      startTime?: string | null;
-      stopTime?: string | null;
-      createTime: string;
-      pinCode?: string | null;
-      state?: string | null;
-      archivedAt?: string | null;
-      codes?: unknown[] | null;
-      loans?: (({
-          /** Format: uuid */
-          id: string;
-          /** @enum {string} */
-          loanType: "TENANT" | "MAINTENANCE";
-          contact?: string | null;
-          contact2?: string | null;
-          contactPerson?: string | null;
-          notes?: string | null;
-          /** Format: date-time */
-          returnedAt?: string | null;
-          /** Format: date-time */
-          availableToNextTenantFrom?: string | null;
-          /** Format: date-time */
-          pickedUpAt?: string | null;
-          /** Format: date-time */
-          createdAt: string;
-          /** Format: date-time */
-          updatedAt: string;
-          createdBy?: string | null;
-          updatedBy?: string | null;
-          keyCount?: number;
-          cardCount?: number;
-        })[]) | null;
-    };
+      cardId: string
+      name?: string | null
+      owner?: unknown
+      appearanceCode?: string | null
+      classification?: string | null
+      disabled?: boolean
+      startTime?: string | null
+      stopTime?: string | null
+      createTime: string
+      pinCode?: string | null
+      state?: string | null
+      archivedAt?: string | null
+      codes?: unknown[] | null
+      loans?:
+        | {
+            /** Format: uuid */
+            id: string
+            /** @enum {string} */
+            loanType: 'TENANT' | 'MAINTENANCE'
+            contact?: string | null
+            contact2?: string | null
+            contactPerson?: string | null
+            notes?: string | null
+            /** Format: date-time */
+            returnedAt?: string | null
+            /** Format: date-time */
+            availableToNextTenantFrom?: string | null
+            /** Format: date-time */
+            pickedUpAt?: string | null
+            /** Format: date-time */
+            createdAt: string
+            /** Format: date-time */
+            updatedAt: string
+            createdBy?: string | null
+            updatedBy?: string | null
+            keyCount?: number
+            cardCount?: number
+          }[]
+        | null
+    }
     QueryCardOwnersParams: {
-      nameFilter?: string;
-      expand?: string;
-      idfilter?: string;
-      attributeFilter?: string;
-      selectedAttributes?: string;
-      folderFilter?: string;
-      organisationFilter?: string;
-      offset?: number;
-      limit?: number;
-    };
+      nameFilter?: string
+      expand?: string
+      idfilter?: string
+      attributeFilter?: string
+      selectedAttributes?: string
+      folderFilter?: string
+      organisationFilter?: string
+      offset?: number
+      limit?: number
+    }
     PaginatedResponse: {
-      content: unknown[];
+      content: unknown[]
       _meta: {
-        totalRecords: number;
-        page: number;
-        limit: number;
-        count: number;
-      };
-      _links: ({
-          href: string;
-          /** @enum {string} */
-          rel: "self" | "first" | "last" | "prev" | "next";
-        })[];
-    };
+        totalRecords: number
+        page: number
+        limit: number
+        count: number
+      }
+      _links: {
+        href: string
+        /** @enum {string} */
+        rel: 'self' | 'first' | 'last' | 'prev' | 'next'
+      }[]
+    }
     SearchQueryParams: {
       /** @description The search query string used to find properties, buildings and residences */
-      q: string;
-    };
+      q: string
+    }
     PropertySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a property result
        * @enum {string}
        */
-      type: "property";
+      type: 'property'
       /** @description Property code */
-      code: string;
+      code: string
       /** @description Name or designation of the property */
-      name: string;
-    };
+      name: string
+    }
     BuildingSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a building result
        * @enum {string}
        */
-      type: "building";
+      type: 'building'
       /** @description Building code */
-      code: string;
+      code: string
       /** @description Name of the building */
-      name: string | null;
-      property?: ({
+      name: string | null
+      property?: {
         /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    };
+        name: string | null
+        id: string
+        code: string
+      } | null
+    }
     MaintenanceUnitSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a maintenance unit result
        * @enum {string}
        */
-      type: "maintenance-unit";
+      type: 'maintenance-unit'
       /** @description Code of the maintenance unit */
-      code: string;
+      code: string
       /** @description Caption/name of the maintenance unit */
-      caption: string | null;
+      caption: string | null
       /** @description Type of maintenance unit */
-      maintenanceType: string | null;
+      maintenanceType: string | null
       /** @description Property code */
-      estateCode: string | null;
+      estateCode: string | null
       /** @description Property name */
-      estate: string | null;
-    };
+      estate: string | null
+    }
     StaircaseSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string;
+      id: string
       /**
        * @description Indicates this is a staircase result
        * @enum {string}
        */
-      type: "staircase";
+      type: 'staircase'
       /** @description Code of the staircase */
-      code: string;
+      code: string
       /** @description Name (caption) of the staircase */
-      name: string | null;
+      name: string | null
       property: {
-        code: string;
+        code: string
         /** @description Name of property associated with the staircase */
-        name: string | null;
-      };
+        name: string | null
+      }
       building: {
-        code: string;
+        code: string
         /** @description Name of building associated with the staircase */
-        name: string | null;
-      };
-    };
+        name: string | null
+      }
+    }
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
-    SearchResult: {
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a property result
-       * @enum {string}
-       */
-      type: "property";
-      /** @description Property code */
-      code: string;
-      /** @description Name or designation of the property */
-      name: string;
-    } | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a building result
-       * @enum {string}
-       */
-      type: "building";
-      /** @description Building code */
-      code: string;
-      /** @description Name of the building */
-      name: string | null;
-      property?: ({
-        /** @description Property associated with the building */
-        name: string | null;
-        id: string;
-        code: string;
-      }) | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a residence result
-       * @enum {string}
-       */
-      type: "residence";
-      /** @description Name of the residence */
-      name: string | null;
-      /** @description Rental object ID of the residence */
-      rentalId: string | null;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the residence */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the residence */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a parking space result
-       * @enum {string}
-       */
-      type: "parking-space";
-      /** @description Name of the parking space */
-      name: string | null;
-      /** @description Rental ID of the parking space */
-      rentalId: string;
-      /** @description Code of the parking space */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the parking space */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the parking space */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a maintenance unit result
-       * @enum {string}
-       */
-      type: "maintenance-unit";
-      /** @description Code of the maintenance unit */
-      code: string;
-      /** @description Caption/name of the maintenance unit */
-      caption: string | null;
-      /** @description Type of maintenance unit */
-      maintenanceType: string | null;
-      /** @description Property code */
-      estateCode: string | null;
-      /** @description Property name */
-      estate: string | null;
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a facility result
-       * @enum {string}
-       */
-      type: "facility";
-      /** @description Name of the facility */
-      name: string | null;
-      /** @description Rental ID of the facility */
-      rentalId: string;
-      /** @description Code of the facility */
-      code: string;
-      property: {
-        code: string | null;
-        /** @description Name of property associated with the facility */
-        name: string | null;
-      };
-      building: {
-        code: string | null;
-        /** @description Name of building associated with the facility */
-        name: string | null;
-      };
-    }) | ({
-      /** @description Unique identifier for the search result */
-      id: string;
-      /**
-       * @description Indicates this is a staircase result
-       * @enum {string}
-       */
-      type: "staircase";
-      /** @description Code of the staircase */
-      code: string;
-      /** @description Name (caption) of the staircase */
-      name: string | null;
-      property: {
-        code: string;
-        /** @description Name of property associated with the staircase */
-        name: string | null;
-      };
-      building: {
-        code: string;
-        /** @description Name of building associated with the staircase */
-        name: string | null;
-      };
-    });
+    SearchResult:
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a property result
+           * @enum {string}
+           */
+          type: 'property'
+          /** @description Property code */
+          code: string
+          /** @description Name or designation of the property */
+          name: string
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a building result
+           * @enum {string}
+           */
+          type: 'building'
+          /** @description Building code */
+          code: string
+          /** @description Name of the building */
+          name: string | null
+          property?: {
+            /** @description Property associated with the building */
+            name: string | null
+            id: string
+            code: string
+          } | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a residence result
+           * @enum {string}
+           */
+          type: 'residence'
+          /** @description Name of the residence */
+          name: string | null
+          /** @description Rental object ID of the residence */
+          rentalId: string | null
+          property: {
+            code: string | null
+            /** @description Name of property associated with the residence */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the residence */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a parking space result
+           * @enum {string}
+           */
+          type: 'parking-space'
+          /** @description Name of the parking space */
+          name: string | null
+          /** @description Rental ID of the parking space */
+          rentalId: string
+          /** @description Code of the parking space */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the parking space */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the parking space */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a maintenance unit result
+           * @enum {string}
+           */
+          type: 'maintenance-unit'
+          /** @description Code of the maintenance unit */
+          code: string
+          /** @description Caption/name of the maintenance unit */
+          caption: string | null
+          /** @description Type of maintenance unit */
+          maintenanceType: string | null
+          /** @description Property code */
+          estateCode: string | null
+          /** @description Property name */
+          estate: string | null
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a facility result
+           * @enum {string}
+           */
+          type: 'facility'
+          /** @description Name of the facility */
+          name: string | null
+          /** @description Rental ID of the facility */
+          rentalId: string
+          /** @description Code of the facility */
+          code: string
+          property: {
+            code: string | null
+            /** @description Name of property associated with the facility */
+            name: string | null
+          }
+          building: {
+            code: string | null
+            /** @description Name of building associated with the facility */
+            name: string | null
+          }
+        }
+      | {
+          /** @description Unique identifier for the search result */
+          id: string
+          /**
+           * @description Indicates this is a staircase result
+           * @enum {string}
+           */
+          type: 'staircase'
+          /** @description Code of the staircase */
+          code: string
+          /** @description Name (caption) of the staircase */
+          name: string | null
+          property: {
+            code: string
+            /** @description Name of property associated with the staircase */
+            name: string | null
+          }
+          building: {
+            code: string
+            /** @description Name of building associated with the staircase */
+            name: string | null
+          }
+        }
     Inspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              details: string
+            }
+            actions: {
+              details: string[]
+            }
+            componentNotes: {
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
               /** @default */
-              condition?: string;
-              cost?: number;
+              condition?: string
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[]) | null;
-    };
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default false */
+            isAddedInThisInspection?: boolean
+          }[]
+        | null
+    }
     InspectionComponent: {
-      componentId: string;
-      label: string;
-      condition: string;
-      action: string[];
-      note: string;
-      photos: string[];
-      cost?: number;
+      componentId: string
+      label: string
+      condition: string
+      action: string[]
+      note: string
+      photos: string[]
+      cost?: number
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: "tenant" | "landlord" | null;
-    };
+      costResponsibility?: 'tenant' | 'landlord' | null
+    }
     InspectionRoom: {
-      roomId: string;
-      name?: string;
+      roomId: string
+      name?: string
       conditions: {
-        details: string;
-      };
+        details: string
+      }
       actions: {
-        details: string[];
-      };
+        details: string[]
+      }
       componentNotes: {
-        details: string;
-      };
+        details: string
+      }
       componentCosts: {
         /** @default 0 */
-        details?: number;
-      };
+        details?: number
+      }
       componentPhotos: {
-        details: string[];
-      };
+        details: string[]
+      }
       componentCostResponsibilities: {
         /**
          * @default null
          * @enum {string|null}
          */
-        details?: "tenant" | "landlord" | null;
-      };
-      photos: string[];
-      isApproved: boolean;
-      isHandled: boolean;
+        details?: 'tenant' | 'landlord' | null
+      }
+      photos: string[]
+      isApproved: boolean
+      isHandled: boolean
       /** @default [] */
-      detailComponents?: ({
-          id: string;
-          type: string;
-          label: string;
-          note: string;
-          /** @default */
-          condition?: string;
-          cost?: number;
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: "tenant" | "landlord" | null;
-        })[];
+      detailComponents?: {
+        id: string
+        type: string
+        label: string
+        note: string
+        /** @default */
+        condition?: string
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+      }[]
       /** @default [] */
-      components?: ({
-          componentId: string;
-          label: string;
-          condition: string;
-          action: string[];
-          note: string;
-          photos: string[];
-          cost?: number;
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: "tenant" | "landlord" | null;
-        })[];
+      components?: {
+        componentId: string
+        label: string
+        condition: string
+        action: string[]
+        note: string
+        photos: string[]
+        cost?: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+      }[]
       /** @default false */
-      isAddedInThisInspection?: boolean;
-    };
+      isAddedInThisInspection?: boolean
+    }
     DetailedInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12257,379 +12496,379 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
-        /** Format: date-time */
-        leaseStartDate: string;
-        /** Format: date-time */
-        leaseEndDate?: string;
-        /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
-        rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
-          address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
-          roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
-          /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
-        rentInfo?: {
-          currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
-            /** Format: date-time */
-            rentStartDate?: string;
-            /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
-        address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
-        /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
-        /** Format: date-time */
-        preferredMoveOutDate?: string;
-        /** Format: date-time */
-        terminationDate?: string;
-        /** Format: date-time */
-        contractDate?: string;
-        /** Format: date-time */
-        lastDebitDate?: string;
-        /** Format: date-time */
-        approvalDate?: string;
-        residentialArea?: {
-          code: string;
-          caption: string;
-        };
-        tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
-            /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-      residence: ({
-        id: string;
-        code: string;
-        name: string | null;
-        /** @enum {string|null} */
-        status: "VACANT" | "LEASED" | null;
-        entrance: string | null;
-        location: string | null;
-        floor: string | null;
-        partNo: number | null;
-        part: string | null;
-        deleted: boolean;
-        validityPeriod: {
-          /** Format: date-time */
-          fromDate: string;
-          /** Format: date-time */
-          toDate: string;
-        };
-        accessibility: {
-          wheelchairAccessible: boolean;
-          elevator: boolean;
-          residenceAdapted: boolean;
-        };
-        features: {
-          hygieneFacility: string | null;
-          balcony1?: {
-            location: string;
-            type: string;
-          };
-          balcony2?: {
-            location: string;
-            type: string;
-          };
-          patioLocation: string | null;
-          sauna: boolean;
-          extraToilet: boolean;
-          sharedKitchen: boolean;
-          petAllergyFree: boolean;
-          /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean;
-          smokeFree: boolean;
-          asbestos: boolean;
-        };
-        type: {
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-        };
-        residenceType: {
-          residenceTypeId: string;
-          code: string;
-          name: string | null;
-          roomCount: number | null;
-          kitchen: number;
-          systemStandard: number;
-          checklistId: string | null;
-          componentTypeActionId: string | null;
-          statisticsGroupSCBId: string | null;
-          statisticsGroup2Id: string | null;
-          statisticsGroup3Id: string | null;
-          statisticsGroup4Id: string | null;
-          timestamp: string;
-        };
-        rentalInformation: ({
-          apartmentNumber: string | null;
-          rentalId: string | null;
-          type: {
-            code: string;
-            name: string | null;
-          };
-        }) | null;
-        propertyObject: {
-          energy: {
-            energyClass: number;
-            /** Format: date-time */
-            energyRegistered?: string;
-            /** Format: date-time */
-            energyReceived?: string;
-            energyIndex?: number;
-          };
-          rentalId: string | null;
-          rentalInformation: ({
-            type: {
-              code: string;
-              name: string | null;
-            };
-          }) | null;
-          rentalBlocks: ({
-              id: string;
-              blockReasonId: string | null;
-              blockReason: string | null;
-              /** Format: date-time */
-              fromDate: string;
-              /** Format: date-time */
-              toDate: string | null;
-              amount: number | null;
-            })[];
-        };
-        property: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        building: {
-          id: string | null;
-          name: string | null;
-          code: string | null;
-        };
-        staircase: ({
-          id: string;
-          code: string;
-          name: string | null;
-          features: {
-            floorPlan: string | null;
-            accessibleByElevator: boolean;
-          };
-          dates: {
-            /** Format: date-time */
-            from: string;
-            /** Format: date-time */
-            to: string;
-          };
-          property?: {
-            propertyId: string | null;
-            propertyName: string | null;
-            propertyCode: string | null;
-          };
-          building?: {
-            buildingId: string | null;
-            buildingName: string | null;
-            buildingCode: string | null;
-          };
-          deleted: boolean;
-          timestamp: string;
-        }) | null;
-        areaSize: number | null;
-        malarEnergiFacilityId: string | null;
-      }) | null;
-    };
-    DetailedInspectionRoom: {
-      room: string;
-      remarks: ({
-          remarkId: string;
-          location: string | null;
-          buildingComponent: string | null;
-          notes: string | null;
-          remarkGrade: number;
-          remarkStatus: string | null;
-          cost: number;
+        electricalSystem?: boolean
+      }
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
           /**
            * @default null
            * @enum {string|null}
            */
-          costResponsibility?: "tenant" | "landlord" | null;
-          invoice: boolean;
-          quantity: number;
-          isMissing: boolean;
+          costResponsibility?: 'tenant' | 'landlord' | null
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
           /** Format: date-time */
-          fixedDate: string | null;
-          workOrderCreated: boolean;
-          workOrderStatus: number | null;
-        })[];
-    };
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+      lease: {
+        leaseId: string
+        leaseNumber: string
+        /** Format: date-time */
+        leaseStartDate: string
+        /** Format: date-time */
+        leaseEndDate?: string
+        /** @enum {string} */
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
+        rentalProperty?: {
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
+          roomTypes?: {
+            roomTypeId: string
+            name: string
+          }[]
+          /** Format: date-time */
+          lastUpdated?: string
+        }
+        type: string
+        rentInfo?: {
+          currentRent: {
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
+            /** Format: date-time */
+            rentStartDate?: string
+            /** Format: date-time */
+            rentEndDate?: string
+          }
+        }
+        address?: {
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
+        /** Format: date-time */
+        noticeDate?: string
+        noticeTimeTenant?: string | number
+        /** Format: date-time */
+        preferredMoveOutDate?: string
+        /** Format: date-time */
+        terminationDate?: string
+        /** Format: date-time */
+        contractDate?: string
+        /** Format: date-time */
+        lastDebitDate?: string
+        /** Format: date-time */
+        approvalDate?: string
+        residentialArea?: {
+          code: string
+          caption: string
+        }
+        tenants?: {
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
+            /** Format: date-time */
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+      residence: {
+        id: string
+        code: string
+        name: string | null
+        /** @enum {string|null} */
+        status: 'VACANT' | 'LEASED' | null
+        entrance: string | null
+        location: string | null
+        floor: string | null
+        partNo: number | null
+        part: string | null
+        deleted: boolean
+        validityPeriod: {
+          /** Format: date-time */
+          fromDate: string
+          /** Format: date-time */
+          toDate: string
+        }
+        accessibility: {
+          wheelchairAccessible: boolean
+          elevator: boolean
+          residenceAdapted: boolean
+        }
+        features: {
+          hygieneFacility: string | null
+          balcony1?: {
+            location: string
+            type: string
+          }
+          balcony2?: {
+            location: string
+            type: string
+          }
+          patioLocation: string | null
+          sauna: boolean
+          extraToilet: boolean
+          sharedKitchen: boolean
+          petAllergyFree: boolean
+          /** @description Is the apartment checked for electric allergy intolerance? */
+          electricAllergyIntolerance: boolean
+          smokeFree: boolean
+          asbestos: boolean
+        }
+        type: {
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+        }
+        residenceType: {
+          residenceTypeId: string
+          code: string
+          name: string | null
+          roomCount: number | null
+          kitchen: number
+          systemStandard: number
+          checklistId: string | null
+          componentTypeActionId: string | null
+          statisticsGroupSCBId: string | null
+          statisticsGroup2Id: string | null
+          statisticsGroup3Id: string | null
+          statisticsGroup4Id: string | null
+          timestamp: string
+        }
+        rentalInformation: {
+          apartmentNumber: string | null
+          rentalId: string | null
+          type: {
+            code: string
+            name: string | null
+          }
+        } | null
+        propertyObject: {
+          energy: {
+            energyClass: number
+            /** Format: date-time */
+            energyRegistered?: string
+            /** Format: date-time */
+            energyReceived?: string
+            energyIndex?: number
+          }
+          rentalId: string | null
+          rentalInformation: {
+            type: {
+              code: string
+              name: string | null
+            }
+          } | null
+          rentalBlocks: {
+            id: string
+            blockReasonId: string | null
+            blockReason: string | null
+            /** Format: date-time */
+            fromDate: string
+            /** Format: date-time */
+            toDate: string | null
+            amount: number | null
+          }[]
+        }
+        property: {
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        building: {
+          id: string | null
+          name: string | null
+          code: string | null
+        }
+        staircase: {
+          id: string
+          code: string
+          name: string | null
+          features: {
+            floorPlan: string | null
+            accessibleByElevator: boolean
+          }
+          dates: {
+            /** Format: date-time */
+            from: string
+            /** Format: date-time */
+            to: string
+          }
+          property?: {
+            propertyId: string | null
+            propertyName: string | null
+            propertyCode: string | null
+          }
+          building?: {
+            buildingId: string | null
+            buildingName: string | null
+            buildingCode: string | null
+          }
+          deleted: boolean
+          timestamp: string
+        } | null
+        areaSize: number | null
+        malarEnergiFacilityId: string | null
+      } | null
+    }
+    DetailedInspectionRoom: {
+      room: string
+      remarks: {
+        remarkId: string
+        location: string | null
+        buildingComponent: string | null
+        notes: string | null
+        remarkGrade: number
+        remarkStatus: string | null
+        cost: number
+        /**
+         * @default null
+         * @enum {string|null}
+         */
+        costResponsibility?: 'tenant' | 'landlord' | null
+        invoice: boolean
+        quantity: number
+        isMissing: boolean
+        /** Format: date-time */
+        fixedDate: string | null
+        workOrderCreated: boolean
+        workOrderStatus: number | null
+      }[]
+    }
     DetailedInspectionRemark: {
-      remarkId: string;
-      location: string | null;
-      buildingComponent: string | null;
-      notes: string | null;
-      remarkGrade: number;
-      remarkStatus: string | null;
-      cost: number;
+      remarkId: string
+      location: string | null
+      buildingComponent: string | null
+      notes: string | null
+      remarkGrade: number
+      remarkStatus: string | null
+      cost: number
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: "tenant" | "landlord" | null;
-      invoice: boolean;
-      quantity: number;
-      isMissing: boolean;
+      costResponsibility?: 'tenant' | 'landlord' | null
+      invoice: boolean
+      quantity: number
+      isMissing: boolean
       /** Format: date-time */
-      fixedDate: string | null;
-      workOrderCreated: boolean;
-      workOrderStatus: number | null;
-    };
+      fixedDate: string | null
+      workOrderCreated: boolean
+      workOrderStatus: number | null
+    }
     TenantContactsResponse: {
       inspection: {
-        id: string;
-        address: string;
-        apartmentCode: string | null;
-      };
+        id: string
+        address: string
+        apartmentCode: string | null
+      }
       new_tenant?: {
         contacts: {
-            fullName: string;
-            emailAddress: string;
-            contactCode: string;
-          }[];
-        contractId: string;
-      };
-      tenant?: components["schemas"]["TenantContactsResponse"]["new_tenant"];
-    };
+          fullName: string
+          emailAddress: string
+          contactCode: string
+        }[]
+        contractId: string
+      }
+      tenant?: components['schemas']['TenantContactsResponse']['new_tenant']
+    }
     SendProtocolRequest: {
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
-    };
+      recipient: 'tenant' | 'new-tenant'
+    }
     SendProtocolResponse: {
-      success: boolean;
+      success: boolean
       /** @enum {string} */
-      recipient: "tenant" | "new-tenant";
+      recipient: 'tenant' | 'new-tenant'
       sentTo: {
-        emails: string[];
-        contactNames: string[];
-        contractId: string;
-      };
-      error?: string;
-    };
+        emails: string[]
+        contactNames: string[]
+        contractId: string
+      }
+      error?: string
+    }
     CreateInspectionRequest: {
-      status: string;
+      status: string
       /** Format: date-time */
-      date: string;
+      date: string
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      inspector: string;
-      type: string;
-      residenceId: string;
-      address: string;
-      apartmentCode: string | null;
-      isFurnished: boolean;
-      leaseId: string;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      masterKeyAccess: string | null;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
+      endedAt: string | null
+      inspector: string
+      type: string
+      residenceId: string
+      address: string
+      apartmentCode: string | null
+      isFurnished: boolean
+      leaseId: string
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      masterKeyAccess: string | null
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12640,185 +12879,185 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: ({
-          room: string;
-          remarks: ({
-              remarkId: string;
-              location: string | null;
-              buildingComponent: string | null;
-              notes: string | null;
-              remarkGrade: number;
-              remarkStatus: string | null;
-              cost: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-              invoice: boolean;
-              quantity: number;
-              isMissing: boolean;
-              /** Format: date-time */
-              fixedDate: string | null;
-              workOrderCreated: boolean;
-              workOrderStatus: number | null;
-            })[];
-        })[];
-    };
+        electricalSystem?: boolean
+      }
+      rooms: {
+        room: string
+        remarks: {
+          remarkId: string
+          location: string | null
+          buildingComponent: string | null
+          notes: string | null
+          remarkGrade: number
+          remarkStatus: string | null
+          cost: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+          invoice: boolean
+          quantity: number
+          isMissing: boolean
+          /** Format: date-time */
+          fixedDate: string | null
+          workOrderCreated: boolean
+          workOrderStatus: number | null
+        }[]
+      }[]
+    }
     UpdateInspectionStatusRequest: {
       /** @enum {string} */
-      status?: "Registrerad" | "Påbörjad" | "Genomförd";
-      inspector?: string;
-    };
+      status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
+      inspector?: string
+    }
     InspectionWithSource: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
       /** @enum {string} */
-      source: "xpand" | "internal";
-      lease: ({
-        leaseId: string;
-        leaseNumber: string;
+      source: 'xpand' | 'internal'
+      lease: {
+        leaseId: string
+        leaseNumber: string
         /** Format: date-time */
-        leaseStartDate: string;
+        leaseStartDate: string
         /** Format: date-time */
-        leaseEndDate?: string;
+        leaseEndDate?: string
         /** @enum {string} */
-        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
-        tenantContactIds?: string[];
-        rentalPropertyId: string;
+        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
+        tenantContactIds?: string[]
+        rentalPropertyId: string
         rentalProperty?: {
-          rentalPropertyId: string;
-          apartmentNumber: number;
-          size: number;
-          type: string;
+          rentalPropertyId: string
+          apartmentNumber: number
+          size: number
+          type: string
           address?: {
-            street?: string;
-            number: string;
-            postalCode: string;
-            city: string;
-          };
-          rentalPropertyType: string;
-          additionsIncludedInRent: string;
-          otherInfo?: string;
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          rentalPropertyType: string
+          additionsIncludedInRent: string
+          otherInfo?: string
           roomTypes?: {
-              roomTypeId: string;
-              name: string;
-            }[];
+            roomTypeId: string
+            name: string
+          }[]
           /** Format: date-time */
-          lastUpdated?: string;
-        };
-        type: string;
+          lastUpdated?: string
+        }
+        type: string
         rentInfo?: {
           currentRent: {
-            rentId?: string;
-            leaseId?: string;
-            currentRent: number;
-            vat: number;
-            additionalChargeDescription?: string;
-            additionalChargeAmount?: number;
+            rentId?: string
+            leaseId?: string
+            currentRent: number
+            vat: number
+            additionalChargeDescription?: string
+            additionalChargeAmount?: number
             /** Format: date-time */
-            rentStartDate?: string;
+            rentStartDate?: string
             /** Format: date-time */
-            rentEndDate?: string;
-          };
-        };
+            rentEndDate?: string
+          }
+        }
         address?: {
-          street?: string;
-          number: string;
-          postalCode: string;
-          city: string;
-        };
-        noticeGivenBy?: string;
+          street?: string
+          number: string
+          postalCode: string
+          city: string
+        }
+        noticeGivenBy?: string
         /** Format: date-time */
-        noticeDate?: string;
-        noticeTimeTenant?: string | number;
+        noticeDate?: string
+        noticeTimeTenant?: string | number
         /** Format: date-time */
-        preferredMoveOutDate?: string;
+        preferredMoveOutDate?: string
         /** Format: date-time */
-        terminationDate?: string;
+        terminationDate?: string
         /** Format: date-time */
-        contractDate?: string;
+        contractDate?: string
         /** Format: date-time */
-        lastDebitDate?: string;
+        lastDebitDate?: string
         /** Format: date-time */
-        approvalDate?: string;
+        approvalDate?: string
         residentialArea?: {
-          code: string;
-          caption: string;
-        };
+          code: string
+          caption: string
+        }
         tenants?: {
-            contactCode: string;
-            contactKey: string;
-            leaseIds?: string[];
-            firstName: string;
-            lastName: string;
-            fullName: string;
-            nationalRegistrationNumber: string;
+          contactCode: string
+          contactKey: string
+          leaseIds?: string[]
+          firstName: string
+          lastName: string
+          fullName: string
+          nationalRegistrationNumber: string
+          /** Format: date-time */
+          birthDate: string
+          address?: {
+            street?: string
+            number: string
+            postalCode: string
+            city: string
+          }
+          phoneNumbers?: {
+            phoneNumber: string
+            type: string
+            isMainNumber: boolean
+          }[]
+          emailAddress?: string
+          isTenant: boolean
+          parkingSpaceWaitingList?: {
             /** Format: date-time */
-            birthDate: string;
-            address?: {
-              street?: string;
-              number: string;
-              postalCode: string;
-              city: string;
-            };
-            phoneNumbers?: {
-                phoneNumber: string;
-                type: string;
-                isMainNumber: boolean;
-              }[];
-            emailAddress?: string;
-            isTenant: boolean;
-            parkingSpaceWaitingList?: {
-              /** Format: date-time */
-              queueTime: string;
-              queuePoints: number;
-              type: number;
-            };
-            specialAttention?: boolean;
-            leaseContactType?: string;
-          }[];
-      }) | null;
-    };
+            queueTime: string
+            queuePoints: number
+            type: number
+          }
+          specialAttention?: boolean
+          leaseContactType?: string
+        }[]
+      } | null
+    }
     InternalInspection: {
-      id: string;
-      status: string;
+      id: string
+      status: string
       /** Format: date-time */
-      date: string;
-      inspector: string;
-      type: string;
-      address: string;
-      apartmentCode: string | null;
-      leaseId: string;
-      masterKeyAccess: string | null;
-      residenceId: string;
-      isFurnished: boolean;
+      date: string
+      inspector: string
+      type: string
+      address: string
+      apartmentCode: string | null
+      leaseId: string
+      masterKeyAccess: string | null
+      residenceId: string
+      isFurnished: boolean
       /** Format: date-time */
-      startedAt: string | null;
+      startedAt: string | null
       /** Format: date-time */
-      endedAt: string | null;
-      isTenantPresent: boolean;
-      isNewTenantPresent: boolean;
-      hasRemarks: boolean;
-      notes: string | null;
-      totalCost: number | null;
-      remarkCount: number;
+      endedAt: string | null
+      isTenantPresent: boolean
+      isNewTenantPresent: boolean
+      hasRemarks: boolean
+      notes: string | null
+      totalCost: number | null
+      remarkCount: number
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12829,388 +13068,425 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
-      rooms: (({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
+        electricalSystem?: boolean
+      }
+      rooms:
+        | {
+            roomId: string
+            name?: string
+            conditions: {
+              details: string
+            }
+            actions: {
+              details: string[]
+            }
+            componentNotes: {
+              details: string
+            }
+            componentCosts: {
+              /** @default 0 */
+              details?: number
+            }
+            componentPhotos: {
+              details: string[]
+            }
+            componentCostResponsibilities: {
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              details?: 'tenant' | 'landlord' | null
+            }
+            photos: string[]
+            isApproved: boolean
+            isHandled: boolean
+            /** @default [] */
+            detailComponents?: {
+              id: string
+              type: string
+              label: string
+              note: string
               /** @default */
-              condition?: string;
-              cost?: number;
+              condition?: string
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default [] */
+            components?: {
+              componentId: string
+              label: string
+              condition: string
+              action: string[]
+              note: string
+              photos: string[]
+              cost?: number
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[]) | null;
-    };
+              costResponsibility?: 'tenant' | 'landlord' | null
+            }[]
+            /** @default false */
+            isAddedInThisInspection?: boolean
+          }[]
+        | null
+    }
     SaveInspectionDraftRequest: {
-      inspectorName: string;
-      rooms: ({
-          roomId: string;
-          name?: string;
-          conditions: {
-            details: string;
-          };
-          actions: {
-            details: string[];
-          };
-          componentNotes: {
-            details: string;
-          };
-          componentCosts: {
-            /** @default 0 */
-            details?: number;
-          };
-          componentPhotos: {
-            details: string[];
-          };
-          componentCostResponsibilities: {
-            /**
-             * @default null
-             * @enum {string|null}
-             */
-            details?: "tenant" | "landlord" | null;
-          };
-          photos: string[];
-          isApproved: boolean;
-          isHandled: boolean;
-          /** @default [] */
-          detailComponents?: ({
-              id: string;
-              type: string;
-              label: string;
-              note: string;
-              /** @default */
-              condition?: string;
-              cost?: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default [] */
-          components?: ({
-              componentId: string;
-              label: string;
-              condition: string;
-              action: string[];
-              note: string;
-              photos: string[];
-              cost?: number;
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              costResponsibility?: "tenant" | "landlord" | null;
-            })[];
-          /** @default false */
-          isAddedInThisInspection?: boolean;
-        })[];
-      isFurnished: boolean;
-      isTenantPresent?: boolean;
-      isNewTenantPresent?: boolean;
+      inspectorName: string
+      rooms: {
+        roomId: string
+        name?: string
+        conditions: {
+          details: string
+        }
+        actions: {
+          details: string[]
+        }
+        componentNotes: {
+          details: string
+        }
+        componentCosts: {
+          /** @default 0 */
+          details?: number
+        }
+        componentPhotos: {
+          details: string[]
+        }
+        componentCostResponsibilities: {
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          details?: 'tenant' | 'landlord' | null
+        }
+        photos: string[]
+        isApproved: boolean
+        isHandled: boolean
+        /** @default [] */
+        detailComponents?: {
+          id: string
+          type: string
+          label: string
+          note: string
+          /** @default */
+          condition?: string
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+        }[]
+        /** @default [] */
+        components?: {
+          componentId: string
+          label: string
+          condition: string
+          action: string[]
+          note: string
+          photos: string[]
+          cost?: number
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: 'tenant' | 'landlord' | null
+        }[]
+        /** @default false */
+        isAddedInThisInspection?: boolean
+      }[]
+      isFurnished: boolean
+      isTenantPresent?: boolean
+      isNewTenantPresent?: boolean
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean;
+        groundFaultBreaker?: boolean
         /** @default false */
-        smokeDetector?: boolean;
+        smokeDetector?: boolean
         /** @default false */
-        electricalSchema?: boolean;
+        electricalSchema?: boolean
         /** @default false */
-        electricalSystem?: boolean;
-      };
+        electricalSystem?: boolean
+      }
       /** Format: date-time */
-      date?: string;
-      type?: string;
-    };
+      date?: string
+      type?: string
+    }
     ComponentWriteBackError: {
-      componentId: string;
-      componentLabel: string;
-      message: string;
-    };
+      componentId: string
+      componentLabel: string
+      message: string
+    }
     AddInspectionRoomRequest: {
       /** @enum {string} */
-      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
-      caption?: string;
-    };
+      roomTypeCode:
+        | 'BAD'
+        | 'BAL'
+        | 'BRS'
+        | 'DUSCH'
+        | 'FÖR'
+        | 'GROV'
+        | 'HALL'
+        | 'KLÄD'
+        | 'KÖK'
+        | 'KOV'
+        | 'KV'
+        | 'MAT'
+        | 'PA'
+        | 'RUM'
+        | 'TRAPP'
+        | 'UP'
+        | 'VARD'
+        | 'WC'
+        | 'WC/DU1'
+      caption?: string
+    }
     FileListItem: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
-    };
+      size: number
+    }
     FileMetadata: {
       /** @description Full file path/name */
-      name: string;
+      name: string
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string;
+      lastModified: string
       /** @description ETag for file version */
-      etag: string;
+      etag: string
       /** @description File size in bytes */
-      size: number;
+      size: number
       /** @description Custom metadata key-value pairs */
       metaData?: {
-        [key: string]: string;
-      };
-    };
+        [key: string]: string
+      }
+    }
     FileUploadRequest: {
       /** @description Target file name/path */
-      fileName: string;
+      fileName: string
       /** @description Base64 encoded file content */
-      fileData: string;
+      fileData: string
       /** @description MIME type of the file */
-      contentType: string;
-    };
+      contentType: string
+    }
     FileUploadResponse: {
       /** @description Stored file name/path */
-      fileName: string;
+      fileName: string
       /** @description Success message */
-      message: string;
-    };
+      message: string
+    }
     FileUrlResponse: {
       /**
        * Format: uri
        * @description Presigned download URL
        */
-      url: string;
+      url: string
       /** @description URL expiry time in seconds */
-      expiresIn: number;
-    };
+      expiresIn: number
+    }
     FileExistsResponse: {
       /** @description Whether the file exists */
-      exists: boolean;
-    };
+      exists: boolean
+    }
     ListFilesResponse: {
       /** @description Array of file metadata objects */
       files: {
-          /** @description Full file path/name */
-          name: string;
-          /**
-           * Format: date-time
-           * @description ISO 8601 timestamp
-           */
-          lastModified: string;
-          /** @description ETag for file version */
-          etag: string;
-          /** @description File size in bytes */
-          size: number;
-        }[];
-    };
+        /** @description Full file path/name */
+        name: string
+        /**
+         * Format: date-time
+         * @description ISO 8601 timestamp
+         */
+        lastModified: string
+        /** @description ETag for file version */
+        etag: string
+        /** @description File size in bytes */
+        size: number
+      }[]
+    }
     ListFilesQuery: {
       /** @description Filter files by prefix */
-      prefix?: string;
-    };
+      prefix?: string
+    }
     FileUrlQuery: {
       /**
        * @description URL expiry time
        * @default 3600
        */
-      expirySeconds?: number;
-    };
+      expirySeconds?: number
+    }
     BulkSmsResult: {
       /** @description Phone numbers that received SMS */
-      successful: string[];
+      successful: string[]
       /** @description Invalid phone numbers */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     BulkEmailResult: {
       /** @description Email addresses that received email */
-      successful: string[];
+      successful: string[]
       /** @description Invalid email addresses */
-      invalid: string[];
-      totalSent: number;
-      totalInvalid: number;
-    };
+      invalid: string[]
+      totalSent: number
+      totalInvalid: number
+    }
     KeycloakUser: {
-      id?: string;
-      username?: string;
-      firstName?: string;
-      lastName?: string;
-      email?: string;
-    };
+      id?: string
+      username?: string
+      firstName?: string
+      lastName?: string
+      email?: string
+    }
     RentalPropertyResponse: {
       content?: {
-        id?: string;
-        type?: string;
+        id?: string
+        type?: string
         property?: {
-          rentalTypeCode?: string;
-          rentalType?: string;
-          address?: string;
-          code?: string;
-          number?: string;
-          type?: string;
-          roomTypeCode?: string;
-          entrance?: string;
-          floor?: string;
-          hasElevator?: boolean;
-          washSpace?: string;
-          area?: number;
-          estateCode?: string;
-          estate?: string;
-          buildingCode?: string;
-          building?: string;
-        };
-      };
+          rentalTypeCode?: string
+          rentalType?: string
+          address?: string
+          code?: string
+          number?: string
+          type?: string
+          roomTypeCode?: string
+          entrance?: string
+          floor?: string
+          hasElevator?: boolean
+          washSpace?: string
+          area?: number
+          estateCode?: string
+          estate?: string
+          buildingCode?: string
+          building?: string
+        }
+      }
       _links?: {
         self?: {
-          href?: string;
-        };
+          href?: string
+        }
         link?: {
-          href?: string;
-          templated?: boolean;
-        };
-      };
-    };
-    ContactV1: ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "individual";
-      personal: {
-        nationalRegistrationNumber: string | null;
-        birthDate: string | null;
-        firstName: string | null;
-        lastName: string | null;
-        fullName: string;
-      };
-      trustee?: {
-        contactCode: string;
-        fullName?: string;
-      };
-    }) | ({
-      contactCode: string;
-      communication: {
-        phoneNumbers: ({
-            phoneNumber: string;
-            /** @enum {string} */
-            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
-            comment?: string;
-            isPrimary: boolean;
-          })[];
-        emailAddresses: {
-            emailAddress: string;
-            type: string;
-            isPrimary: boolean;
-          }[];
-        specialAttention: boolean;
-      };
-      addresses: ({
-          careOf?: string;
-          street: string | null;
-          zipCode: string | null;
-          city: string | null;
-          region: string | null;
-          country: string | null;
-        })[];
-      /** @enum {string} */
-      type: "organisation";
-      organisation: {
-        organisationNumber: string;
-        name: string;
-      };
-    });
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+          href?: string
+          templated?: boolean
+        }
+      }
+    }
+    ContactV1:
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'individual'
+          personal: {
+            nationalRegistrationNumber: string | null
+            birthDate: string | null
+            firstName: string | null
+            lastName: string | null
+            fullName: string
+          }
+          trustee?: {
+            contactCode: string
+            fullName?: string
+          }
+        }
+      | {
+          contactCode: string
+          communication: {
+            phoneNumbers: {
+              phoneNumber: string
+              /** @enum {string} */
+              type:
+                | 'work'
+                | 'home'
+                | 'mobile'
+                | 'direct-line'
+                | 'fax'
+                | 'pager'
+                | 'unspecified'
+              comment?: string
+              isPrimary: boolean
+            }[]
+            emailAddresses: {
+              emailAddress: string
+              type: string
+              isPrimary: boolean
+            }[]
+            specialAttention: boolean
+          }
+          addresses: {
+            careOf?: string
+            street: string | null
+            zipCode: string | null
+            city: string | null
+            region: string | null
+            country: string | null
+          }[]
+          /** @enum {string} */
+          type: 'organisation'
+          organisation: {
+            organisationNumber: string
+            name: string
+          }
+        }
+  }
+  responses: never
+  parameters: never
+  requestBodies: never
+  headers: never
+  pathItems: never
 }
 
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 
-export type external = Record<string, never>;
+export type external = Record<string, never>
 
-export type operations = Record<string, never>;
+export type operations = Record<string, never>

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -3,8 +3,9 @@
  * Do not make direct changes to the file.
  */
 
+
 export interface paths {
-  '/auth/generatehash': {
+  "/auth/generatehash": {
     /**
      * Generates a salt and hashes the given password using that salt.
      * @description Generates a salt and hashes the given password using that salt. Pass cleartext password as query parameter.
@@ -13,18 +14,18 @@ export interface paths {
       parameters: {
         query: {
           /** @description The cleartext password that should be hashed */
-          password: string
-        }
-      }
+          password: string;
+        };
+      };
       responses: {
         /** @description Hashed password and salt */
         200: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/generatetoken': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/generatetoken": {
     /**
      * Generates a JWT token
      * @description Validates username and password from request body and returns a JWT token.
@@ -32,41 +33,41 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/x-www-form-urlencoded': {
-            username?: string
-            password?: string
-          }
-        }
-      }
+          "application/x-www-form-urlencoded": {
+            username?: string;
+            password?: string;
+          };
+        };
+      };
       responses: {
         /** @description A valid JWT token */
         200: {
           content: {
-            'application/json': {
-              token?: string
-            }
-          }
-        }
+            "application/json": {
+              token?: string;
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
-              errorMessage?: string
-            }
-          }
-        }
+            "application/json": {
+              errorMessage?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/auth/login': {
+            "application/json": {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/auth/login": {
     /**
      * Redirects to Keycloak login
      * @description Redirects the user to the Keycloak login page
@@ -75,12 +76,12 @@ export interface paths {
       responses: {
         /** @description Redirect to Keycloak login */
         302: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/callback': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/callback": {
     /**
      * OAuth callback endpoint
      * @description Handles the OAuth callback from Keycloak
@@ -88,21 +89,21 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            code?: string
-            redirectUri?: string
-          }
-        }
-      }
+          "application/json": {
+            code?: string;
+            redirectUri?: string;
+          };
+        };
+      };
       responses: {
         /** @description User profile information */
         200: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/logout': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/logout": {
     /**
      * Logout endpoint
      * @description Clears authentication cookies and redirects to Keycloak logout
@@ -111,12 +112,12 @@ export interface paths {
       responses: {
         /** @description Redirect to login page */
         302: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/profile': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/profile": {
     /**
      * Get user profile
      * @description Returns the authenticated user's profile information
@@ -125,16 +126,16 @@ export interface paths {
       responses: {
         /** @description User profile information */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Unauthorized */
         401: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/refresh': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/refresh": {
     /**
      * Refresh access token
      * @description Uses refresh_token cookie to get new access_token
@@ -143,16 +144,16 @@ export interface paths {
       responses: {
         /** @description Token refreshed successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid or expired refresh token */
         401: {
-          content: never
-        }
-      }
-    }
-  }
-  '/auth/roles/{roleName}/users': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/auth/roles/{roleName}/users": {
     /**
      * Get users by realm role (via group membership)
      * @description Returns all users that belong to groups assigned the given Keycloak realm role. Users are deduplicated across groups.
@@ -161,44 +162,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The name of the Keycloak realm role */
-          roleName: string
-        }
-      }
+          roleName: string;
+        };
+      };
       responses: {
         /** @description List of users with the given role */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeycloakUser'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeycloakUser"][];
+            };
+          };
+        };
         /** @description Unauthorized */
         401: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Forbidden — insufficient permissions to query role members */
         403: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Role not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Keycloak unreachable */
         502: {
-          content: never
-        }
-      }
-    }
-  }
-  openapi: {}
-  security: {}
-  '/sendBulkSms': {
+          content: never;
+        };
+      };
+    };
+  };
+  "openapi": {
+  };
+  "security": {
+  };
+  "/sendBulkSms": {
     /**
      * Send SMS to multiple contacts
      * @description Send SMS messages to multiple phone numbers
@@ -206,35 +209,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Array of phone numbers */
-            phoneNumbers: string[]
+            phoneNumbers: string[];
             /** @description SMS message content */
-            text: string
-          }
-        }
-      }
+            text: string;
+          };
+        };
+      };
       responses: {
         /** @description SMS sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BulkSmsResult']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BulkSmsResult"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/sendBulkEmail': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/sendBulkEmail": {
     /**
      * Send email to multiple contacts
      * @description Send email messages to multiple email addresses
@@ -242,37 +245,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Array of email addresses */
-            emails: string[]
+            emails: string[];
             /** @description Email subject */
-            subject: string
+            subject: string;
             /** @description Email message content */
-            text: string
-          }
-        }
-      }
+            text: string;
+          };
+        };
+      };
       responses: {
         /** @description Email sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BulkEmailResult']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BulkEmailResult"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/getLinearTickets': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/getLinearTickets": {
     /**
      * Get Linear tickets with mimer-visible label
      * @description Fetch Linear issues that have the mimer-visible label
@@ -281,24 +284,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of tickets to fetch */
-          first?: number
+          first?: number;
           /** @description Cursor for pagination */
-          after?: string
-        }
-      }
+          after?: string;
+        };
+      };
       responses: {
         /** @description Linear tickets fetched successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/createLinearErrand': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/createLinearErrand": {
     /**
      * Create a new Linear errand
      * @description Create a new issue in Linear with specified team, project, and labels
@@ -306,33 +309,33 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Errand title */
-            title: string
+            title: string;
             /** @description Errand description */
-            description: string
+            description: string;
             /** @description Label ID for category (Bug, Improvement, etc.) */
-            categoryLabelId: string
-          }
-        }
-      }
+            categoryLabelId: string;
+          };
+        };
+      };
       responses: {
         /** @description Linear errand created successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/getLinearLabels': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/getLinearLabels": {
     /**
      * Get Linear category labels
      * @description Fetch available category labels (Bug, Improvement, new feature)
@@ -341,16 +344,16 @@ export interface paths {
       responses: {
         /** @description Linear labels fetched successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/health': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/health": {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -360,35 +363,35 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /**
                * @description Name of the system.
                * @example core
                */
-              name?: string
+              name?: string;
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string
-              subsystems?: {
-                /** @description Name of the subsystem. */
-                name?: string
-                /**
-                 * @description Status of the subsystem.
-                 * @enum {string}
-                 */
-                status?: 'active' | 'impaired' | 'failure' | 'unknown'
-                /** @description Additional details about the subsystem status. */
-                details?: string
-              }[]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/leases/search': {
+              status?: string;
+              subsystems?: ({
+                  /** @description Name of the subsystem. */
+                  name?: string;
+                  /**
+                   * @description Status of the subsystem.
+                   * @enum {string}
+                   */
+                  status?: "active" | "impaired" | "failure" | "unknown";
+                  /** @description Additional details about the subsystem status. */
+                  details?: string;
+                })[];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/leases/search": {
     /**
      * Search and filter leases
      * @description Search leases with comprehensive filtering options including text search, object type, status, date ranges, and property hierarchy filters.
@@ -397,70 +400,64 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking)) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
+          buildingManager?: string[];
           /** @description Page number */
-          page?: number
+          page?: number;
           /** @description Items per page */
-          limit?: number
+          limit?: number;
           /** @description Include Upphört (ended) contracts. Excluded by default for performance. */
-          includeEnded?: boolean
+          includeEnded?: boolean;
           /** @description Sort field */
-          sortBy?:
-            | 'leaseStartDate'
-            | 'lastDebitDate'
-            | 'leaseId'
-            | 'address'
-            | 'objectType'
-            | 'rentalObjectCode'
+          sortBy?: "leaseStartDate" | "lastDebitDate" | "leaseId" | "address" | "objectType" | "rentalObjectCode";
           /** @description Sort direction */
-          sortOrder?: 'asc' | 'desc'
-        }
-      }
+          sortOrder?: "asc" | "desc";
+        };
+      };
       responses: {
         /** @description Successfully retrieved lease search results with pagination */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['LeaseSearchResult'][]
-              _meta?: components['schemas']['PaginationMeta']
-              _links?: components['schemas']['PaginationLinks'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["LeaseSearchResult"][];
+              _meta?: components["schemas"]["PaginationMeta"];
+              _links?: components["schemas"]["PaginationLinks"][];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/building-managers': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/building-managers": {
     /**
      * Get all building managers
      * @description Returns a list of all building managers (Kvartersvärd) with their code, name and district.
@@ -470,23 +467,23 @@ export interface paths {
         /** @description List of building managers */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                code?: string
-                name?: string
-                district?: string
-              }[]
-            }
-          }
-        }
+                  code?: string;
+                  name?: string;
+                  district?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/parking-space-types': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/parking-space-types": {
     /**
      * Get all parking space types
      * @description Returns a list of all parking space types (P-platstyper).
@@ -496,22 +493,22 @@ export interface paths {
         /** @description List of parking space types */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                code?: string
-                caption?: string
-              }[]
-            }
-          }
-        }
+                  code?: string;
+                  caption?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/export': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/export": {
     /**
      * Export leases to Excel
      * @description Export lease search results to Excel file. Uses same filters as /leases/search but without pagination.
@@ -520,44 +517,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
-        }
-      }
+          buildingManager?: string[];
+        };
+      };
       responses: {
         /** @description Excel file download */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/from-lease-search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/from-lease-search": {
     /**
      * Get contacts matching lease search filters
      * @description Retrieves contact information for tenants matching the given lease search filters.
@@ -566,48 +563,48 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Free-text search (contract ID, tenant name, PNR, contact code, address) */
-          q?: string
+          q?: string;
           /** @description Object types (e.g., residence, parking) */
-          objectType?: string[]
+          objectType?: string[];
           /** @description Contract status filter (0=Current, 1=Upcoming, 2=AboutToEnd, 3=Ended) */
-          status?: ('0' | '1' | '2' | '3')[]
+          status?: ("0" | "1" | "2" | "3")[];
           /** @description Minimum start date (YYYY-MM-DD) */
-          startDateFrom?: string
+          startDateFrom?: string;
           /** @description Maximum start date (YYYY-MM-DD) */
-          startDateTo?: string
+          startDateTo?: string;
           /** @description Minimum end date (YYYY-MM-DD) */
-          endDateFrom?: string
+          endDateFrom?: string;
           /** @description Maximum end date (YYYY-MM-DD) */
-          endDateTo?: string
+          endDateTo?: string;
           /** @description Property/estate names */
-          property?: string[]
+          property?: string[];
           /** @description Building codes */
-          buildingCodes?: string[]
+          buildingCodes?: string[];
           /** @description Area codes (Område) */
-          areaCodes?: string[]
+          areaCodes?: string[];
           /** @description District names */
-          districtNames?: string[]
+          districtNames?: string[];
           /** @description Building manager names (Kvartersvärd) */
-          buildingManager?: string[]
-        }
-      }
+          buildingManager?: string[];
+        };
+      };
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ContactInfo'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ContactInfo"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/leases/by-rental-property-id/{rentalPropertyId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/leases/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get leases with related entities for a specific rental property id
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified rental property id.
@@ -616,38 +613,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
+          includeTerminatedLeases?: boolean;
           /** @description Whether to include contact information in the response */
-          includeContacts?: boolean
+          includeContacts?: boolean;
           /** @description Whether to include rent information in the response */
-          includeRentInfo?: boolean
-        }
+          includeRentInfo?: boolean;
+        };
         path: {
           /** @description Rental roperty id of the building/residence to fetch leases for. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/leases/by-pnr/{pnr}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/leases/by-pnr/{pnr}": {
     /**
      * Get leases with related entities for a specific Personal Number (PNR)
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified Personal Number (PNR).
@@ -656,28 +653,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
-        }
+          includeTerminatedLeases?: boolean;
+        };
         path: {
           /** @description Personal Number (PNR) of the individual to fetch leases for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/leases/by-contact-code/{contactCode}': {
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/leases/by-contact-code/{contactCode}": {
     /**
      * Get leases with related entities for a specific contact code
      * @description Retrieves lease information along with related entities (such as tenants, properties, etc.) for the specified contact code.
@@ -686,28 +683,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include upcoming leases in the response */
-          includeUpcomingLeases?: boolean
+          includeUpcomingLeases?: boolean;
           /** @description Whether to include terminated leases in the response */
-          includeTerminatedLeases?: boolean
-        }
+          includeTerminatedLeases?: boolean;
+        };
         path: {
           /** @description Contact code of the individual to fetch leases for. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with leases and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/consumer-reports/by-pnr/{pnr}': {
+            "application/json": {
+              content?: components["schemas"]["Lease"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/consumer-reports/by-pnr/{pnr}": {
     /**
      * Get consumer report for a specific Personal Number (PNR)
      * @description Retrieves credit information and consumer report for the specified Personal Number (PNR).
@@ -716,20 +713,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch credit information for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with credit information and consumer report */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/contacts/by-pnr/{pnr}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/contacts/by-pnr/{pnr}": {
     /**
      * Get contact information for a specific Personal Number (PNR)
      * @description Retrieves contact information associated with the specified Personal Number (PNR).
@@ -738,20 +735,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description Personal Number (PNR) of the individual to fetch contact information for. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with contact information */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/offers': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/offers": {
     /**
      * Get offers for a contact
      * @description Retrieves all offers associated with a specific contact based on the provided contact code.
@@ -760,28 +757,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique code identifying the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with a list of offers for the contact. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description The contact was not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve offers. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/comments': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/comments": {
     /**
      * Get comments for a contact
      * @description Retrieves all comments/notes for a contact from Xpand
@@ -790,57 +787,57 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by comment type. If omitted, returns all comment types. */
-          commentType?: 'Standard' | 'Sökande'
-        }
+          commentType?: "Standard" | "Sökande";
+        };
         path: {
           /**
            * @description The unique code identifying the contact.
            * @example P086890
            */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved comments */
         200: {
           content: {
-            'application/json': {
-              content?: {
-                contactKey?: string
-                contactCode?: string
-                commentKey?: string
-                id?: number
-                commentType?: string | null
-                /** @description Array of individual notes parsed from comment text */
-                notes?: {
-                  /**
-                   * Format: date
-                   * @description Date in YYYY-MM-DD format
-                   */
-                  date?: string | null
-                  /** @description Time in HH:MM format */
-                  time?: string | null
-                  /** @description Author initials (6 letters) or "Notering utan signatur" */
-                  author?: string
-                  /** @description Note content (plain text) */
-                  text?: string
-                }[]
-                priority?: number | null
-                kind?: number | null
-              }[]
-            }
-          }
-        }
+            "application/json": {
+              content?: ({
+                  contactKey?: string;
+                  contactCode?: string;
+                  commentKey?: string;
+                  id?: number;
+                  commentType?: string | null;
+                  /** @description Array of individual notes parsed from comment text */
+                  notes?: ({
+                      /**
+                       * Format: date
+                       * @description Date in YYYY-MM-DD format
+                       */
+                      date?: string | null;
+                      /** @description Time in HH:MM format */
+                      time?: string | null;
+                      /** @description Author initials (6 letters) or "Notering utan signatur" */
+                      author?: string;
+                      /** @description Note content (plain text) */
+                      text?: string;
+                    })[];
+                  priority?: number | null;
+                  kind?: number | null;
+                })[];
+            };
+          };
+        };
         /** @description Contact not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Create or append to contact comment
      * @description Creates a new comment if none exists for the contact, or appends to existing comment in Xpand
@@ -852,56 +849,56 @@ export interface paths {
            * @description The unique code identifying the contact
            * @example P086890
            */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /**
              * @description Plain text content of the note
              * @example Customer contacted regarding lease renewal
              */
-            content: string
+            content: string;
             /**
              * @description Author name or code (1-50 characters)
              * @example DAVLIN
              */
-            author: string
+            author: string;
             /**
              * @description Type of comment. Defaults to 'Standard' if not specified.
              * @default Standard
              * @enum {string}
              */
-            commentType?: 'Standard' | 'Sökande'
-          }
-        }
-      }
+            commentType?: "Standard" | "Sökande";
+          };
+        };
+      };
       responses: {
         /** @description Comment updated successfully (appended to existing comment) */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Comment created successfully (new comment) */
         201: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request body (validation failed) */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Contact not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/applicants/{contactCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/applicants/{contactCode}": {
     /**
      * Get a specific offer for an applicant
      * @description Retrieve details of a specific offer associated with an applicant using contact code and offer ID.
@@ -910,30 +907,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the offer. */
-          offerId: string
+          offerId: string;
           /** @description The unique code identifying the applicant. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Details of the specified offer. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Offer not found for the specified contact code and offer ID. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/by-listing-id/{listingId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/by-listing-id/{listingId}": {
     /**
      * Get offers for a specific listing
      * @description Get all offers for a listing.
@@ -942,24 +939,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description A list of offers. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/by-listing-id/{listingId}/active': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/by-listing-id/{listingId}/active": {
     /**
      * Gets active offer for a specific listing
      * @description Get an offer for a listing.
@@ -968,24 +965,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the listing. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description The active offer. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/search": {
     /**
      * Search contacts by name, PNR, contact code, or email
      * @description Search contacts by contact code, personal registration number, name, or email. Supports searching by full name or partial name (e.g., "john smith" or "smith"). Multiple search terms are matched with AND logic. Email search is triggered when query contains "@".
@@ -994,30 +991,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description Search query - can be contact code, personal registration number, name, or email (if query contains "@"). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successful response with search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Contact'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Contact"][];
+            };
+          };
+        };
         /** @description Bad request. The query parameter 'q' must be a string. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve contacts. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/for-identity-check': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/for-identity-check": {
     /**
      * Get contacts for deceased/protected identity check
      * @description Returns paginated list of person contacts eligible for deceased/protected identity verification. Note - Results are validated using the personnummer package, so the actual count may be fewer than the requested limit if invalid personnummer are filtered out.
@@ -1026,38 +1023,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved contacts for identity check. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['IdentityCheckContact'][]
+            "application/json": {
+              content?: components["schemas"]["IdentityCheckContact"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}": {
     /**
      * Get contact by contact code
      * @description Retrieves a contact based on the provided contact code.
@@ -1066,22 +1063,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Contact']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/tenants/by-contact-code/{contactCode}': {
+            "application/json": {
+              content?: components["schemas"]["Contact"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/tenants/by-contact-code/{contactCode}": {
     /**
      * Get tenant by contact code
      * @description Retrieves a tenant based on the provided contact code.
@@ -1090,31 +1087,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to identify the contact. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant information. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The tenant data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve Tenant information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/by-phone-number/{pnr}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/by-phone-number/{pnr}": {
     /**
      * Get contact by phone number
      * @description Retrieves a contact based on the provided phone number.
@@ -1123,20 +1120,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The phone number used to identify the contact. */
-          pnr: string
-        }
-      }
+          pnr: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested contact */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/leases/{id}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/leases/{id}": {
     /**
      * Get lease by ID
      * @description Retrieves lease details along with related entities based on the provided ID.
@@ -1145,22 +1142,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the lease to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested lease and related entities */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Lease']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/accept': {
+            "application/json": {
+              content?: components["schemas"]["Lease"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/accept": {
     /**
      * Accept an offer
      * @description Accepts an offer for the contact of the contactCode provided
@@ -1169,22 +1166,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to accept */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer accepted successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to accept the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/deny': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/deny": {
     /**
      * Deny an offer
      * @description Denies an offer
@@ -1193,22 +1190,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to deny */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer denied successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to deny the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/offers/{offerId}/expire': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/offers/{offerId}/expire": {
     /**
      * Expire an offer
      * @description Expires an offer
@@ -1217,22 +1214,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the offer to expire */
-          offerId: string
-        }
-      }
+          offerId: string;
+        };
+      };
       responses: {
         /** @description Offer expired successful. */
         202: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to expire the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/applicants': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/applicants": {
     /**
      * Get applicants by contact code
      * @description Retrieves applicants based on the contact code.
@@ -1241,20 +1238,20 @@ export interface paths {
       parameters: {
         query: {
           /** @description The contact code used to fetch applicants. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of applicants. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/validate-rental-rules/property/{contactCode}/{rentalObjectCode}": {
     /**
      * Validate property rental rules for applicant
      * @description Validate property rental rules for an applicant based on contact code and listing ID.
@@ -1263,61 +1260,61 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The xpand rental object code of the property. */
-          rentalObjectCode: number
-        }
-      }
+          rentalObjectCode: number;
+        };
+      };
       responses: {
         /** @description No property rental rules apply to this property. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string
+              applicationType?: string;
               /** @example No property rental rules applies to this property. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Rental object code is not a parking space. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental object code entity is not a parking space. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Applicant is not eligible for the property based on property rental rules. */
         403: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description Listing, property info, or applicant not found. */
         404: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description An error occurred while validating property rental rules. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example An error occurred while validating property rental rules. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants/validate-rental-rules/residential-area/{contactCode}/{districtCode}": {
     /**
      * Validate residential area rental rules for applicant
      * @description Validate residential area rental rules for an applicant based on contact code and district code.
@@ -1326,52 +1323,52 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The xpand district code of the residential area to validate against. */
-          districtCode: string
-        }
-      }
+          districtCode: string;
+        };
+      };
       responses: {
         /** @description Either no residential area rental rules apply or applicant is eligible to apply for parking space. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Additional - applicant is eligible for applying for an additional parking space. Replace - applicant is eligible for replacing their current parking space in the same residential area or property. */
-              applicationType?: string
-              reason?: string
-            }
-          }
-        }
+              applicationType?: string;
+              reason?: string;
+            };
+          };
+        };
         /** @description Applicant is not eligible for the listing based on residential area rental rules. */
         403: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant does not have any current or upcoming housing contracts in the residential area. */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Listing or applicant not found. */
         404: {
           content: {
-            'application/json': {
-              reason?: string
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+            };
+          };
+        };
         /** @description An error occurred while validating residential area rental rules. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example An error occurred while validating residential area rental rules. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants-with-listings/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants-with-listings/by-contact-code/{contactCode}": {
     /**
      * Get applicants with listings by contact code
      * @description Retrieves applicants along with their listings based on the contact code.
@@ -1380,20 +1377,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch applicants and their associated listings. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of applicants with their listings. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{contactCode}/{listingId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{contactCode}/{listingId}": {
     /**
      * Get applicant by contact code and listing ID
      * @description Retrieves an applicant by their contact code and listing ID.
@@ -1402,22 +1399,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code of the applicant. */
-          contactCode: string
+          contactCode: string;
           /** @description The ID of the listing associated with the applicant. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of the applicant. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{applicantId}/by-manager': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{applicantId}/by-manager": {
     /**
      * Withdraw applicant by manager
      * @description Withdraws an applicant by the manager using the applicant ID.
@@ -1426,32 +1423,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string
-        }
-      }
+          applicantId: string;
+        };
+      };
       responses: {
         /** @description Successful withdrawal of the applicant by manager. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant successfully withdrawn by manager. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Error message describing the issue. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/applicants/{applicantId}/by-user/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/applicants/{applicantId}/by-user/{contactCode}": {
     /**
      * Withdraw applicant by user
      * @description Withdraws an applicant by the user identified by contact code and applicant ID.
@@ -1460,34 +1457,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the applicant to be withdrawn. */
-          applicantId: string
+          applicantId: string;
           /** @description The contact code of the user initiating the withdrawal. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successful withdrawal of the applicant by user. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Applicant successfully withdrawn by user. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to withdraw the applicant. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Error message describing the issue. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile": {
     /**
      * Gets an application profile by contact code
      * @description Retrieve application profile information by contact code.
@@ -1496,31 +1493,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile/admin': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile/admin": {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1529,41 +1526,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Successfully created application profile. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/application-profile/client': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/application-profile/client": {
     /**
      * Creates or updates an application profile by contact code
      * @description Create or update application profile information by contact code.
@@ -1572,41 +1569,41 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated application profile. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Successfully created application profile. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The application profile data. */
-              data?: Record<string, never>
-            }
-          }
-        }
+              data?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error. Failed to update application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/contacts/{contactCode}/{rentalObjectCode}/verify-application': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/contacts/{contactCode}/{rentalObjectCode}/verify-application": {
     /**
      * Validate max num residents.
      * @description Checks if application is allowed based on current number of residents.
@@ -1615,32 +1612,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code associated with the application profile. */
-          contactCode: string
+          contactCode: string;
           /** @description The rental object code associated with the rental property. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Application allowed. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Application not allowed. */
         403: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to retrieve application profile information. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings": {
     /**
      * Get listings
      * @description Retrieves a list of listings.
@@ -1649,28 +1646,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The listing category, either PARKING_SPACE, APARTMENT or STORAGE. */
-          listingCategory?: string
+          listingCategory?: string;
           /** @description true for published listings, false for unpublished listings. */
-          published?: boolean
+          published?: boolean;
           /** @description The rental rule for the listings, either SCORED or NON_SCORED. */
-          rentalRule?: string
+          rentalRule?: string;
           /** @description A contact code to filter out listings that are not valid to rent for the contact. */
-          validToRentForContactCode?: string
+          validToRentForContactCode?: string;
           /** @description A Rental Object Code to filter the listings. */
-          rentalObjectCode?: string
-        }
-      }
+          rentalObjectCode?: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested list of listings. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}": {
     /**
      * Delete a Listing by ID
      * @description Deletes a listing by it's ID.
@@ -1679,31 +1676,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       responses: {
         /** @description Successfully deleted listing. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Conflict. */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/status': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/status": {
     /**
      * Update a listings status by ID
      * @description Updates a listing status by it's ID.
@@ -1712,36 +1709,36 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the listing to delete. */
-          listingId: number
-        }
-      }
+          listingId: number;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Successfully updated listing. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/offers': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/offers": {
     /**
      * Create an offer for a listing
      * @description Creates an offer for the specified listing.
@@ -1750,22 +1747,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to create an offer for. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Offer creation successful. */
         201: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to create the offer. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings/{listingId}/applicants/details': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings/{listingId}/applicants/details": {
     /**
      * Get listing by ID with detailed applicants
      * @description Retrieves a listing by ID along with detailed information about its applicants.
@@ -1774,20 +1771,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to fetch along with detailed applicant information. */
-          listingId: string
-        }
-      }
+          listingId: string;
+        };
+      };
       responses: {
         /** @description Successful retrieval of the listing with detailed applicant information. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings/{id}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings/{id}": {
     /**
      * Get listing by ID
      * @description Retrieves details of a listing based on the provided ID.
@@ -1796,20 +1793,20 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the listing to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested listing details. */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/listings-with-applicants': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/listings-with-applicants": {
     /**
      * Get listings with applicants
      * @description Retrieves a list of listings along with their associated applicants.
@@ -1818,24 +1815,24 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filters listings by one of the above types. Must be one of the specified values. */
-          type?: 'published' | 'ready-for-offer' | 'offered' | 'historical'
-        }
-      }
+          type?: "published" | "ready-for-offer" | "offered" | "historical";
+        };
+      };
       responses: {
         /** @description Successful response with listings and their applicants. */
         200: {
           content: {
-            'application/json': Record<string, never>[]
-          }
-        }
+            "application/json": Record<string, never>[];
+          };
+        };
         /** @description Internal server error. Failed to retrieve listings with applicants. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listings/batch': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listings/batch": {
     /**
      * Create multiple listings
      * @description Create multiple listings in a single request.
@@ -1843,54 +1840,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            listings: {
-              rentalObjectCode: string
-              /** Format: date-time */
-              publishedFrom: string
-              /** Format: date-time */
-              publishedTo: string
-              /** @enum {string} */
-              status:
-                | 'ACTIVE'
-                | 'INACTIVE'
-                | 'CLOSED'
-                | 'ASSIGNED'
-                | 'EXPIRED'
-                | 'NO_APPLICANTS'
-              /** @enum {string} */
-              rentalRule: 'SCORED' | 'NON_SCORED'
-              /** @enum {string} */
-              listingCategory: 'PARKING_SPACE' | 'APARTMENT' | 'STORAGE'
-            }[]
-          }
-        }
-      }
+          "application/json": {
+            listings: ({
+                rentalObjectCode: string;
+                /** Format: date-time */
+                publishedFrom: string;
+                /** Format: date-time */
+                publishedTo: string;
+                /** @enum {string} */
+                status: "ACTIVE" | "INACTIVE" | "CLOSED" | "ASSIGNED" | "EXPIRED" | "NO_APPLICANTS";
+                /** @enum {string} */
+                rentalRule: "SCORED" | "NON_SCORED";
+                /** @enum {string} */
+                listingCategory: "PARKING_SPACE" | "APARTMENT" | "STORAGE";
+              })[];
+          };
+        };
+      };
       responses: {
         /** @description All listings created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Partial success. Some listings created, some failed. */
         207: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request. Invalid input data. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. Failed to create listings. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/vacant-parkingspaces': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/vacant-parkingspaces": {
     /**
      * Get all vacant parking spaces
      * @description Retrieves a list of all vacant parking spaces.
@@ -1900,39 +1891,39 @@ export interface paths {
         /** @description A list of vacant parking spaces. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalObjectCode?: string
-                address?: string
-                monthlyRent?: number
-                propertyCaption?: string
-                propertyCode?: string
-                residentialAreaCode?: string
-                residentialAreaCaption?: string
-                objectTypeCaption?: string
-                objectTypeCode?: string
-                /** Format: date-time */
-                vacantFrom?: string
-                districtCaption?: string
-                districtCode?: string
-                braArea?: number
-              }[]
-            }
-          }
-        }
+                  rentalObjectCode?: string;
+                  address?: string;
+                  monthlyRent?: number;
+                  propertyCaption?: string;
+                  propertyCode?: string;
+                  residentialAreaCode?: string;
+                  residentialAreaCaption?: string;
+                  objectTypeCaption?: string;
+                  objectTypeCode?: string;
+                  /** Format: date-time */
+                  vacantFrom?: string;
+                  districtCaption?: string;
+                  districtCode?: string;
+                  braArea?: number;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve vacant parking spaces. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rental-objects/by-code/{rentalObjectCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rental-objects/by-code/{rentalObjectCode}": {
     /**
      * Get a rental object by code
      * @description Fetches a rental object by Rental Object Code.
@@ -1941,46 +1932,46 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the rental object to fetch. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rental object. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalObjectCode?: string
-                address?: string
-                monthlyRent?: number
-                propertyCaption?: string
-                propertyCode?: string
-                residentialAreaCode?: string
-                residentialAreaCaption?: string
-                objectTypeCaption?: string
-                objectTypeCode?: string
-                /** Format: date-time */
-                vacantFrom?: string
-                districtCaption?: string
-                districtCode?: string
-                braArea?: number
-              }[]
-            }
-          }
-        }
+                  rentalObjectCode?: string;
+                  address?: string;
+                  monthlyRent?: number;
+                  propertyCaption?: string;
+                  propertyCode?: string;
+                  residentialAreaCode?: string;
+                  residentialAreaCaption?: string;
+                  objectTypeCaption?: string;
+                  objectTypeCode?: string;
+                  /** Format: date-time */
+                  vacantFrom?: string;
+                  districtCaption?: string;
+                  districtCode?: string;
+                  braArea?: number;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error. Failed to fetch rental object. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description The error message. */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/listing-text-content/{rentalObjectCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/listing-text-content/{rentalObjectCode}": {
     /**
      * Get listing text content by rental object code
      * @description Fetch the listing text content for a specific rental object.
@@ -1989,28 +1980,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to fetch text content for. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Listing text content object */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update listing text content
      * @description Update existing listing text content.
@@ -2019,37 +2010,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to update. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateListingTextContentRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateListingTextContentRequest"];
+        };
+      };
       responses: {
         /** @description Listing text content updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete listing text content
      * @description Delete listing text content.
@@ -2058,26 +2049,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code of the listing text content to delete. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Listing text content deleted successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/listing-text-content': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/listing-text-content": {
     /**
      * Create listing text content
      * @description Create new listing text content for a rental object.
@@ -2085,34 +2076,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateListingTextContentRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateListingTextContentRequest"];
+        };
+      };
       responses: {
         /** @description Listing text content created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListingTextContent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListingTextContent"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Listing text content already exists for rental object code */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/floorplan': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/floorplan": {
     /**
      * Get floor plan for a rental property
      * @description Returns the floor plan image for the specified rental property.
@@ -2121,100 +2112,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved floor plan image */
         200: {
           content: {
-            'image/jpeg': string
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-options': {
+            "image/jpeg": string;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-options": {
     /** Get room types with material options by rental property ID */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch room types for */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with room types and their material options */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-options/{materialOptionId}': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-options/{materialOptionId}": {
     /** Get material option by ID for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material options from */
-          id: string
+          id: string;
           /** @description ID of the material option to fetch */
-          materialOptionId: string
-        }
-      }
+          materialOptionId: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material option */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{apartmentId}/contracts/{contractId}/material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{apartmentId}/contracts/{contractId}/material-choices": {
     /** Get material choices for a specific apartment and contract */
     get: {
       parameters: {
         path: {
           /** @description ID of the apartment to fetch material choices for */
-          apartmentId: string
+          apartmentId: string;
           /** @description ID of the contract to fetch material choices for */
-          contractId: string
-        }
-      }
+          contractId: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/rooms-with-material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/rooms-with-material-choices": {
     /** Get rooms with material choices for a specific rental property */
     get: {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch rooms with material choices for */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested rooms and their material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}/material-choices': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}/material-choices": {
     /**
      * Get material choices for a specific rental property
      * @description Retrieve material choices associated with a rental property identified by {id}.
@@ -2223,18 +2214,18 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch material choices for. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with the requested material choices */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
     /**
      * Save material choices for a rental property
      * @description Saves material choices for a specific rental property.
@@ -2243,25 +2234,25 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to save material choices for. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': Record<string, never>
-        }
-      }
+          "application/json": Record<string, never>;
+        };
+      };
       responses: {
         /** @description Material choices successfully saved */
         200: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
-      }
-    }
-  }
-  '/material-choice-statuses': {
+            "application/json": Record<string, never>;
+          };
+        };
+      };
+    };
+  };
+  "/material-choice-statuses": {
     /**
      * Get material choice statuses for rental properties
      * @description Retrieves statuses of material choices associated with rental properties. Optionally includes rental property details if specified in query parameter.
@@ -2270,20 +2261,20 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional parameter to include rental property details in response. */
-          includeRentalProperties?: 'true'
-        }
-      }
+          includeRentalProperties?: "true";
+        };
+      };
       responses: {
         /** @description Successful response with material choice statuses */
         200: {
           content: {
-            'application/json': unknown[]
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/{id}': {
+            "application/json": unknown[];
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/{id}": {
     /**
      * Get rental property by ID
      * @description Retrieves details of a rental property based on the provided ID.
@@ -2292,22 +2283,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successful response with rental property details */
         200: {
           content: {
-            'application/json': {
-              data?: Record<string, never>
-            }
-          }
-        }
-      }
-    }
-  }
-  '/parking-spaces/{parkingSpaceId}/leases': {
+            "application/json": {
+              data?: Record<string, never>;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/parking-spaces/{parkingSpaceId}/leases": {
     /**
      * Create lease for an external parking space
      * @description Creates a new lease for the specified external parking space.
@@ -2316,38 +2307,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the lease is being created. */
-          parkingSpaceId: string
-        }
-      }
+          parkingSpaceId: string;
+        };
+      };
       responses: {
         /** @description Lease successfully created */
         201: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Parking space id is missing. It needs to be passed in the url. */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example A technical error has occured. */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/parking-spaces/{parkingSpaceId}/note-of-interests': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/parking-spaces/{parkingSpaceId}/note-of-interests": {
     /**
      * Create a note of interest for an internal parking space
      * @description Creates a new note of interest for the specified internal parking space.
@@ -2356,38 +2347,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the parking space for which the note of interest is being created. */
-          parkingSpaceId: string
-        }
-      }
+          parkingSpaceId: string;
+        };
+      };
       responses: {
         /** @description Note of interest successfully created */
         201: {
           content: {
-            'application/json': Record<string, never>
-          }
-        }
+            "application/json": Record<string, never>;
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Contact code is missing. It needs to be passed in the body (contactCode) */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example A technical error has occured. */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rental-properties/by-rental-object-code/{rentalObjectCode}': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rental-properties/by-rental-object-code/{rentalObjectCode}": {
     /**
      * Get rental property information from Xpand
      * @description Retrieves detailed information about a rental property from Xpand based on the provided rental object code.
@@ -2396,32 +2387,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental object code used to identify the specific rental property in Xpand. */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved rental property information */
         200: {
           content: {
-            'application/json': components['schemas']['RentalPropertyResponse']
-          }
-        }
+            "application/json": components["schemas"]["RentalPropertyResponse"];
+          };
+        };
         /** @description Rental property not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-rental-property-id/{rentalPropertyId}/{type}": {
     /**
      * Get maintenance units for a rental property
      * @description Retrieves maintenance units for a specific rental property, optionally filtered by type.
@@ -2430,22 +2421,22 @@ export interface paths {
       parameters: {
         path: {
           /** @description ID of the rental property to fetch maintenance units for. */
-          rentalPropertyId: string
+          rentalPropertyId: string;
           /** @description Optional type filter for maintenance units. */
-          type: string
-        }
-      }
+          type: string;
+        };
+      };
       responses: {
         /** @description Successful response with maintenance units */
         200: {
           content: {
-            'application/json': unknown[]
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-contact-code/{contactCode}': {
+            "application/json": unknown[];
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-contact-code/{contactCode}": {
     /**
      * Get maintenance units by contact code.
      * @description Returns all maintenance units belonging to a contact code.
@@ -2454,33 +2445,33 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code for which to retrieve maintenance units. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                ok?: boolean
-                data?: components['schemas']['MaintenanceUnit'][]
-              }[]
-            }
-          }
-        }
+                  ok?: boolean;
+                  data?: components["schemas"]["MaintenanceUnit"][];
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/data/{identifier}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/data/{identifier}": {
     /**
      * Get work order data by different identifiers
      * @description Retrieves work order data along with associated leases based on the provided identifier type.
@@ -2489,55 +2480,50 @@ export interface paths {
       parameters: {
         query: {
           /** @description The type of the identifier used to fetch work order data. */
-          handler:
-            | 'rentalObjectId'
-            | 'leaseId'
-            | 'pnr'
-            | 'phoneNumber'
-            | 'contactCode'
-        }
+          handler: "rentalObjectId" | "leaseId" | "pnr" | "phoneNumber" | "contactCode";
+        };
         path: {
           /** @description The identifier value for fetching work order data. */
-          identifier: string
-        }
-      }
+          identifier: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work order data. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                rentalPropertyId?: string
-                leases?: {
-                  leaseId?: string
-                  rentalPropertyId?: string
-                }[]
-              }[]
-            }
-          }
-        }
+                  rentalPropertyId?: string;
+                  leases?: {
+                      leaseId?: string;
+                      rentalPropertyId?: string;
+                    }[];
+                }[];
+            };
+          };
+        };
         /** @description Invalid handler */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid handler */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work order data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-contact-code/{contactCode}": {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -2546,34 +2532,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-rental-property-id/{rentalPropertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get work orders by rental property id
      * @description Retrieves work orders based on the provided rental property id.
@@ -2582,34 +2568,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-property-id/{propertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-property-id/{propertyId}": {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -2618,34 +2604,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string
-        }
-      }
+          propertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-building-id/{buildingId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-building-id/{buildingId}": {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -2654,34 +2640,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string
-        }
-      }
+          buildingId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/by-maintenance-unit-code/{maintenanceUnitCode}": {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2690,34 +2676,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string
-        }
-      }
+          maintenanceUnitCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['WorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["WorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-contact-code/{contactCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-contact-code/{contactCode}": {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -2726,42 +2712,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number
+          skip?: number;
           /** @description The number of work orders to fetch. */
-          limit?: number
+          limit?: number;
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean
-        }
+          sortAscending?: boolean;
+        };
         path: {
           /** @description The contact code used to fetch work orders. */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-rental-property-id/{rentalPropertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-rental-property-id/{rentalPropertyId}": {
     /**
      * Get work orders by rental property id from xpand
      * @description Retrieves work orders based on the provided rental property id.
@@ -2770,34 +2756,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental property id used to fetch work orders. */
-          rentalPropertyId: string
-        }
-      }
+          rentalPropertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-property-id/{propertyId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-property-id/{propertyId}": {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders based on the provided property id.
@@ -2806,34 +2792,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id used to fetch work orders. */
-          propertyId: string
-        }
-      }
+          propertyId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-building-id/{buildingId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-building-id/{buildingId}": {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders based on the provided building id.
@@ -2842,34 +2828,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id used to fetch work orders. */
-          buildingId: string
-        }
-      }
+          buildingId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/by-maintenance-unit-code/{maintenanceUnitCode}": {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves work orders based on the provided maintenance unit code.
@@ -2878,42 +2864,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number
+          skip?: number;
           /** @description The number of work orders to fetch. */
-          limit?: number
+          limit?: number;
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean
-        }
+          sortAscending?: boolean;
+        };
         path: {
           /** @description The maintenance unit code used to fetch work orders. */
-          maintenanceUnitCode: string
-        }
-      }
+          maintenanceUnitCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                totalCount?: number
-                workOrders?: components['schemas']['XpandWorkOrder'][]
-              }
-            }
-          }
-        }
+                totalCount?: number;
+                workOrders?: components["schemas"]["XpandWorkOrder"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/xpand/{code}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/xpand/{code}": {
     /**
      * Get work order details by rental property id from xpand
      * @description Retrieves work order details.
@@ -2922,40 +2908,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['XpandWorkOrder']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["XpandWorkOrder"];
+            };
+          };
+        };
         /** @description Work order not found. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders": {
     /**
      * Create a new work order
      * @description Creates a new work order.
@@ -2963,64 +2949,64 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The contact code of the tenant. */
-            ContactCode?: string
+            ContactCode?: string;
             /** @description The rental property ID. */
-            RentalObjectCode?: string
+            RentalObjectCode?: string;
             Rows?: {
-              /** @description The location code of the work order. */
-              LocationCode?: string
-            }[]
+                /** @description The location code of the work order. */
+                LocationCode?: string;
+              }[];
             /** @description Access options for the work order. */
-            AccessOptions?: Record<string, never>
+            AccessOptions?: Record<string, never>;
             /** @description Pet information for the work order. */
-            Pet?: Record<string, never>
-            Images?: string[]
-          }
-        }
-      }
+            Pet?: Record<string, never>;
+            Images?: string[];
+          };
+        };
+      };
       responses: {
         /** @description Successfully created the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order created */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example ContactCode is missing */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Not found. Rental property or active lease not found. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental property not found */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to create the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to create a new work order */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/maintenance-teams': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/maintenance-teams": {
     /**
      * List maintenance teams (resursgrupper)
      * @description Returns the selectable Odoo maintenance teams (resursgrupper) for the inspection work-order picker.
@@ -3030,19 +3016,19 @@ export interface paths {
         /** @description Maintenance teams retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceTeam'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceTeam"][];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/from-inspection': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/from-inspection": {
     /**
      * Create work orders from an inspection (one per resursgrupp)
      * @description Resolves the apartment from rentalObjectCode, then creates one work order per resursgrupp group. Each group is an independent Odoo commit, so the response reports per-group success/failure.
@@ -3050,34 +3036,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateInspectionWorkOrdersRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateInspectionWorkOrdersRequest"];
+        };
+      };
       responses: {
         /** @description Work orders processed (see per-group results) */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CreateInspectionWorkOrdersResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["CreateInspectionWorkOrdersResponse"];
+            };
+          };
+        };
         /** @description Bad request (invalid body or not an apartment). */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Rental property not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/work-orders/{workOrderId}/update': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/work-orders/{workOrderId}/update": {
     /**
      * Update a work order with a message
      * @description Adds a message to the specified work order.
@@ -3086,49 +3072,49 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be updated. */
-          workOrderId: string
-        }
-      }
+          workOrderId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The message to be added to the work order. */
-            message?: string
-          }
-        }
-      }
+            message?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully added the message to the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Message added to work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Message is missing from the request body */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to add the message to the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to add message to work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/{workOrderId}/close': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/{workOrderId}/close": {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -3137,32 +3123,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string
-        }
-      }
+          workOrderId: string;
+        };
+      };
       responses: {
         /** @description Successfully closed the work order. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Work order with ID {workOrderId} updated successfully */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to close the work order. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/send-sms': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/send-sms": {
     /**
      * Send SMS for a work order
      * @description Sends an SMS message to the specified phone number for a work order.
@@ -3170,46 +3156,46 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The phone number to send the SMS to. */
-            phoneNumber?: string
+            phoneNumber?: string;
             /** @description The message to be sent via SMS. */
-            text?: string
-          }
-        }
-      }
+            text?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully sent the SMS. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Sms sent to {phoneNumber} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Bad request: phoneNumber and message are required */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to send the SMS. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Unexpected error sending sms to {phoneNumber} */
-              message?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/work-orders/send-email': {
+              message?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/work-orders/send-email": {
     /**
      * Send email for a work order
      * @description Sends an email to the specified recipient for a work order.
@@ -3217,48 +3203,48 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description The email address of the recipient. */
-            to?: string
+            to?: string;
             /** @description The subject of the email. */
-            subject?: string
+            subject?: string;
             /** @description The message to be sent in the email. */
-            text?: string
-          }
-        }
-      }
+            text?: string;
+          };
+        };
+      };
       responses: {
         /** @description Successfully sent the email. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Email sent to {to} */
-              message?: string
-            }
-          }
-        }
+              message?: string;
+            };
+          };
+        };
         /** @description Bad request. Missing or invalid parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Bad request: to, subject, and message are required */
-              reason?: string
-            }
-          }
-        }
+              reason?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to send the email. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Failed to send email to {to}, status: {statusCode} */
-              text?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/components/by-room/{roomId}': {
+              text?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/components/by-room/{roomId}": {
     /**
      * Get components by room ID
      * @description Returns all components currently installed in a specific space via their installation records.
@@ -3268,40 +3254,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the room */
-          roomId: string
-        }
-      }
+          roomId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the components list */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"][];
+            };
+          };
+        };
         /** @description Room not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Room not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-categories': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-categories": {
     /**
      * Get all component categories
      * @description Top-level groupings for building components (e.g., Ventilation, VVS, Vitvaror, Tak). Use categoryId to filter component types.
@@ -3309,21 +3295,21 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          page?: number
-          limit?: number
-        }
-      }
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component categories */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory'][]
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"][];
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component category
      * @description Creates a new top-level category for organizing component types.
@@ -3331,22 +3317,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentCategoryRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentCategoryRequest"];
+        };
+      };
       responses: {
         /** @description Component category created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-categories/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-categories/{id}": {
     /**
      * Get component category by ID
      * @description Returns a single category with its name and metadata.
@@ -3354,24 +3340,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component category details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
         /** @description Component category not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component category
      * @description Updates category name or metadata.
@@ -3379,25 +3365,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentCategoryRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentCategoryRequest"];
+        };
+      };
       responses: {
         /** @description Component category updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentCategory']
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentCategory"];
+            };
+          };
+        };
+      };
+    };
     /**
      * Delete a component category
      * @description Removes a category. Will fail if category has associated types.
@@ -3405,18 +3391,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component category deleted */
         204: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-types': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-types": {
     /**
      * Get all component types
      * @description Specific kinds of components within a category (e.g., Diskmaskin, Värmepump, Takbeläggning). Filter by categoryId to get types for a specific category.
@@ -3425,22 +3411,22 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter types by category ID */
-          categoryId?: string
-          page?: number
-          limit?: number
-        }
-      }
+          categoryId?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component types */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType'][]
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"][];
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component type
      * @description Creates a new type within a category. Requires categoryId.
@@ -3448,22 +3434,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentTypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentTypeRequest"];
+        };
+      };
       responses: {
         /** @description Component type created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-types/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-types/{id}": {
     /**
      * Get component type by ID
      * @description Returns a single type with its category relationship.
@@ -3471,24 +3457,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component type details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
         /** @description Component type not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component type
      * @description Updates type name or category assignment.
@@ -3496,25 +3482,25 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentTypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentTypeRequest"];
+        };
+      };
       responses: {
         /** @description Component type updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentType']
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              content?: components["schemas"]["ComponentType"];
+            };
+          };
+        };
+      };
+    };
     /**
      * Delete a component type
      * @description Removes a type. Will fail if type has associated subtypes.
@@ -3522,18 +3508,18 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component type deleted */
         204: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-subtypes': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-subtypes": {
     /**
      * Get all component subtypes
      * @description Variants of a type with lifecycle data including depreciation price, technical/economic lifespan, and replacement interval. Filter by typeId or subtypeName.
@@ -3542,30 +3528,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter subtypes by type ID */
-          typeId?: string
+          typeId?: string;
           /** @description Search subtypes by name (case-insensitive) */
-          subtypeName?: string
-          page?: number
-          limit?: number
-        }
-      }
+          subtypeName?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component subtypes */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component subtype
      * @description Creates a subtype with lifecycle parameters. Requires typeId.
@@ -3573,22 +3559,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentSubtypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentSubtypeRequest"];
+        };
+      };
       responses: {
         /** @description Component subtype created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-subtypes/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-subtypes/{id}": {
     /**
      * Get component subtype by ID
      * @description Returns subtype with full lifecycle and cost planning data.
@@ -3596,24 +3582,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component subtype details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component subtype
      * @description Updates subtype specifications or lifecycle data.
@@ -3621,29 +3607,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentSubtypeRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentSubtypeRequest"];
+        };
+      };
       responses: {
         /** @description Component subtype updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentSubtype']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentSubtype"];
+            };
+          };
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component subtype
      * @description Removes a subtype. Will fail if subtype has associated models.
@@ -3651,22 +3637,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component subtype deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component subtype not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models": {
     /**
      * Get all component models
      * @description Specific manufacturer products with pricing, warranty, specifications, and dimensions. Filter by subtypeId, manufacturer, or modelName.
@@ -3675,32 +3661,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter models by component type ID */
-          componentTypeId?: string
+          componentTypeId?: string;
           /** @description Filter models by subtype ID */
-          subtypeId?: string
+          subtypeId?: string;
           /** @description Filter models by manufacturer name */
-          manufacturer?: string
-          page?: number
-          limit?: number
-        }
-      }
+          manufacturer?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component models */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component model
      * @description Creates a manufacturer product entry. Requires subtypeId.
@@ -3708,49 +3694,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentModelRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentModelRequest"];
+        };
+      };
       responses: {
         /** @description Component model created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/documents/component-models/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/documents/component-models/{id}": {
     /** Get all documents for a component model */
     get: {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            'application/json': components['schemas']['DocumentWithUrl'][]
-          }
-        }
+            "application/json": components["schemas"]["DocumentWithUrl"][];
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/{id}": {
     /**
      * Get component model by ID
      * @description Returns full model details including specs and current pricing.
@@ -3758,24 +3744,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component model details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component model
      * @description Updates model pricing, specs, or warranty info.
@@ -3783,29 +3769,29 @@ export interface paths {
     put: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentModelRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentModelRequest"];
+        };
+      };
       responses: {
         /** @description Component model updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"];
+            };
+          };
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component model
      * @description Removes a model. Will fail if model has associated components.
@@ -3813,22 +3799,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component model deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component model not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/surface': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/surface": {
     /**
      * Get surface component models (Ytskikt hierarchy)
      * @description Returns all ComponentModels under the Ytskikt category with full Subtype → Type → Category hierarchy populated. Subtypes whose name starts with "Ospecificera" sort first within each Type.
@@ -3838,19 +3824,19 @@ export interface paths {
         /** @description List of surface component models */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentModel'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentModel"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components": {
     /**
      * Get all components
      * @description Physical units with serial numbers and status. Filter by modelId, status (ACTIVE/INACTIVE/MAINTENANCE/DECOMMISSIONED), or serialNumber.
@@ -3858,31 +3844,31 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          modelId?: string
-          status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+          modelId?: string;
+          status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
           /** @description Search by serial number (case-insensitive partial match) */
-          serialNumber?: string
-          page?: number
-          limit?: number
-        }
-      }
+          serialNumber?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of components */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component'][]
+            "application/json": {
+              content?: components["schemas"]["Component"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component
      * @description Registers a new physical unit. Requires modelId and serialNumber.
@@ -3890,22 +3876,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentRequest"];
+        };
+      };
       responses: {
         /** @description Component created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/components/{id}': {
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/components/{id}": {
     /**
      * Get component by ID
      * @description Returns full component details including purchase info, warranty dates, and current status.
@@ -3913,24 +3899,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component
      * @description Updates component status, warranty dates, or other attributes.
@@ -3939,29 +3925,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentRequest"];
+        };
+      };
       responses: {
         /** @description Component updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Component']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Component"];
+            };
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component
      * @description Removes a component record. Automatically deletes associated installation records.
@@ -3969,22 +3955,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/{id}/inspection-state': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/{id}/inspection-state": {
     /**
      * Update component inspection state
      * @description Updates component condition and last inspection date
@@ -3993,40 +3979,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component instance ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @enum {string} */
-            condition: 'GOOD' | 'FAIR' | 'DAMAGED'
+            condition: "GOOD" | "FAIR" | "DAMAGED";
             /** Format: date-time */
-            lastInspectionDate: string
-          }
-        }
-      }
+            lastInspectionDate: string;
+          };
+        };
+      };
       responses: {
         /** @description Component inspection state updated */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-installations': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-installations": {
     /**
      * Get all component installations
      * @description Placement records linking components to property locations (spaceId). A component can be moved between locations over time. Filter by componentId, spaceId, or buildingPartId.
@@ -4034,30 +4020,30 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          componentId?: string
-          spaceId?: string
-          buildingPartId?: string
-          page?: number
-          limit?: number
-        }
-      }
+          componentId?: string;
+          spaceId?: string;
+          buildingPartId?: string;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description List of component installations */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation'][]
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"][];
               pagination?: {
-                page?: number
-                limit?: number
-                total?: number
-                totalPages?: number
-              }
-            }
-          }
-        }
-      }
-    }
+                page?: number;
+                limit?: number;
+                total?: number;
+                totalPages?: number;
+              };
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new component installation
      * @description Records a component being installed at a location. Requires componentId and spaceId.
@@ -4065,22 +4051,22 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateComponentInstallationRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateComponentInstallationRequest"];
+        };
+      };
       responses: {
         /** @description Component installation created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
-      }
-    }
-  }
-  '/component-installations/{id}': {
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/component-installations/{id}": {
     /**
      * Get component installation by ID
      * @description Returns installation record with dates, location, order number, and cost.
@@ -4088,24 +4074,24 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component installation details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a component installation
      * @description Updates installation details or records deinstallation date.
@@ -4114,29 +4100,29 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component installation ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateComponentInstallationRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateComponentInstallationRequest"];
+        };
+      };
       responses: {
         /** @description Component installation updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ComponentInstallation']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ComponentInstallation"];
+            };
+          };
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a component installation
      * @description Removes an installation record.
@@ -4144,22 +4130,22 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Component installation deleted */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Component installation not found */
         404: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/{id}/upload": {
     /**
      * Upload a file to a component
      * @description Attach photos or documents to a specific component (e.g., installation photos, receipts).
@@ -4168,92 +4154,92 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
+            fileData: string;
             /** @description Original file name */
-            fileName: string
+            fileName: string;
             /** @description MIME type of the file */
-            contentType: string
+            contentType: string;
             /** @description Optional caption for the file */
-            caption?: string
-          }
-        }
-      }
+            caption?: string;
+          };
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/documents/component-instances/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/documents/component-instances/{id}": {
     /** Get all documents for a component */
     get: {
       parameters: {
         path: {
           /** @description Component ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Array of documents with presigned URLs */
         200: {
           content: {
-            'application/json': components['schemas']['DocumentWithUrl'][]
-          }
-        }
+            "application/json": components["schemas"]["DocumentWithUrl"][];
+          };
+        };
         /** @description Component not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/documents/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/documents/{id}": {
     /** Delete a document by ID */
     delete: {
       parameters: {
         path: {
           /** @description Document ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Document deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Document not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/component-models/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/component-models/{id}/upload": {
     /**
      * Upload a document to a component model
      * @description Attach product documentation, manuals, or spec sheets to a model for reference.
@@ -4262,38 +4248,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description Component model ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
+            fileData: string;
             /** @description Original file name */
-            fileName: string
+            fileName: string;
             /** @description MIME type of the file */
-            contentType: string
-          }
-        }
-      }
+            contentType: string;
+          };
+        };
+      };
       responses: {
         /** @description Document uploaded successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Bad request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/components/analyze-image': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/components/analyze-image": {
     /**
      * Analyze component image(s) using AI
      * @description Upload photos to identify component type, model, or condition using AI image analysis. Can accept a typeplate/label image, product photo, or both for improved accuracy.
@@ -4301,30 +4287,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['AnalyzeComponentImageRequest']
-        }
-      }
+          "application/json": components["schemas"]["AnalyzeComponentImageRequest"];
+        };
+      };
       responses: {
         /** @description Component analysis successful */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['AIComponentAnalysis']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["AIComponentAnalysis"];
+            };
+          };
+        };
         /** @description Invalid request (e.g., image too large, missing required fields) */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description AI analysis failed */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/processes/add-component': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/processes/add-component": {
     /**
      * Add a component with model, instance, and installation
      * @description Unified process to add a component. This handles:
@@ -4340,99 +4326,99 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Model name (used to find existing model or create new one) */
-            modelName: string
+            modelName: string;
             /**
              * Format: uuid
              * @description Subtype ID (must exist)
              */
-            componentSubtypeId: string
+            componentSubtypeId: string;
             /** @description Required if model doesn't exist */
-            manufacturer?: string
+            manufacturer?: string;
             /** @description Required if model doesn't exist */
-            currentPrice?: number
+            currentPrice?: number;
             /** @description Required if model doesn't exist */
-            currentInstallPrice?: number
+            currentInstallPrice?: number;
             /** @description Required if model doesn't exist */
-            modelWarrantyMonths?: number
-            technicalSpecification?: string
-            dimensions?: string
-            coclassCode?: string
-            serialNumber: string
-            specifications?: string
-            additionalInformation?: string
+            modelWarrantyMonths?: number;
+            technicalSpecification?: string;
+            dimensions?: string;
+            coclassCode?: string;
+            serialNumber: string;
+            specifications?: string;
+            additionalInformation?: string;
             /**
              * Format: date-time
              * @description ISO-8601 DateTime format (e.g., 2026-01-01T00:00:00.000Z)
              */
-            warrantyStartDate?: string
-            componentWarrantyMonths: number
-            priceAtPurchase: number
-            depreciationPriceAtPurchase: number
-            economicLifespan: number
+            warrantyStartDate?: string;
+            componentWarrantyMonths: number;
+            priceAtPurchase: number;
+            depreciationPriceAtPurchase: number;
+            economicLifespan: number;
             /** @default 1 */
-            quantity?: number
+            quantity?: number;
             /** @description NCS color code */
-            ncsCode?: string
+            ncsCode?: string;
             /**
              * @default ACTIVE
              * @enum {string}
              */
-            status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+            status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
             /**
              * @description Physical condition of the component (optional)
              * @enum {string|null}
              */
-            condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+            condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
             /** @description Where to install the component */
-            spaceId: string
+            spaceId: string;
             /** @enum {string} */
-            spaceType: 'OBJECT' | 'PropertyObject'
-            installationDate: string
-            orderNumber?: string
-            installationCost: number
-          }
-        }
-      }
+            spaceType: "OBJECT" | "PropertyObject";
+            installationDate: string;
+            orderNumber?: string;
+            installationCost: number;
+          };
+        };
+      };
       responses: {
         /** @description Component added successfully */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                modelCreated?: boolean
+                modelCreated?: boolean;
                 model?: {
-                  id?: string
-                  modelName?: string
-                  manufacturer?: string
-                }
+                  id?: string;
+                  modelName?: string;
+                  manufacturer?: string;
+                };
                 component?: {
-                  id?: string
-                  serialNumber?: string
-                  status?: string
-                }
+                  id?: string;
+                  serialNumber?: string;
+                  status?: string;
+                };
                 installation?: {
-                  id?: string
-                  spaceId?: string
-                  installationDate?: string
-                }
-              }
-            }
-          }
-        }
+                  id?: string;
+                  spaceId?: string;
+                  installationDate?: string;
+                };
+              };
+            };
+          };
+        };
         /** @description Validation error or missing required model fields */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/buildings': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/buildings": {
     /**
      * Get all buildings for a specific property
      * @description Retrieves all buildings associated with a given property code.
@@ -4443,30 +4429,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the property. */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the buildings. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/buildings/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/buildings/{id}": {
     /**
      * Get detailed information about a specific building
      * @description Retrieves comprehensive information about a building using its unique building id.
@@ -4477,40 +4463,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique id of the building */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved building information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"];
+            };
+          };
+        };
         /** @description Building not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Building not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/buildings/by-building-code/{buildingCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/buildings/by-building-code/{buildingCode}": {
     /**
      * Get building by building code
      * @description Retrieves building data by building code
@@ -4519,40 +4505,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved building */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"];
+            };
+          };
+        };
         /** @description Building not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Building not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/buildings/by-property-code/{propertyCode}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/buildings/by-property-code/{propertyCode}": {
     /**
      * Get buildings by property code
      * @description Retrieves buildings by property code
@@ -4561,31 +4547,31 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property to fetch buildings for */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved buildings */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Building'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Building"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/companies': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/companies": {
     /**
      * Get all companies
      * @description Retrieves companies from property base
@@ -4595,24 +4581,24 @@ export interface paths {
         /** @description Successfully retrieved companies */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Company'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Company"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/companies/{organizationNumber}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/companies/{organizationNumber}": {
     /**
      * Get detailed information about a specific company
      * @description Retrieves comprehensive information about a company using its organization number.
@@ -4621,40 +4607,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The organization number of the company. */
-          organizationNumber: string
-        }
-      }
+          organizationNumber: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved company information */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CompanyDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["CompanyDetails"];
+            };
+          };
+        };
         /** @description Company not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Company not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences": {
     /**
      * Get residences by building code and (optional) staircase code
      * @description Retrieves residences by building code and (optional) staircase code
@@ -4663,41 +4649,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch residences from */
-          buildingCode: string
+          buildingCode: string;
           /** @description Code for the staircase to fetch residences from */
-          staircaseCode?: string
-        }
-      }
+          staircaseCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residences */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Residence'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Residence"][];
+            };
+          };
+        };
         /** @description Missing building code or invalid query parameters */
         400: {
           content: {
-            'application/json': {
-              error?: Record<string, never>
-            }
-          }
-        }
+            "application/json": {
+              error?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/properties': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/properties": {
     /**
      * Get properties by company code and (optional) tract
      * @description Retrieves properties by company code and (optional) tract
@@ -4706,41 +4692,41 @@ export interface paths {
       parameters: {
         query: {
           /** @description The code of the company that owns the properties. */
-          companyCode: string
+          companyCode: string;
           /** @description Optional filter to get properties in a specific tract. */
-          tract?: string
-        }
-      }
+          tract?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved properties */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"][];
+            };
+          };
+        };
         /** @description Missing company code or invalid query parameters */
         400: {
           content: {
-            'application/json': {
-              error?: Record<string, never>
-            }
-          }
-        }
+            "application/json": {
+              error?: Record<string, never>;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/properties/search': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/properties/search": {
     /**
      * Search properties
      * @description Retrieves a list of all real estate properties by name.
@@ -4749,30 +4735,30 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The search query. */
-          q?: string
-        }
-      }
+          q?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved list of properties. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/properties/{propertyCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/properties/{propertyCode}": {
     /**
      * Get property by property code
      * @description Retrieves property by property code
@@ -4781,40 +4767,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved property */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Property']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Property"];
+            };
+          };
+        };
         /** @description Property not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Property not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/by-rental-id/{rentalId}": {
     /**
      * Get residence data by residence rental id
      * @description Retrieves residence data by residence rental id
@@ -4823,40 +4809,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id for the residence to fetch */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residence. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceDetails"];
+            };
+          };
+        };
         /** @description Residence not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Residence not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve residence data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/by-rental-id/{rentalId}": {
     /**
      * Get rental blocks by rental ID
      * @description Retrieves rental blocks by rental ID
@@ -4865,44 +4851,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean
-        }
+          active?: boolean;
+        };
         path: {
           /** @description Rental id to fetch rental blocks for */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved rental blocks. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlock'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["RentalBlock"][];
+            };
+          };
+        };
         /** @description Rental ID not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Rental ID not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve rental blocks. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/export': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/export": {
     /**
      * Export rental blocks to Excel
      * @description Generates and downloads an Excel file with all rental blocks matching the filters
@@ -4911,36 +4897,36 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term */
-          q?: string
+          q?: string;
           /** @description Filter by category (supports multiple values) */
-          kategori?: string[]
+          kategori?: string[];
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[]
+          distrikt?: string[];
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[]
+          blockReason?: string[];
           /** @description Filter by property (supports multiple values) */
-          fastighet?: string[]
+          fastighet?: string[];
           /** @description Filter by start date */
-          fromDateGte?: string
+          fromDateGte?: string;
           /** @description Filter by end date */
-          toDateLte?: string
+          toDateLte?: string;
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean
-        }
-      }
+          active?: boolean;
+        };
+      };
       responses: {
         /** @description Excel file download */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/search": {
     /**
      * Search rental blocks with server-side filtering
      * @description Search and filter rental blocks. Searches by rentalId and address.
@@ -4949,55 +4935,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Search term (searches rentalId, address) */
-          q?: string
+          q?: string;
           /** @description Comma-separated fields to search (default rentalId,address,propertyName,blockReason) */
-          fields?: string
+          fields?: string;
           /** @description Filter by category (Bostad, Bilplats, Lokal, Förråd) - supports multiple values */
-          kategori?: string[]
+          kategori?: string[];
           /** @description Filter by district (supports multiple values) */
-          distrikt?: string[]
+          distrikt?: string[];
           /** @description Filter by block reason (supports multiple values) */
-          blockReason?: string[]
+          blockReason?: string[];
           /** @description Filter by property code/name (supports multiple values) */
-          fastighet?: string[]
+          fastighet?: string[];
           /** @description Filter blocks starting on or after this date */
-          fromDateGte?: string
+          fromDateGte?: string;
           /** @description Filter blocks ending on or before this date */
-          toDateLte?: string
+          toDateLte?: string;
           /** @description Filter by active status. true = currently active blocks, false = ended blocks. If omitted, all blocks. */
-          active?: boolean
-          page?: number
-          limit?: number
-        }
-      }
+          active?: boolean;
+          page?: number;
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully searched rental blocks */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlockWithRentalObject'][]
+            "application/json": {
+              content?: components["schemas"]["RentalBlockWithRentalObject"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
-              _links?: {
-                href?: string
-                /** @enum {string} */
-                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
+              _links?: ({
+                  href?: string;
+                  /** @enum {string} */
+                  rel?: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/rental-blocks/all': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/rental-blocks/all": {
     /**
      * Get all rental blocks (paginated)
      * @description Retrieves all rental blocks for residences across the system with pagination support
@@ -5006,46 +4992,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter rental blocks by active status. true = currently active blocks, false = ended blocks. If omitted, include all blocks. */
-          active?: boolean
+          active?: boolean;
           /** @description Page number (1-indexed) */
-          page?: number
+          page?: number;
           /** @description Number of items per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved all rental blocks. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['RentalBlockWithRentalObject'][]
+            "application/json": {
+              content?: components["schemas"]["RentalBlockWithRentalObject"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
-              _links?: {
-                href?: string
-                /** @enum {string} */
-                rel?: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
+              _links?: ({
+                  href?: string;
+                  /** @enum {string} */
+                  rel?: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/residences/block-reasons': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/residences/block-reasons": {
     /**
      * Get all block reasons
      * @description Returns all available block reasons for rental blocks. Used for filtering dropdowns.
@@ -5055,22 +5041,22 @@ export interface paths {
         /** @description Successfully retrieved block reasons */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                id?: string
-                caption?: string
-              }[]
-            }
-          }
-        }
+                  id?: string;
+                  caption?: string;
+                }[];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/search": {
     /**
      * Search residences
      * @description Searches for residences by rental object id.
@@ -5079,30 +5065,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental object id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved residences matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceSearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceSearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/residences/summary/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/residences/summary/by-building-code/{buildingCode}": {
     /**
      * Get residences by building code, optionally filtered by staircase code.
      * @description Returns all residences belonging to a specific building, optionally filtered by staircase code.
@@ -5111,34 +5097,34 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string
-        }
+          staircaseCode?: string;
+        };
         path: {
           /** @description The building code of the building. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the residences. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ResidenceSummary'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ResidenceSummary"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/staircases': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/staircases": {
     /**
      * Get staircases for a building
      * @description Retrieves staircases for a building
@@ -5147,42 +5133,42 @@ export interface paths {
       parameters: {
         query: {
           /** @description Code for the building to fetch staircases for */
-          buildingCode: string
+          buildingCode: string;
           /** @description The code of the staircase (optional). */
-          staircaseCode?: string
-        }
-      }
+          staircaseCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved staircases. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Staircase'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Staircase"][];
+            };
+          };
+        };
         /** @description Missing buildingCode */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Missing buildingCode */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/rooms': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/rooms": {
     /**
      * Get rooms by rental id.
      * @description Returns all rooms belonging to a residence.
@@ -5191,30 +5177,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The rental id of the residence. */
-          rentalId: string
+          rentalId: string;
           /** @description The code of the room (optional). */
-          roomCode?: string
-        }
-      }
+          roomCode?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Create a room for a residence.
      * @description Forwards to property-base-service which performs a transactional
@@ -5224,34 +5210,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateRoomRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateRoomRequest"];
+        };
+      };
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Residence not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/rooms/by-facility-id/{facilityId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/rooms/by-facility-id/{facilityId}": {
     /**
      * Get rooms by facility id.
      * @description Returns all rooms belonging to a facility.
@@ -5260,26 +5246,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The id of the facility. */
-          facilityId: string
-        }
-      }
+          facilityId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the rooms. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Room'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Room"][];
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/parking-spaces/by-rental-id/{rentalId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/parking-spaces/by-rental-id/{rentalId}": {
     /**
      * Get parking space data by rentalId
      * @description Retrieves parking space data by rentalId
@@ -5288,40 +5274,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description Rental id to fetch parking space for */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved parking space. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ParkingSpace']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ParkingSpace"];
+            };
+          };
+        };
         /** @description Parking space not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Parking space not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve parking space data. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-rental-id/{rentalId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-rental-id/{rentalId}": {
     /**
      * Get maintenance units by rental id.
      * @description Returns all maintenance units belonging to a rental property.
@@ -5330,30 +5316,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the rental property for which to retrieve maintenance units. */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-building-code/{buildingCode}": {
     /**
      * Get maintenance units by building code.
      * @description Returns all maintenance units belonging to a building.
@@ -5362,30 +5348,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve maintenance units. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-rental-id/{rentalId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-rental-id/{rentalId}": {
     /**
      * Get facility by rental id.
      * @description Returns facility.
@@ -5394,30 +5380,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental id of the facility. */
-          rentalId: string
-        }
-      }
+          rentalId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facility. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FacilityDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FacilityDetails"];
+            };
+          };
+        };
         /** @description Not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-property-code/{code}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-property-code/{code}": {
     /**
      * Get maintenance units by property code.
      * @description Returns all maintenance units belonging to a property.
@@ -5426,30 +5412,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve maintenance units. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance units. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/by-code/{code}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/by-code/{code}": {
     /**
      * Get a maintenance unit by its code
      * @description Returns a single maintenance unit by its unique code.
@@ -5458,30 +5444,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the maintenance unit to retrieve. */
-          code: string
-        }
-      }
+          code: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the maintenance unit. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"];
+            };
+          };
+        };
         /** @description Maintenance unit not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/maintenance-units/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/maintenance-units/search": {
     /**
      * Search maintenance units
      * @description Searches for maintenance units by code.
@@ -5490,30 +5476,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (maintenance unit code). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved maintenance units matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['MaintenanceUnit'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["MaintenanceUnit"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-property-code/{propertyCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-property-code/{propertyCode}": {
     /**
      * Get facilities by property code.
      * @description Returns all facilities belonging to a property.
@@ -5522,30 +5508,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the property for which to retrieve facilities. */
-          propertyCode: string
-        }
-      }
+          propertyCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Facilities not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/by-building-code/{buildingCode}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/by-building-code/{buildingCode}": {
     /**
      * Get facilities by building code.
      * @description Returns all facilities belonging to a building.
@@ -5554,30 +5540,30 @@ export interface paths {
       parameters: {
         path: {
           /** @description The code of the building for which to retrieve facilities. */
-          buildingCode: string
-        }
-      }
+          buildingCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the facilities. */
         200: {
           content: {
-            'application/json': {
-              content?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              content?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Facilities not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/facilities/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/facilities/search": {
     /**
      * Search facilities
      * @description Searches for facilities by rental id.
@@ -5586,30 +5572,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved facilities matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FacilitySearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FacilitySearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/parking-spaces/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/parking-spaces/search": {
     /**
      * Search parking spaces
      * @description Searches for parking spaces by rental id.
@@ -5618,30 +5604,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query (rental id). */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved parking spaces matching the search query. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ParkingSpaceSearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ParkingSpaceSearchResult"][];
+            };
+          };
+        };
         /** @description Invalid query provided */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/apartments/{objectNumber}/temperatures': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/apartments/{objectNumber}/temperatures": {
     /**
      * Get indoor temperatures for an apartment
      * @description Fetches indoor temperature time series for an apartment by its object
@@ -5654,42 +5640,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Unix timestamp (seconds) for range start. Defaults to `to - 86400`. */
-          from?: number
+          from?: number;
           /** @description Unix timestamp (seconds) for range end. Defaults to now. */
-          to?: number
+          to?: number;
           /** @description Aggregation bucket size. Defaults to "H" (hourly). */
-          interval?: 'H' | 'D'
-        }
+          interval?: "H" | "D";
+        };
         path: {
           /** @description Apartment object number (e.g. "806-032-01-0101"). */
-          objectNumber: string
-        }
-      }
+          objectNumber: string;
+        };
+      };
       responses: {
         /** @description Temperature series successfully retrieved. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ApartmentTemperaturesResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ApartmentTemperaturesResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description No apartment node found for the given object number. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/search": {
     /**
      * Omni-search for different entities
      * @description Search for properties, buildings, residences, parking spaces, and maintenance units.
@@ -5706,30 +5692,30 @@ export interface paths {
       parameters: {
         query: {
           /** @description The search query string */
-          q: string
-        }
-      }
+          q: string;
+        };
+      };
       responses: {
         /** @description A list of search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SearchResult'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SearchResult"][];
+            };
+          };
+        };
         /** @description Bad request - invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/inspections': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/inspections": {
     /**
      * Retrieve inspections from all sources
      * @description Retrieves inspections from both the local database and Xpand, merged with a source indicator per item.
@@ -5738,58 +5724,58 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number
+          page?: number;
           /** @description Maximum number of records to return. */
-          limit?: number
+          limit?: number;
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
+          statusFilter?: "ongoing" | "completed";
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false
+          sortAscending?: true | false;
           /** @description Filter inspections by inspector name. */
-          inspector?: string
+          inspector?: string;
           /** @description Filter inspections by address. */
-          address?: string
-        }
-      }
+          address?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections from all sources. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['InspectionWithSource'][]
+            "application/json": {
+              content?: components["schemas"]["InspectionWithSource"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid query parameters */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
+              error?: string;
+            };
+          };
+        };
+      };
+    };
     /**
      * Create a new inspection
      * @description Creates a new inspection in the local inspection database
@@ -5797,40 +5783,40 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateInspectionRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateInspectionRequest"];
+        };
+      };
       responses: {
         /** @description Inspection created successfully */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['DetailedInspection']
-              }
-            }
-          }
-        }
+                inspection?: components["schemas"]["DetailedInspection"];
+              };
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/residence/{residenceId}': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/residence/{residenceId}": {
     /**
      * Retrieve inspections by residence ID from all sources
      * @description Retrieves inspections associated with a specific residence ID from both the local database and Xpand.
@@ -5839,37 +5825,37 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
-        }
+          statusFilter?: "ongoing" | "completed";
+        };
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string
-        }
-      }
+          residenceId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspections?: components['schemas']['InspectionWithSource'][]
-              }
-            }
-          }
-        }
+                inspections?: components["schemas"]["InspectionWithSource"][];
+              };
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand": {
     /**
      * Retrieve inspections from Xpand
      * @description Retrieves inspections from Xpand with pagination and status filtering support.
@@ -5878,60 +5864,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number for pagination. */
-          page?: number
+          page?: number;
           /** @description Maximum number of records to return. */
-          limit?: number
+          limit?: number;
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
+          statusFilter?: "ongoing" | "completed";
           /** @description Whether to sort the results in ascending order. */
-          sortAscending?: true | false
+          sortAscending?: true | false;
           /** @description Filter inspections by inspector name. */
-          inspector?: string
+          inspector?: string;
           /** @description Filter inspections by address. */
-          address?: string
-        }
-      }
+          address?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Inspection'][]
+            "application/json": {
+              content?: components["schemas"]["Inspection"][];
               _meta?: {
-                totalRecords?: number
-                page?: number
-                limit?: number
-                count?: number
-              }
+                totalRecords?: number;
+                page?: number;
+                limit?: number;
+                count?: number;
+              };
               _links?: {
-                href?: string
-                rel?: string
-              }[]
-            }
-          }
-        }
+                  href?: string;
+                  rel?: string;
+                }[];
+            };
+          };
+        };
         /** @description Invalid query parameters. */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid query parameters */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/residence/{residenceId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/residence/{residenceId}": {
     /**
      * Retrieve inspections by residence ID from Xpand
      * @description Retrieves inspections associated with a specific residence ID from Xpand.
@@ -5940,46 +5926,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter inspections by status (ongoing or completed). */
-          statusFilter?: 'ongoing' | 'completed'
-        }
+          statusFilter?: "ongoing" | "completed";
+        };
         path: {
           /** @description The ID of the residence to retrieve inspections for. */
-          residenceId: string
-        }
-      }
+          residenceId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved inspections for the specified residence ID. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspections?: components['schemas']['Inspection'][]
-              }
-            }
-          }
-        }
+                inspections?: components["schemas"]["Inspection"][];
+              };
+            };
+          };
+        };
         /** @description No inspections found for the specified residence ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve inspections. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/{inspectionId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/{inspectionId}": {
     /**
      * Retrieve an inspection by ID from Xpand
      * @description Retrieves a specific inspection by its ID from Xpand.
@@ -5988,40 +5974,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['DetailedInspection']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["DetailedInspection"];
+            };
+          };
+        };
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to retrieve the inspection. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/xpand/{inspectionId}/pdf': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/xpand/{inspectionId}/pdf": {
     /**
      * Generate PDF protocol for an inspection
      * @description Generates and returns a PDF protocol for a specific inspection by its ID.
@@ -6030,47 +6016,47 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean
-        }
+          includeCosts?: boolean;
+        };
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string
-              }
-            }
-          }
-        }
+                pdfBase64?: string;
+              };
+            };
+          };
+        };
         /** @description Inspection not found for the specified ID. */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example not-found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. Failed to generate PDF. */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/details': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/details": {
     /**
      * Retrieve an enriched internal inspection by ID
      * @description Retrieves a specific internal inspection by its ID, normalized into the same shape as Xpand inspections (with lease, residence, and flattened room remarks) so it can be rendered by the protocol UI without source-specific branching.
@@ -6079,38 +6065,38 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to retrieve. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved the inspection. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['DetailedInspection']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["DetailedInspection"];
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/pdf': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/pdf": {
     /**
      * Generate PDF protocol for an internal inspection
      * @description Generates and returns a PDF protocol for a specific internal inspection by its ID.
@@ -6119,45 +6105,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Whether to include cost information in the PDF. */
-          includeCosts?: boolean
-        }
+          includeCosts?: boolean;
+        };
         path: {
           /** @description The ID of the inspection to generate a PDF for. */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully generated PDF protocol. */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
                 /** @description Base64 encoded PDF document */
-                pdfBase64?: string
-              }
-            }
-          }
-        }
+                pdfBase64?: string;
+              };
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/tenant-contacts': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/tenant-contacts": {
     /**
      * Get tenant contacts for an internal inspection
      * @description Retrieves contact information for new and previous tenants associated with an internal inspection's residence.
@@ -6165,38 +6151,38 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant contacts. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['TenantContactsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["TenantContactsResponse"];
+            };
+          };
+        };
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/send-protocol': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/send-protocol": {
     /**
      * Send inspection protocol to tenant for an internal inspection
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous) for an internal inspection.
@@ -6204,51 +6190,51 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SendProtocolRequest']
-        }
-      }
+          "application/json": components["schemas"]["SendProtocolRequest"];
+        };
+      };
       responses: {
         /** @description Protocol sent successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SendProtocolResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SendProtocolResponse"];
+            };
+          };
+        };
         /** @description Invalid request or no contract found. */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/{inspectionId}/tenant-contacts': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/{inspectionId}/tenant-contacts": {
     /**
      * Get tenant contacts for inspection protocol modal
      * @description Retrieves contact information for new and previous tenants to display in confirmation modal before sending protocol
@@ -6257,40 +6243,40 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved tenant contacts */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['TenantContactsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["TenantContactsResponse"];
+            };
+          };
+        };
         /** @description Inspection or residence not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Inspection not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/{inspectionId}/send-protocol': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/{inspectionId}/send-protocol": {
     /**
      * Send inspection protocol to tenant
      * @description Sends the inspection protocol PDF via email to the specified tenant (new or previous)
@@ -6299,90 +6285,90 @@ export interface paths {
       parameters: {
         path: {
           /** @description The inspection ID */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SendProtocolRequest']
-        }
-      }
+          "application/json": components["schemas"]["SendProtocolRequest"];
+        };
+      };
       responses: {
         /** @description Protocol sent successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['SendProtocolResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["SendProtocolResponse"];
+            };
+          };
+        };
         /** @description Invalid request or no contract found */
         400: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Invalid request body */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Inspection not found */
-              error?: string
-            }
-          }
-        }
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @example Internal server error */
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}': {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}": {
     /** Get internal inspection by ID including draft room data */
     get: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       responses: {
         /** @description Internal inspection with draft room data */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['InternalInspection']
-              }
-            }
-          }
-        }
+                inspection?: components["schemas"]["InternalInspection"];
+              };
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
     /**
      * Update internal inspection
      * @description Updates an internal inspection. Supports updating status (with valid transitions Registrerad → Påbörjad → Genomförd) and/or inspector. At least one field must be provided.
@@ -6391,100 +6377,100 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the inspection to update */
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateInspectionStatusRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateInspectionStatusRequest"];
+        };
+      };
       responses: {
         /** @description Inspection updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                inspection?: components['schemas']['InternalInspection']
+                inspection?: components["schemas"]["InternalInspection"];
                 /** @description Per-component write-back errors recorded when transitioning to "Genomförd". Empty for other status transitions. */
-                componentWriteBackErrors?: components['schemas']['ComponentWriteBackError'][]
-              }
-            }
-          }
-        }
+                componentWriteBackErrors?: components["schemas"]["ComponentWriteBackError"][];
+              };
+            };
+          };
+        };
         /** @description Invalid request body or invalid status transition */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/draft': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/draft": {
     /** Save inspection draft data (rooms and inspector name) */
     patch: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['SaveInspectionDraftRequest']
-        }
-      }
+          "application/json": components["schemas"]["SaveInspectionDraftRequest"];
+        };
+      };
       responses: {
         /** @description Draft saved successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Invalid request body */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection not found */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/rooms': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/rooms": {
     /**
      * Add a room to a residence during an inspection.
      * @description Creates a new room in Xpand (via property-base) for the residence
@@ -6500,53 +6486,53 @@ export interface paths {
     post: {
       parameters: {
         path: {
-          inspectionId: string
-        }
-      }
+          inspectionId: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['AddInspectionRoomRequest']
-        }
-      }
+          "application/json": components["schemas"]["AddInspectionRoomRequest"];
+        };
+      };
       responses: {
         /** @description Room created. */
         201: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                room?: components['schemas']['Room']
-              }
-            }
-          }
-        }
+                room?: components["schemas"]["Room"];
+              };
+            };
+          };
+        };
         /** @description Invalid request body or no residence linked to the inspection. */
         400: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Inspection or residence not found. */
         404: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
         /** @description Internal server error. */
         500: {
           content: {
-            'application/json': {
-              error?: string
-            }
-          }
-        }
-      }
-    }
-  }
-  '/inspections/internal/{inspectionId}/rooms/{roomId}': {
+            "application/json": {
+              error?: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/inspections/internal/{inspectionId}/rooms/{roomId}": {
     /**
      * Remove a room that was added during the current inspection.
      * @description Symmetric to POST /inspections/internal/{inspectionId}/rooms.
@@ -6562,206 +6548,206 @@ export interface paths {
     delete: {
       parameters: {
         path: {
-          inspectionId: string
-          roomId: string
-        }
-      }
+          inspectionId: string;
+          roomId: string;
+        };
+      };
       responses: {
         /** @description Room removed. */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /**
          * @description Inspection not found, room not found in Xpand, or the room was
          * not added during this inspection.
          */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Room has installed components and cannot be removed. */
         409: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files": {
     /** List files with optional prefix */
     get: {
       parameters: {
         query?: {
-          prefix?: string
-        }
-      }
+          prefix?: string;
+        };
+      };
       responses: {
         /** @description List of files with metadata */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['ListFilesResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["ListFilesResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/upload": {
     /** Upload a file */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['FileUploadRequest']
-        }
-      }
+          "application/json": components["schemas"]["FileUploadRequest"];
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileUploadResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileUploadResponse"];
+            };
+          };
+        };
         /** @description Invalid request */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/url': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/url": {
     /** Get presigned URL for file download */
     get: {
       parameters: {
         query?: {
           /** @description URL expiry time in seconds */
-          expirySeconds?: number
-        }
+          expirySeconds?: number;
+        };
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description Presigned URL generated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileUrlResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileUrlResponse"];
+            };
+          };
+        };
         /** @description Invalid query parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/metadata': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/metadata": {
     /** Get file metadata */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File metadata */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileMetadata']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileMetadata"];
+            };
+          };
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}": {
     /** Delete a file */
     delete: {
       parameters: {
         path: {
           /** @description Name of the file to delete */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description File not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/files/{fileName}/exists': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/files/{fileName}/exists": {
     /** Check if file exists */
     get: {
       parameters: {
         path: {
           /** @description Name of the file */
-          fileName: string
-        }
-      }
+          fileName: string;
+        };
+      };
       responses: {
         /** @description File existence status */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['FileExistsResponse']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["FileExistsResponse"];
+            };
+          };
+        };
         /** @description Server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/dax/card-owners': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/dax/card-owners": {
     /**
      * Search card owners from DAX
      * @description Search for card owners in the DAX access control system
@@ -6770,44 +6756,44 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by name (rental object ID / object code) */
-          nameFilter?: string
+          nameFilter?: string;
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string
+          expand?: string;
           /** @description Filter by ID */
-          idfilter?: string
+          idfilter?: string;
           /** @description Filter by attribute */
-          attributeFilter?: string
+          attributeFilter?: string;
           /** @description Select specific attributes to return */
-          selectedAttributes?: string
+          selectedAttributes?: string;
           /** @description Filter by folder */
-          folderFilter?: string
+          folderFilter?: string;
           /** @description Filter by organisation */
-          organisationFilter?: string
+          organisationFilter?: string;
           /** @description Pagination offset */
-          offset?: number
+          offset?: number;
           /** @description Maximum number of results */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Card owners retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              cardOwners?: Record<string, never>[]
-            }
-          }
-        }
+            "application/json": {
+              cardOwners?: Record<string, never>[];
+            };
+          };
+        };
         /** @description Failed to fetch card owners */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/dax/card-owners/{cardOwnerId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/dax/card-owners/{cardOwnerId}": {
     /**
      * Get a specific card owner from DAX
      * @description Retrieve a card owner by ID from the DAX access control system
@@ -6816,38 +6802,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "cards") */
-          expand?: string
-        }
+          expand?: string;
+        };
         path: {
           /** @description The card owner ID */
-          cardOwnerId: string
-        }
-      }
+          cardOwnerId: string;
+        };
+      };
       responses: {
         /** @description Card owner retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              cardOwner?: components['schemas']['CardOwner']
-            }
-          }
-        }
+            "application/json": {
+              cardOwner?: components["schemas"]["CardOwner"];
+            };
+          };
+        };
         /** @description Card owner not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Failed to fetch card owner */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/dax/cards/{cardId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/dax/cards/{cardId}": {
     /**
      * Get a specific card from DAX
      * @description Retrieve a card by ID from the DAX access control system
@@ -6856,38 +6842,38 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Comma-separated list of fields to expand (e.g., "codes") */
-          expand?: string
-        }
+          expand?: string;
+        };
         path: {
           /** @description The card ID */
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Card retrieved successfully */
         200: {
           content: {
-            'application/json': {
-              card?: components['schemas']['Card']
-            }
-          }
-        }
+            "application/json": {
+              card?: components["schemas"]["Card"];
+            };
+          };
+        };
         /** @description Card not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Failed to fetch card */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-bundles': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-bundles": {
     /**
      * List key bundles with pagination
      * @description Fetches a paginated list of all key bundles ordered by name.
@@ -6896,28 +6882,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description A paginated list of key bundles. */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description An error occurred while listing key bundles. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key bundle
      * @description Create a new key bundle record.
@@ -6925,30 +6911,30 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyBundleRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyBundleRequest"];
+        };
+      };
       responses: {
         /** @description Key bundle created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while creating the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/search': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/search": {
     /**
      * Search key bundles with pagination
      * @description Search key bundles with flexible filtering and pagination.
@@ -6957,35 +6943,35 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. */
-          fields?: string
-        }
-      }
+          fields?: string;
+        };
+      };
       responses: {
         /** @description Paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description Invalid search parameters */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/by-key/{keyId}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/by-key/{keyId}": {
     /**
      * Get all bundles containing a specific key
      * @description Returns all bundle records containing the specified key ID
@@ -6994,26 +6980,26 @@ export interface paths {
       parameters: {
         path: {
           /** @description The key ID to search for */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description Array of bundles containing this key */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/{id}': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/{id}": {
     /**
      * Get key bundle by ID
      * @description Fetch a specific key bundle by its ID.
@@ -7022,28 +7008,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key bundle object. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while fetching the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Delete a key bundle
      * @description Delete a key bundle by ID.
@@ -7052,24 +7038,24 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to delete. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key bundle deleted successfully. */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while deleting the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
+          content: never;
+        };
+      };
+    };
     /**
      * Update a key bundle
      * @description Partially update an existing key bundle.
@@ -7078,39 +7064,39 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key bundle to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyBundleRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyBundleRequest"];
+        };
+      };
       responses: {
         /** @description Key bundle updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundle']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyBundle"];
+            };
+          };
+        };
         /** @description Invalid request body */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key bundle not found. */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description An error occurred while updating the key bundle. */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/{id}/keys-with-loan-status': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/{id}/keys-with-loan-status": {
     /**
      * Get keys in bundle with maintenance loan status
      * @description Fetches all keys in a key bundle along with their active maintenance loan information
@@ -7124,38 +7110,38 @@ export interface paths {
            * Soft fails — if the contacts service errors, the response is
            * returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The key bundle ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Bundle information and keys with loan status */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyBundleDetailsResponse']
+            "application/json": {
+              content?: components["schemas"]["KeyBundleDetailsResponse"];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Key bundle not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-bundles/by-contact/{contactCode}/with-loaned-keys': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-bundles/by-contact/{contactCode}/with-loaned-keys": {
     /**
      * Get key bundles with keys loaned to a contact
      * @description Fetches all key bundles that have keys currently loaned to a specific contact.
@@ -7164,28 +7150,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code (F-number) to find bundles for */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description A list of bundles with loaned keys info. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['BundleWithLoanedKeysInfo'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["BundleWithLoanedKeysInfo"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching bundles. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events": {
     /**
      * Get all key events
      * @description Returns all key events ordered by creation date.
@@ -7195,19 +7181,19 @@ export interface paths {
         /** @description List of key events. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a key event
      * @description Create a new key event record. Will fail with 409 if any of the keys have an incomplete event (status not COMPLETED).
@@ -7215,43 +7201,43 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyEventRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyEventRequest"];
+        };
+      };
       responses: {
         /** @description Key event created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Conflict - one or more keys have incomplete events. */
         409: {
           content: {
-            'application/json': {
-              reason?: string
-              conflictingKeys?: string[]
-            }
-          }
-        }
+            "application/json": {
+              reason?: string;
+              conflictingKeys?: string[];
+            };
+          };
+        };
         /** @description An error occurred while creating the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events/by-key/{keyId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events/by-key/{keyId}": {
     /**
      * Get all key events for a specific key
      * @description Returns all key events associated with a specific key ID. Optionally limit results to get only the latest event(s).
@@ -7260,32 +7246,32 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Optional limit on number of results (e.g., 1 for latest event only). */
-          limit?: number
-        }
+          limit?: number;
+        };
         path: {
           /** @description The key ID to filter events by. */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description List of key events for the key. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"][];
+            };
+          };
+        };
         /** @description An error occurred while fetching key events. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-events/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-events/{id}": {
     /**
      * Get key event by ID
      * @description Fetch a specific key event by its ID.
@@ -7294,32 +7280,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key event object. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Key event not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while fetching the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key event
      * @description Update an existing key event.
@@ -7328,45 +7314,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key event to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyEventRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyEventRequest"];
+        };
+      };
       responses: {
         /** @description Key event updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyEvent']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyEvent"];
+            };
+          };
+        };
         /** @description Invalid request body. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key event not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while updating the key event. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans": {
     /**
      * List all key loans
      * @description Fetches a list of all key loans ordered by creation date.
@@ -7376,19 +7362,19 @@ export interface paths {
         /** @description A list of key loans. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
+            };
+          };
+        };
         /** @description An error occurred while listing key loans. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key loan
      * @description Create a new key loan record.
@@ -7396,34 +7382,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyLoanRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyLoanRequest"];
+        };
+      };
       responses: {
         /** @description Key loan created successfully. */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"];
+            };
+          };
+        };
         /** @description Invalid request data. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description An error occurred while creating the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/search": {
     /**
      * Search key loans
      * @description Search key loans with flexible filtering.
@@ -7436,69 +7422,69 @@ export interface paths {
     get: {
       parameters: {
         query?: {
-          q?: string
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to contact and contact2. */
-          fields?: string
+          fields?: string;
           /** @description Search by key name or rental object code (requires JOIN with keys table) */
-          keyNameOrObjectCode?: string
+          keyNameOrObjectCode?: string;
           /** @description Minimum number of keys in loan */
-          minKeys?: number
+          minKeys?: number;
           /** @description Maximum number of keys in loan */
-          maxKeys?: number
+          maxKeys?: number;
           /** @description Filter by pickedUpAt null status (true = NOT NULL, false = NULL) */
-          hasPickedUp?: boolean
+          hasPickedUp?: boolean;
           /** @description Filter by returnedAt null status (true = NOT NULL, false = NULL) */
-          hasReturned?: boolean
-          id?: string
-          keys?: string
-          contact?: string
-          contact2?: string
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          hasReturned?: boolean;
+          id?: string;
+          keys?: string;
+          contact?: string;
+          contact2?: string;
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          returnedAt?: string
-          availableToNextTenantFrom?: string
+          returnedAt?: string;
+          availableToNextTenantFrom?: string;
           /** @description Supports comparison operators (e.g., >=2024-01-01, <2024-12-31) */
-          pickedUpAt?: string
-          createdAt?: string
-          updatedAt?: string
+          pickedUpAt?: string;
+          createdAt?: string;
+          updatedAt?: string;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Successfully retrieved search results */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-key/{keyId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-key/{keyId}": {
     /**
      * Get all loans for a specific key
      * @description Returns all loan records for the specified key ID, ordered by creation date DESC
@@ -7512,36 +7498,36 @@ export interface paths {
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The key ID to fetch loans for */
-          keyId: string
-        }
-      }
+          keyId: string;
+        };
+      };
       responses: {
         /** @description Array of loans for this key */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-card/{cardId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-card/{cardId}": {
     /**
      * Get all loans for a specific card
      * @description Returns all loan records for the specified card ID, ordered by creation date DESC
@@ -7550,23 +7536,23 @@ export interface paths {
       parameters: {
         path: {
           /** @description The card ID to fetch loans for */
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Array of loans for this card */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan'][]
-            }
-          }
-        }
-        500: components['responses']['InternalServerError']
-      }
-    }
-  }
-  '/key-loans/by-rental-object/{rentalObjectCode}': {
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"][];
+            };
+          };
+        };
+        500: components["responses"]["InternalServerError"];
+      };
+    };
+  };
+  "/key-loans/by-rental-object/{rentalObjectCode}": {
     /**
      * Get key loans by rental object code
      * @description Returns all key loans for a specific rental object with keys and optional receipts
@@ -7575,43 +7561,43 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by contact code */
-          contact?: string
+          contact?: string;
           /** @description Filter by second contact code */
-          contact2?: string
+          contact2?: string;
           /** @description Include receipts in the response */
-          includeReceipts?: boolean
+          includeReceipts?: boolean;
           /**
            * @description Filter by return status:
            * - true: Only returned loans (returnedAt IS NOT NULL)
            * - false: Only active loans (returnedAt IS NULL)
            * - omitted: All loans (no filter)
            */
-          returned?: boolean
-        }
+          returned?: boolean;
+        };
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description A list of key loans with details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-contact/{contact}/with-keys': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-contact/{contact}/with-keys": {
     /**
      * Get key loans by contact with keys
      * @description Returns all key loans for a specific contact with full key details, optionally filtered by loan type and return status
@@ -7620,45 +7606,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean
+          returned?: boolean;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The contact identifier to search for */
-          contact: string
-        }
-      }
+          contact: string;
+        };
+      };
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/by-bundle/{bundleId}/with-keys': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/by-bundle/{bundleId}/with-keys": {
     /**
      * Get key loans by bundle with keys
      * @description Returns all key loans for a specific bundle with full key details, optionally filtered by loan type and return status
@@ -7667,45 +7653,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Filter by loan type (TENANT or MAINTENANCE) */
-          loanType?: 'TENANT' | 'MAINTENANCE'
+          loanType?: "TENANT" | "MAINTENANCE";
           /** @description Filter by return status (true = returned, false = not returned) */
-          returned?: boolean
+          returned?: boolean;
           /**
            * @description When true, batch-fetches contacts referenced by the loans and
            * attaches them as a `contacts` sidecar keyed by contactCode. Soft
            * fails — if the contacts service errors, loans are still returned
            * without the sidecar.
            */
-          includeContacts?: boolean
-        }
+          includeContacts?: boolean;
+        };
         path: {
           /** @description The bundle ID to search for */
-          bundleId: string
-        }
-      }
+          bundleId: string;
+        };
+      };
       responses: {
         /** @description Array of key loans with full key details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoanWithDetails'][]
+            "application/json": {
+              content?: components["schemas"]["KeyLoanWithDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-loans/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-loans/{id}": {
     /**
      * Get key loan by ID
      * @description Fetch a specific key loan by its ID.
@@ -7718,44 +7704,42 @@ export interface paths {
       parameters: {
         query?: {
           /** @description When true, includes keysArray with keySystem data attached to each key. */
-          includeKeySystem?: boolean
+          includeKeySystem?: boolean;
           /** @description When true, includes keyCardsArray with card data from DAX. Auto-implies key fetching. */
-          includeCards?: boolean
+          includeCards?: boolean;
           /** @description When true, includes loan history attached to each key in keysArray. */
-          includeLoans?: boolean
+          includeLoans?: boolean;
           /** @description When true, includes event history attached to each key in keysArray. */
-          includeEvents?: boolean
-        }
+          includeEvents?: boolean;
+        };
         path: {
           /** @description The unique ID of the key loan to retrieve. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description A key loan object. Returns KeyLoanWithDetails if includeKeySystem or includeCards is true. */
         200: {
           content: {
-            'application/json': {
-              content?:
-                | components['schemas']['KeyLoan']
-                | components['schemas']['KeyLoanWithDetails']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"] | components["schemas"]["KeyLoanWithDetails"];
+            };
+          };
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while fetching the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a key loan
      * @description Delete an existing key loan by ID.
@@ -7764,28 +7748,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to delete. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key loan deleted successfully. */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while deleting the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key loan
      * @description Partially update an existing key loan.
@@ -7794,45 +7778,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The unique ID of the key loan to update. */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyLoanRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyLoanRequest"];
+        };
+      };
       responses: {
         /** @description Key loan updated successfully. */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyLoan']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyLoan"];
+            };
+          };
+        };
         /** @description Invalid request data. */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key loan not found. */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description An error occurred while updating the key loan. */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes/{id}": {
     /**
      * Get key note by ID
      * @description Retrieve a specific key note by its ID
@@ -7841,32 +7825,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key note
      * @description Update the description of an existing key note
@@ -7875,45 +7859,45 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key note to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyNoteRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyNoteRequest"];
+        };
+      };
       responses: {
         /** @description Key note updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes/by-rental-object/{rentalObjectCode}": {
     /**
      * Get key note by rental object code
      * @description Retrieve the key note for a specific rental object
@@ -7922,34 +7906,34 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key note */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Key note not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-notes': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-notes": {
     /**
      * Create a new key note
      * @description Create a new key note for a rental object
@@ -7957,34 +7941,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyNoteRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyNoteRequest"];
+        };
+      };
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeyNote']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeyNote"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems": {
     /**
      * List all key systems with pagination
      * @description Retrieve a paginated list of all key systems
@@ -7993,28 +7977,28 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated key systems */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeySystem'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeySystem"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Create a new key system
      * @description Create a new key system
@@ -8022,34 +8006,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeySystemRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeySystemRequest"];
+        };
+      };
       responses: {
         /** @description Key system created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/search": {
     /**
      * Search key systems
      * @description Search key systems with flexible filtering.
@@ -8066,54 +8050,54 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Search query for OR search across fields specified in 'fields' parameter */
-          q?: string
+          q?: string;
           /** @description Comma-separated list of fields for OR search (e.g., "systemCode,manufacturer"). Defaults to systemCode. */
-          fields?: string
-          id?: string
-          systemCode?: string
-          name?: string
-          manufacturer?: string
-          managingSupplier?: string
-          type?: string
-          propertyIds?: string
-          installationDate?: string
-          isActive?: string
-          notes?: string
-          createdAt?: string
-          updatedAt?: string
-          createdBy?: string
-          updatedBy?: string
-        }
-      }
+          fields?: string;
+          id?: string;
+          systemCode?: string;
+          name?: string;
+          manufacturer?: string;
+          managingSupplier?: string;
+          type?: string;
+          propertyIds?: string;
+          installationDate?: string;
+          isActive?: string;
+          notes?: string;
+          createdAt?: string;
+          updatedAt?: string;
+          createdBy?: string;
+          updatedBy?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeySystem'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeySystem"][];
+            };
+          };
+        };
         /** @description Bad request. Invalid parameters or field names */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/{id}": {
     /**
      * Get key system by ID
      * @description Retrieve a specific key system by its ID
@@ -8122,32 +8106,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved key system */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a key system
      * @description Delete a key system by ID
@@ -8156,28 +8140,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to delete */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key system deleted successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a key system
      * @description Partially update a key system
@@ -8186,139 +8170,139 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the key system to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeySystemRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeySystemRequest"];
+        };
+      };
       responses: {
         /** @description Key system updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['KeySystem']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["KeySystem"];
+            };
+          };
+        };
         /** @description Invalid type or duplicate system code */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Key system not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/upload-schema': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/upload-schema": {
     /** Upload a schema file for a key system */
     post: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
-            fileContentType?: string
-            fileName?: string
-          }
-        }
-      }
+            fileData: string;
+            fileContentType?: string;
+            fileName?: string;
+          };
+        };
+      };
       responses: {
         /** @description Schema file uploaded successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                fileId?: string
-              }
-            }
-          }
-        }
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Missing fileData */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/download-schema': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/download-schema": {
     /** Get presigned download URL for a key system schema file */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            'application/json': components['schemas']['SchemaDownloadUrlResponse']
-          }
-        }
+            "application/json": components["schemas"]["SchemaDownloadUrlResponse"];
+          };
+        };
         /** @description Key system or schema file not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/key-systems/{id}/schema': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/key-systems/{id}/schema": {
     /** Delete the schema file for a key system */
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Schema deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Key system not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/keys': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/keys": {
     /**
      * List keys with pagination
      * @description Returns paginated keys ordered by createdAt (desc).
@@ -8327,71 +8311,71 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Paginated list of keys */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyDetails'][]
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Create a key */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateKeyRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateKeyRequest"];
+        };
+      };
       responses: {
         /** @description Created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Invalid key_type */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/search": {
     /**
      * Search keys
      * @description Search keys with flexible filtering.
@@ -8404,59 +8388,59 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to keyName. */
-          fields?: string
-          id?: string
-          keyName?: string
-          keySequenceNumber?: string
-          flexNumber?: string
-          rentalObjectCode?: string
-          keyType?: string
-          keySystemId?: string
-          createdAt?: string
-          updatedAt?: string
+          fields?: string;
+          id?: string;
+          keyName?: string;
+          keySequenceNumber?: string;
+          flexNumber?: string;
+          rentalObjectCode?: string;
+          keyType?: string;
+          keySystemId?: string;
+          createdAt?: string;
+          updatedAt?: string;
           /**
            * @description When true, batch-fetches contacts referenced by the keys'
            * `activeLoanContact` field and attaches them as a `contacts`
            * sidecar keyed by contactCode. Soft fails — if the contacts
            * service errors, keys are still returned without the sidecar.
            */
-          includeContacts?: boolean
-        }
-      }
+          includeContacts?: boolean;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['KeyDetails'][]
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["KeyDetails"][];
               /** @description Present only when `includeContacts=true` and the fetch succeeded. */
               contacts?: {
-                [key: string]: components['schemas']['ContactV1']
-              }
-            }
-          }
-        }
+                [key: string]: components["schemas"]["ContactV1"];
+              };
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/by-rental-object/{rentalObjectCode}": {
     /**
      * Get all keys by rental object code
      * @description Returns all keys associated with a specific rental object code without pagination
@@ -8465,182 +8449,182 @@ export interface paths {
       parameters: {
         path: {
           /** @description The rental object code to filter keys by */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved keys */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/cards/by-rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/cards/by-rental-object/{rentalObjectCode}": {
     /** Get cards by rental object code */
     get: {
       parameters: {
         query?: {
-          includeLoans?: boolean
-        }
+          includeLoans?: boolean;
+        };
         path: {
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Cards for the rental object */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['CardDetails'][]
-            }
-          }
-        }
-      }
-    }
-  }
-  '/cards/{cardId}': {
+            "application/json": {
+              content?: components["schemas"]["CardDetails"][];
+            };
+          };
+        };
+      };
+    };
+  };
+  "/cards/{cardId}": {
     /** Get card by ID */
     get: {
       parameters: {
         path: {
-          cardId: string
-        }
-      }
+          cardId: string;
+        };
+      };
       responses: {
         /** @description Card found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Card']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Card"];
+            };
+          };
+        };
         /** @description Card not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/{id}": {
     /** Get key by ID */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Key found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Delete a key */
     delete: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Deleted */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Update a key (partial) */
     patch: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateKeyRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateKeyRequest"];
+        };
+      };
       responses: {
         /** @description Updated */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Key']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Key"];
+            };
+          };
+        };
         /** @description Invalid key_type */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-update': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-update": {
     /**
      * Bulk update keys
      * @description Update multiple keys with the same values. Maximum 100 keys per request.
@@ -8648,35 +8632,35 @@ export interface paths {
     patch: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['BulkUpdateKeysRequest']
-        }
-      }
+          "application/json": components["schemas"]["BulkUpdateKeysRequest"];
+        };
+      };
       responses: {
         /** @description Keys updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys updated */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-update-flex': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-update-flex": {
     /**
      * Bulk update flex number for all keys on a rental object
      * @description Update the flex number for all keys associated with a specific rental object code. Flex numbers range from 1-3.
@@ -8684,35 +8668,35 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['BulkUpdateFlexRequest']
-        }
-      }
+          "application/json": components["schemas"]["BulkUpdateFlexRequest"];
+        };
+      };
       responses: {
         /** @description Flex numbers updated successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys updated */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/keys/bulk-delete': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/keys/bulk-delete": {
     /**
      * Bulk delete keys
      * @description Delete multiple keys by their IDs. Maximum 100 keys per request.
@@ -8720,37 +8704,37 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
-            keyIds: string[]
-          }
-        }
-      }
+          "application/json": {
+            keyIds: string[];
+          };
+        };
+      };
       responses: {
         /** @description Keys deleted successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               /** @description Number of keys deleted */
-              content?: number
-            }
-          }
-        }
+              content?: number;
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs": {
     /**
      * List logs with pagination
      * @description Returns paginated logs (most recent per objectId) ordered by eventTime (desc).
@@ -8759,60 +8743,60 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description Paginated list of logs */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /** Create a log */
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateLogRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateLogRequest"];
+        };
+      };
       responses: {
         /** @description Created */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"];
+            };
+          };
+        };
         /** @description Invalid or missing fields */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/search': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/search": {
     /**
      * Search logs with pagination
      * @description Search logs with flexible filtering and pagination.
@@ -8825,46 +8809,46 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-          q?: string
+          limit?: number;
+          q?: string;
           /** @description Comma-separated list of fields for OR search. Defaults to objectId. */
-          fields?: string
-          id?: string
-          userName?: string
-          eventType?: string
-          eventTime?: string
-          objectType?: string
-          objectId?: string
-          description?: string
-        }
-      }
+          fields?: string;
+          id?: string;
+          userName?: string;
+          eventType?: string;
+          eventTime?: string;
+          objectType?: string;
+          objectId?: string;
+          description?: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved paginated search results */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Bad request */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/object/{objectId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/object/{objectId}": {
     /**
      * Get all logs for a specific objectId
      * @description Returns all log entries for a given objectId, ordered by most recent first
@@ -8872,60 +8856,60 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          objectId: string
-        }
-      }
+          objectId: string;
+        };
+      };
       responses: {
         /** @description List of logs for the objectId */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/{id}": {
     /** Get log by ID */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Log found */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Log']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Log"];
+            };
+          };
+        };
         /** @description Not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/rental-object/{rentalObjectCode}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/rental-object/{rentalObjectCode}": {
     /**
      * Get all logs for a specific rental object
      * @description Returns all log entries for a given rental object code by JOINing across multiple tables.
@@ -8942,40 +8926,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string
+          eventType?: string;
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string
+          objectType?: string;
           /** @description Filter by user name */
-          userName?: string
-        }
+          userName?: string;
+        };
         path: {
           /** @description The rental object code (e.g., "705-011-03-0102") */
-          rentalObjectCode: string
-        }
-      }
+          rentalObjectCode: string;
+        };
+      };
       responses: {
         /** @description Paginated list of logs for the rental object */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/logs/contact/{contactId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/logs/contact/{contactId}": {
     /**
      * Get all logs for a specific contact
      * @description Returns all log entries for a given contact code by JOINing across keyLoans and receipts.
@@ -8992,40 +8976,40 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Page number (starts from 1) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
+          limit?: number;
           /** @description Filter by event type (creation, update, delete) */
-          eventType?: string
+          eventType?: string;
           /** @description Filter by object type (key, keyLoan, receipt, etc.) */
-          objectType?: string
+          objectType?: string;
           /** @description Filter by user name */
-          userName?: string
-        }
+          userName?: string;
+        };
         path: {
           /** @description The contact code (e.g., "P079586", "F123456") */
-          contactId: string
-        }
-      }
+          contactId: string;
+        };
+      };
       responses: {
         /** @description Paginated list of logs for the contact */
         200: {
           content: {
-            'application/json': components['schemas']['PaginatedResponse'] & {
-              content?: components['schemas']['Log'][]
-            }
-          }
-        }
+            "application/json": components["schemas"]["PaginatedResponse"] & {
+              content?: components["schemas"]["Log"][];
+            };
+          };
+        };
         /** @description Server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts": {
     /**
      * Create a receipt
      * @description Create a new receipt record for a key loan
@@ -9033,34 +9017,34 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['CreateReceiptRequest']
-        }
-      }
+          "application/json": components["schemas"]["CreateReceiptRequest"];
+        };
+      };
       responses: {
         /** @description Key note created successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts/{id}": {
     /**
      * Get a receipt by ID
      * @description Retrieve a specific receipt by its ID
@@ -9069,32 +9053,32 @@ export interface paths {
       parameters: {
         path: {
           /** @description The receipt ID */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Successfully retrieved receipt */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Delete a receipt
      * @description Delete a receipt by ID (and associated file from MinIO)
@@ -9103,28 +9087,28 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to delete */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Receipt deleted successfully */
         204: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
     /**
      * Update a receipt
      * @description Update a receipt (e.g., set fileId after upload)
@@ -9133,144 +9117,144 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the receipt to update */
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': components['schemas']['UpdateReceiptRequest']
-        }
-      }
+          "application/json": components["schemas"]["UpdateReceiptRequest"];
+        };
+      };
       responses: {
         /** @description Receipt updated successfully */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Receipt not found */
         404: {
           content: {
-            'application/json': components['schemas']['NotFoundResponse']
-          }
-        }
+            "application/json": components["schemas"]["NotFoundResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/receipts/by-key-loan/{keyLoanId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/receipts/by-key-loan/{keyLoanId}": {
     /** Get receipts by key loan ID */
     get: {
       parameters: {
         path: {
-          keyLoanId: string
-        }
-      }
+          keyLoanId: string;
+        };
+      };
       responses: {
         /** @description Receipts for the key loan */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Receipt'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Receipt"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/receipts/{id}/upload': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/receipts/{id}/upload": {
     /** Upload a file for a receipt */
     post: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @description Base64 encoded file data */
-            fileData: string
-            fileContentType?: string
-          }
-        }
-      }
+            fileData: string;
+            fileContentType?: string;
+          };
+        };
+      };
       responses: {
         /** @description File uploaded successfully */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                fileId?: string
-              }
-            }
-          }
-        }
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Missing fileData */
         400: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Receipt not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/receipts/{id}/download': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/receipts/{id}/download": {
     /** Get presigned download URL for a receipt file */
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Presigned download URL */
         200: {
           content: {
-            'application/json': {
+            "application/json": {
               content?: {
-                url?: string
-                expiresIn?: number
-                fileId?: string
-              }
-            }
-          }
-        }
+                url?: string;
+                expiresIn?: number;
+                fileId?: string;
+              };
+            };
+          };
+        };
         /** @description Receipt or file not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/signatures/send': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/signatures/send": {
     /**
      * Send a document for digital signature via SimpleSign
      * @description Send a PDF document to SimpleSign for digital signature
@@ -9278,49 +9262,49 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': {
+          "application/json": {
             /** @enum {string} */
-            resourceType: 'receipt'
+            resourceType: "receipt";
             /** Format: uuid */
-            resourceId: string
+            resourceId: string;
             /** Format: email */
-            recipientEmail: string
-            recipientName?: string
-            pdfBase64: string
-          }
-        }
-      }
+            recipientEmail: string;
+            recipientName?: string;
+            pdfBase64: string;
+          };
+        };
+      };
       responses: {
         /** @description Signature request sent successfully */
         201: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"];
+            };
+          };
+        };
         /** @description Invalid request data */
         400: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Resource not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/signatures/{id}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/signatures/{id}": {
     /**
      * Get a signature by ID
      * @description Retrieve a specific signature by its ID
@@ -9328,34 +9312,34 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          id: string
-        }
-      }
+          id: string;
+        };
+      };
       responses: {
         /** @description Signature details */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature']
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"];
+            };
+          };
+        };
         /** @description Signature not found */
         404: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/signatures/resource/{resourceType}/{resourceId}': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/signatures/resource/{resourceType}/{resourceId}": {
     /**
      * Get all signatures for a resource
      * @description Retrieve all signatures associated with a specific resource
@@ -9363,29 +9347,29 @@ export interface paths {
     get: {
       parameters: {
         path: {
-          resourceType: 'receipt'
-          resourceId: string
-        }
-      }
+          resourceType: "receipt";
+          resourceId: string;
+        };
+      };
       responses: {
         /** @description List of signatures */
         200: {
           content: {
-            'application/json': {
-              content?: components['schemas']['Signature'][]
-            }
-          }
-        }
+            "application/json": {
+              content?: components["schemas"]["Signature"][];
+            };
+          };
+        };
         /** @description Internal server error */
         500: {
           content: {
-            'application/json': components['schemas']['ErrorResponse']
-          }
-        }
-      }
-    }
-  }
-  '/webhooks/simplesign': {
+            "application/json": components["schemas"]["ErrorResponse"];
+          };
+        };
+      };
+    };
+  };
+  "/webhooks/simplesign": {
     /**
      * Webhook endpoint for SimpleSign status updates
      * @description Receives webhook notifications from SimpleSign when document status changes (e.g., signed, declined)
@@ -9393,26 +9377,26 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          'application/json': components['schemas']['SimpleSignWebhookPayload']
-        }
-      }
+          "application/json": components["schemas"]["SimpleSignWebhookPayload"];
+        };
+      };
       responses: {
         /** @description Webhook processed successfully */
         200: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Signature not found */
         404: {
-          content: never
-        }
+          content: never;
+        };
         /** @description Internal server error */
         500: {
-          content: never
-        }
-      }
-    }
-  }
-  '/v1/contacts': {
+          content: never;
+        };
+      };
+    };
+  };
+  "/v1/contacts": {
     /**
      * List and filter(search) for contact information
      * @description Filtering can be done by wildcard search
@@ -9421,55 +9405,55 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Wildcard search string */
-          q?: string[]
+          q?: string[];
           /** @description Filter on contact type */
-          type?: 'individual' | 'organisation'
+          type?: "individual" | "organisation";
           /** @description Page number for paginated results (1-based) */
-          page?: number
+          page?: number;
           /** @description Number of records per page */
-          limit?: number
-        }
-      }
+          limit?: number;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              content: components['schemas']['ContactV1'][]
+            "application/json": {
+              content: components["schemas"]["ContactV1"][];
               _meta: {
-                totalRecords: number
-                page: number
-                limit: number
-                count: number
-              }
-              _links: {
-                href: string
-                /** @enum {string} */
-                rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-              }[]
-            }
-          }
-        }
+                totalRecords: number;
+                page: number;
+                limit: number;
+                count: number;
+              };
+              _links: ({
+                  href: string;
+                  /** @enum {string} */
+                  rel: "self" | "first" | "last" | "prev" | "next";
+                })[];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
         /** @description Internal Server Error */
         500: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/batch': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/batch": {
     /**
      * Batch lookup of contacts by contact code
      * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, or `includeAddress` to include those joins. Missing contact codes are simply absent from the response.
@@ -9478,3014 +9462,2868 @@ export interface paths {
       parameters: {
         query: {
           /** @description Contact code(s) to look up. Repeat the parameter for multiple codes, e.g. ?code=P123&code=P456. */
-          code: string[]
+          code: string[];
           /** @description Include phone numbers in the response. */
-          includePhone?: boolean
+          includePhone?: boolean;
           /** @description Include email addresses in the response. */
-          includeEmail?: boolean
+          includeEmail?: boolean;
           /** @description Include addresses in the response. */
-          includeAddress?: boolean
-        }
-      }
+          includeAddress?: boolean;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1'][]
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"][];
+            };
+          };
+        };
         /** @description Internal Server Error */
         500: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/{contactCode}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/{contactCode}": {
     /** Get a single contact by canonical id (contact code) */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/{contactCode}/trustee': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/{contactCode}/trustee": {
     /** Get the trustee of a contact */
     get: {
       parameters: {
         path: {
           /** @description Contact Code */
-          contactCode: string
-        }
-      }
+          contactCode: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-phone-number/{phoneNumber}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-phone-number/{phoneNumber}": {
     /** List contacts by phone number */
     get: {
       parameters: {
         path: {
           /** @description Phone Number */
-          phoneNumber: string
-        }
-      }
+          phoneNumber: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-email-address/{emailAddress}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-email-address/{emailAddress}": {
     /** List contacts by email address */
     get: {
       parameters: {
         path: {
           /** @description Email Address */
-          emailAddress: string
-        }
-      }
+          emailAddress: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
-  '/v1/contacts/by-national-id/{nid}': {
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
+  "/v1/contacts/by-national-id/{nid}": {
     /** List contacts by national id (Personnummer / Org.nr) */
     get: {
       parameters: {
         path: {
           /** @description National ID */
-          nid: string
-        }
-      }
+          nid: string;
+        };
+      };
       responses: {
         /** @description OK */
         200: {
           content: {
-            'application/json': {
-              _links?: unknown
-              content: components['schemas']['ContactV1']
-            }
-          }
-        }
+            "application/json": {
+              _links?: unknown;
+              content: components["schemas"]["ContactV1"];
+            };
+          };
+        };
         /** @description Not Found */
         404: {
           content: {
-            'application/json': {
-              _links?: unknown
-            }
-          }
-        }
-      }
-    }
-  }
+            "application/json": {
+              _links?: unknown;
+            };
+          };
+        };
+      };
+    };
+  };
 }
 
-export type webhooks = Record<string, never>
+export type webhooks = Record<string, never>;
 
 export interface components {
   schemas: {
     Lease: {
-      leaseId: string
-      leaseNumber: string
+      leaseId: string;
+      leaseNumber: string;
       /** Format: date-time */
-      leaseStartDate: string
+      leaseStartDate: string;
       /** Format: date-time */
-      leaseEndDate?: string
+      leaseEndDate?: string;
       /** @enum {string} */
-      status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-      tenantContactIds?: string[]
-      rentalPropertyId: string
+      status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+      tenantContactIds?: string[];
+      rentalPropertyId: string;
       rentalProperty?: {
-        rentalPropertyId: string
-        apartmentNumber: number
-        size: number
-        type: string
+        rentalPropertyId: string;
+        apartmentNumber: number;
+        size: number;
+        type: string;
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        rentalPropertyType: string
-        additionsIncludedInRent: string
-        otherInfo?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        rentalPropertyType: string;
+        additionsIncludedInRent: string;
+        otherInfo?: string;
         roomTypes?: {
-          roomTypeId: string
-          name: string
-        }[]
+            roomTypeId: string;
+            name: string;
+          }[];
         /** Format: date-time */
-        lastUpdated?: string
-      }
-      type: string
+        lastUpdated?: string;
+      };
+      type: string;
       rentInfo?: {
         currentRent: {
-          rentId?: string
-          leaseId?: string
-          currentRent: number
-          vat: number
-          additionalChargeDescription?: string
-          additionalChargeAmount?: number
+          rentId?: string;
+          leaseId?: string;
+          currentRent: number;
+          vat: number;
+          additionalChargeDescription?: string;
+          additionalChargeAmount?: number;
           /** Format: date-time */
-          rentStartDate?: string
+          rentStartDate?: string;
           /** Format: date-time */
-          rentEndDate?: string
-        }
-      }
+          rentEndDate?: string;
+        };
+      };
       address?: {
-        street?: string
-        number: string
-        postalCode: string
-        city: string
-      }
-      noticeGivenBy?: string
+        street?: string;
+        number: string;
+        postalCode: string;
+        city: string;
+      };
+      noticeGivenBy?: string;
       /** Format: date-time */
-      noticeDate?: string
-      noticeTimeTenant?: string | number
+      noticeDate?: string;
+      noticeTimeTenant?: string | number;
       /** Format: date-time */
-      preferredMoveOutDate?: string
+      preferredMoveOutDate?: string;
       /** Format: date-time */
-      terminationDate?: string
+      terminationDate?: string;
       /** Format: date-time */
-      contractDate?: string
+      contractDate?: string;
       /** Format: date-time */
-      lastDebitDate?: string
+      lastDebitDate?: string;
       /** Format: date-time */
-      approvalDate?: string
+      approvalDate?: string;
       residentialArea?: {
-        code: string
-        caption: string
-      }
+        code: string;
+        caption: string;
+      };
       tenants?: {
-        contactCode: string
-        contactKey: string
-        leaseIds?: string[]
-        firstName: string
-        lastName: string
-        fullName: string
-        nationalRegistrationNumber: string
-        /** Format: date-time */
-        birthDate: string
-        address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        phoneNumbers?: {
-          phoneNumber: string
-          type: string
-          isMainNumber: boolean
-        }[]
-        emailAddress?: string
-        isTenant: boolean
-        parkingSpaceWaitingList?: {
+          contactCode: string;
+          contactKey: string;
+          leaseIds?: string[];
+          firstName: string;
+          lastName: string;
+          fullName: string;
+          nationalRegistrationNumber: string;
           /** Format: date-time */
-          queueTime: string
-          queuePoints: number
-          type: number
-        }
-        specialAttention?: boolean
-        leaseContactType?: string
-      }[]
-    }
+          birthDate: string;
+          address?: {
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          phoneNumbers?: {
+              phoneNumber: string;
+              type: string;
+              isMainNumber: boolean;
+            }[];
+          emailAddress?: string;
+          isTenant: boolean;
+          parkingSpaceWaitingList?: {
+            /** Format: date-time */
+            queueTime: string;
+            queuePoints: number;
+            type: number;
+          };
+          specialAttention?: boolean;
+          leaseContactType?: string;
+        }[];
+    };
     IdentityCheckContact: {
-      contactCode: string
-      nationalRegistrationNumber: string
-    }
+      contactCode: string;
+      nationalRegistrationNumber: string;
+    };
     LeaseSearchResult: {
-      leaseId: string
-      objectTypeCode: string
-      leaseType: string
-      contacts: {
-        name: string
-        contactCode: string
-        email: string | null
-        phone: string | null
-      }[]
-      address: string | null
+      leaseId: string;
+      objectTypeCode: string;
+      leaseType: string;
+      contacts: ({
+          name: string;
+          contactCode: string;
+          email: string | null;
+          phone: string | null;
+        })[];
+      address: string | null;
       /** Format: date-time */
-      startDate: string | null
+      startDate: string | null;
       /** Format: date-time */
-      lastDebitDate: string | null
+      lastDebitDate: string | null;
       /** @enum {number} */
-      status: 0 | 1 | 2 | 3
-      rentalObjectCode: string | null
-      property?: string | null
-      buildingCode?: string | null
-      area?: string | null
-      buildingManager?: string | null
-      districtName?: string | null
-      parkingSpaceType?: string | null
-    }
+      status: 0 | 1 | 2 | 3;
+      rentalObjectCode: string | null;
+      property?: string | null;
+      buildingCode?: string | null;
+      area?: string | null;
+      buildingManager?: string | null;
+      districtName?: string | null;
+      parkingSpaceType?: string | null;
+    };
     ContactInfo: {
-      name: string
-      contactCode: string
-      email: string | null
-      phone: string | null
-    }
+      name: string;
+      contactCode: string;
+      email: string | null;
+      phone: string | null;
+    };
     PaginationMeta: {
-      totalRecords: number
-      page: number
-      limit: number
-      count: number
-    }
+      totalRecords: number;
+      page: number;
+      limit: number;
+      count: number;
+    };
     PaginationLinks: {
-      href: string
+      href: string;
       /** @enum {string} */
-      rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-    }
+      rel: "self" | "first" | "last" | "prev" | "next";
+    };
     Contact: {
-      contactCode: string
-      contactKey: string
-      leaseIds?: string[]
-      firstName: string | null
-      lastName: string | null
-      fullName: string | null
-      nationalRegistrationNumber: string
+      contactCode: string;
+      contactKey: string;
+      leaseIds?: string[];
+      firstName: string | null;
+      lastName: string | null;
+      fullName: string | null;
+      nationalRegistrationNumber: string;
       /** Format: date-time */
-      birthDate: string | null
+      birthDate: string | null;
       address: {
-        street: string
-        number: string
-        postalCode: string
-        city: string
-      } | null
+        street: string;
+        number: string;
+        postalCode: string;
+        city: string;
+      } | null;
       phoneNumbers: {
-        phoneNumber: string
-        type: string
-        isMainNumber: boolean
-      }[]
-      emailAddress: string | null
-      isTenant: boolean
-      specialAttention?: boolean
-    }
+          phoneNumber: string;
+          type: string;
+          isMainNumber: boolean;
+        }[];
+      emailAddress: string | null;
+      isTenant: boolean;
+      specialAttention?: boolean;
+    };
     ListingTextContent: {
       /** Format: uuid */
-      id: string
-      rentalObjectCode: string
-      contentBlocks: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
+      id: string;
+      rentalObjectCode: string;
+      contentBlocks: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     CreateListingTextContentRequest: {
-      rentalObjectCode: string
-      contentBlocks: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
-    }
+      rentalObjectCode: string;
+      contentBlocks: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
+    };
     UpdateListingTextContentRequest: {
-      contentBlocks?: (
-        | {
-            /** @enum {string} */
-            type: 'preamble'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'headline'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'subtitle'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bullet_list'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'bold_text'
-            content: string
-          }
-        | {
-            /** @enum {string} */
-            type: 'link'
-            name: string
-            /** Format: uri */
-            url: string
-          }
-      )[]
-    }
+      contentBlocks?: ({
+          /** @enum {string} */
+          type: "preamble";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "headline";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "subtitle";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bullet_list";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "bold_text";
+          content: string;
+        } | {
+          /** @enum {string} */
+          type: "link";
+          name: string;
+          /** Format: uri */
+          url: string;
+        })[];
+    };
     WorkOrder: {
-      accessCaption: string
-      caption: string
-      code: string
-      contactCode: string
-      description: string
-      detailsCaption: string
-      externalResource: boolean
-      id: string
+      accessCaption: string;
+      caption: string;
+      code: string;
+      contactCode: string;
+      description: string;
+      detailsCaption: string;
+      externalResource: boolean;
+      id: string;
       /** Format: date-time */
-      lastChanged: string
-      priority: string
+      lastChanged: string;
+      priority: string;
       /** Format: date-time */
-      registered: string
-      dueDate: ('null' | null) | string
-      rentalObjectCode: string
-      status: string
-      hiddenFromMyPages?: boolean
-      workOrderRows: {
-        description: string | null
-        locationCode: string | null
-        equipmentCode: string | null
-      }[]
+      registered: string;
+      dueDate: ("null" | null) | string;
+      rentalObjectCode: string;
+      status: string;
+      hiddenFromMyPages?: boolean;
+      workOrderRows: ({
+          description: string | null;
+          locationCode: string | null;
+          equipmentCode: string | null;
+        })[];
       messages?: {
-        id: number
-        body: string
-        messageType: string
-        author: string
-        /** Format: date-time */
-        createDate: string
-      }[]
-      url?: string
-    }
+          id: number;
+          body: string;
+          messageType: string;
+          author: string;
+          /** Format: date-time */
+          createDate: string;
+        }[];
+      url?: string;
+    };
     XpandWorkOrder: {
-      accessCaption: string
-      caption: string | null
-      code: string
-      contactCode: string | null
-      id: string
+      accessCaption: string;
+      caption: string | null;
+      code: string;
+      contactCode: string | null;
+      id: string;
       /** Format: date-time */
-      lastChanged: string
-      priority: string | null
+      lastChanged: string;
+      priority: string | null;
       /** Format: date-time */
-      registered: string
-      dueDate: ('null' | null) | string
-      rentalObjectCode: string
-      status: string
-    }
+      registered: string;
+      dueDate: ("null" | null) | string;
+      rentalObjectCode: string;
+      status: string;
+    };
     MaintenanceTeam: {
-      id: number
-      name: string
-    }
+      id: number;
+      name: string;
+    };
     CreateInspectionWorkOrdersRequest: {
-      rentalObjectCode: string
+      rentalObjectCode: string;
       groups: {
-        maintenanceTeamId: number
-        maintenanceTeamName: string
-        descriptionHtml: string
-      }[]
-    }
+          maintenanceTeamId: number;
+          maintenanceTeamName: string;
+          descriptionHtml: string;
+        }[];
+    };
     CreateInspectionWorkOrdersResponse: {
       results: {
-        maintenanceTeamId: number
-        ok: boolean
-        workOrderId?: number
-        err?: string
-      }[]
-    }
+          maintenanceTeamId: number;
+          ok: boolean;
+          workOrderId?: number;
+          err?: string;
+        }[];
+    };
     Building: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       buildingType: {
-        id: string | null
-        code: string | null
-        name: string | null
-      }
+        id: string | null;
+        code: string | null;
+        name: string | null;
+      };
       construction: {
-        constructionYear: number | null
-        renovationYear: number | null
-        valueYear: number | null
-      }
+        constructionYear: number | null;
+        renovationYear: number | null;
+        valueYear: number | null;
+      };
       features: {
-        heating?: string | null
-        fireRating?: string | null
-      }
+        heating?: string | null;
+        fireRating?: string | null;
+      };
       insurance: {
-        class: string | null
-        value: number | null
-      }
-      quantityValues?: {
-        id: string
-        value: number
-        name: string
-        unitId: string | null
-      }[]
-      deleted: boolean
-      property?: {
-        name: string | null
-        code: string
-        id: string
-      } | null
-    }
+        class: string | null;
+        value: number | null;
+      };
+      quantityValues?: ({
+          id: string;
+          value: number;
+          name: string;
+          unitId: string | null;
+        })[];
+      deleted: boolean;
+      property?: ({
+        name: string | null;
+        code: string;
+        id: string;
+      }) | null;
+    };
     Company: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string
-      organizationNumber: string | null
-    }
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string;
+      organizationNumber: string | null;
+    };
     CompanyDetails: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string
-      organizationNumber: string | null
-      phone: string | null
-      fax: string | null
-      vatNumber?: string | null
-      internalExternal: number
-      fTax: number
-      cooperativeHousingAssociation: number
-      differentiatedAdditionalCapital: number
-      rentAdministered: number
-      blocked: number
-      rentDaysPerMonth: number
-      economicPlanApproved: number
-      vatObligationPercent: number
-      vatRegistered: number
-      energyOptimization: number
-      ownedCompany: number
-      interestInvoice: number
-      errorReportAdministration: number
-      mediaBilling: number
-      ownResponsibilityForInternalMaintenance: number
-      subletPercentage: number
-      subletFeeAmount: number
-      disableQuantitiesBelowCompany: number
-      timestamp: string
-    }
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string;
+      organizationNumber: string | null;
+      phone: string | null;
+      fax: string | null;
+      vatNumber?: string | null;
+      internalExternal: number;
+      fTax: number;
+      cooperativeHousingAssociation: number;
+      differentiatedAdditionalCapital: number;
+      rentAdministered: number;
+      blocked: number;
+      rentDaysPerMonth: number;
+      economicPlanApproved: number;
+      vatObligationPercent: number;
+      vatRegistered: number;
+      energyOptimization: number;
+      ownedCompany: number;
+      interestInvoice: number;
+      errorReportAdministration: number;
+      mediaBilling: number;
+      ownResponsibilityForInternalMaintenance: number;
+      subletPercentage: number;
+      subletFeeAmount: number;
+      disableQuantitiesBelowCompany: number;
+      timestamp: string;
+    };
     Property: {
-      id: string
-      propertyObjectId: string
-      marketAreaId: string | null
-      districtId: string | null
-      propertyDesignationId: string | null
-      valueAreaId: string | null
-      code: string
-      designation: string
-      municipality: string
-      tract: string
-      block: string
-      sector: string | null
-      propertyIndexNumber: string | null
-      congregation: string | null
-      builtStatus: number
-      separateAssessmentUnit: number
-      consolidationNumber: string | null
-      ownershipType: string
-      registrationDate: string | null
-      acquisitionDate: string | null
-      isLeasehold: number
-      leaseholdTerminationDate: string | null
-      area: string | null
-      purpose: string | null
-      buildingType: string | null
-      propertyTaxNumber: string | null
-      mainPartAssessedValue: number
-      includeInAssessedValue: number
-      grading: number
-      deleteMark: number
+      id: string;
+      propertyObjectId: string;
+      marketAreaId: string | null;
+      districtId: string | null;
+      propertyDesignationId: string | null;
+      valueAreaId: string | null;
+      code: string;
+      designation: string;
+      municipality: string;
+      tract: string;
+      block: string;
+      sector: string | null;
+      propertyIndexNumber: string | null;
+      congregation: string | null;
+      builtStatus: number;
+      separateAssessmentUnit: number;
+      consolidationNumber: string | null;
+      ownershipType: string;
+      registrationDate: string | null;
+      acquisitionDate: string | null;
+      isLeasehold: number;
+      leaseholdTerminationDate: string | null;
+      area: string | null;
+      purpose: string | null;
+      buildingType: string | null;
+      propertyTaxNumber: string | null;
+      mainPartAssessedValue: number;
+      includeInAssessedValue: number;
+      grading: number;
+      deleteMark: number;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string
-      timestamp: string
-    }
+      toDate: string;
+      timestamp: string;
+    };
     Residence: {
-      id: string
-      code: string
-      name: string
-      deleted: boolean
+      id: string;
+      code: string;
+      name: string;
+      deleted: boolean;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string
+        fromDate: string;
         /** Format: date-time */
-        toDate: string
-      }
-    }
+        toDate: string;
+      };
+    };
     ResidenceDetails: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       /** @enum {string|null} */
-      status: 'VACANT' | 'LEASED' | null
-      entrance: string | null
-      location: string | null
-      floor: string | null
-      partNo: number | null
-      part: string | null
-      deleted: boolean
+      status: "VACANT" | "LEASED" | null;
+      entrance: string | null;
+      location: string | null;
+      floor: string | null;
+      partNo: number | null;
+      part: string | null;
+      deleted: boolean;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string
+        fromDate: string;
         /** Format: date-time */
-        toDate: string
-      }
+        toDate: string;
+      };
       accessibility: {
-        wheelchairAccessible: boolean
-        elevator: boolean
-        residenceAdapted: boolean
-      }
+        wheelchairAccessible: boolean;
+        elevator: boolean;
+        residenceAdapted: boolean;
+      };
       features: {
-        hygieneFacility: string | null
+        hygieneFacility: string | null;
         balcony1?: {
-          location: string
-          type: string
-        }
+          location: string;
+          type: string;
+        };
         balcony2?: {
-          location: string
-          type: string
-        }
-        patioLocation: string | null
-        sauna: boolean
-        extraToilet: boolean
-        sharedKitchen: boolean
-        petAllergyFree: boolean
+          location: string;
+          type: string;
+        };
+        patioLocation: string | null;
+        sauna: boolean;
+        extraToilet: boolean;
+        sharedKitchen: boolean;
+        petAllergyFree: boolean;
         /** @description Is the apartment checked for electric allergy intolerance? */
-        electricAllergyIntolerance: boolean
-        smokeFree: boolean
-        asbestos: boolean
-      }
+        electricAllergyIntolerance: boolean;
+        smokeFree: boolean;
+        asbestos: boolean;
+      };
       type: {
-        code: string
-        name: string | null
-        roomCount: number | null
-        kitchen: number
-      }
+        code: string;
+        name: string | null;
+        roomCount: number | null;
+        kitchen: number;
+      };
       residenceType: {
-        residenceTypeId: string
-        code: string
-        name: string | null
-        roomCount: number | null
-        kitchen: number
-        systemStandard: number
-        checklistId: string | null
-        componentTypeActionId: string | null
-        statisticsGroupSCBId: string | null
-        statisticsGroup2Id: string | null
-        statisticsGroup3Id: string | null
-        statisticsGroup4Id: string | null
-        timestamp: string
-      }
-      rentalInformation: {
-        apartmentNumber: string | null
-        rentalId: string | null
+        residenceTypeId: string;
+        code: string;
+        name: string | null;
+        roomCount: number | null;
+        kitchen: number;
+        systemStandard: number;
+        checklistId: string | null;
+        componentTypeActionId: string | null;
+        statisticsGroupSCBId: string | null;
+        statisticsGroup2Id: string | null;
+        statisticsGroup3Id: string | null;
+        statisticsGroup4Id: string | null;
+        timestamp: string;
+      };
+      rentalInformation: ({
+        apartmentNumber: string | null;
+        rentalId: string | null;
         type: {
-          code: string
-          name: string | null
-        }
-      } | null
+          code: string;
+          name: string | null;
+        };
+      }) | null;
       propertyObject: {
         energy: {
-          energyClass: number
+          energyClass: number;
           /** Format: date-time */
-          energyRegistered?: string
+          energyRegistered?: string;
           /** Format: date-time */
-          energyReceived?: string
-          energyIndex?: number
-        }
-        rentalId: string | null
-        rentalInformation: {
+          energyReceived?: string;
+          energyIndex?: number;
+        };
+        rentalId: string | null;
+        rentalInformation: ({
           type: {
-            code: string
-            name: string | null
-          }
-        } | null
-        rentalBlocks: {
-          id: string
-          blockReasonId: string | null
-          blockReason: string | null
-          /** Format: date-time */
-          fromDate: string
-          /** Format: date-time */
-          toDate: string | null
-          amount: number | null
-        }[]
-      }
+            code: string;
+            name: string | null;
+          };
+        }) | null;
+        rentalBlocks: ({
+            id: string;
+            blockReasonId: string | null;
+            blockReason: string | null;
+            /** Format: date-time */
+            fromDate: string;
+            /** Format: date-time */
+            toDate: string | null;
+            amount: number | null;
+          })[];
+      };
       property: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
       building: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
-      staircase: {
-        id: string
-        code: string
-        name: string | null
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
+      staircase: ({
+        id: string;
+        code: string;
+        name: string | null;
         features: {
-          floorPlan: string | null
-          accessibleByElevator: boolean
-        }
+          floorPlan: string | null;
+          accessibleByElevator: boolean;
+        };
         dates: {
           /** Format: date-time */
-          from: string
+          from: string;
           /** Format: date-time */
-          to: string
-        }
+          to: string;
+        };
         property?: {
-          propertyId: string | null
-          propertyName: string | null
-          propertyCode: string | null
-        }
+          propertyId: string | null;
+          propertyName: string | null;
+          propertyCode: string | null;
+        };
         building?: {
-          buildingId: string | null
-          buildingName: string | null
-          buildingCode: string | null
-        }
-        deleted: boolean
-        timestamp: string
-      } | null
-      areaSize: number | null
-      malarEnergiFacilityId: string | null
-    }
+          buildingId: string | null;
+          buildingName: string | null;
+          buildingCode: string | null;
+        };
+        deleted: boolean;
+        timestamp: string;
+      }) | null;
+      areaSize: number | null;
+      malarEnergiFacilityId: string | null;
+    };
     ResidenceSummary: {
-      id: string
-      code: string
-      name: string | null
-      deleted: boolean
-      rentalId: string
-      buildingCode: string
-      buildingName: string
-      staircaseCode: string
-      staircaseName: string
-      elevator: number | null
-      floor: string
-      hygieneFacility: string | null
-      wheelchairAccessible: number
+      id: string;
+      code: string;
+      name: string | null;
+      deleted: boolean;
+      rentalId: string;
+      buildingCode: string;
+      buildingName: string;
+      staircaseCode: string;
+      staircaseName: string;
+      elevator: number | null;
+      floor: string;
+      hygieneFacility: string | null;
+      wheelchairAccessible: number;
       validityPeriod: {
         /** Format: date-time */
-        fromDate: string | null
+        fromDate: string | null;
         /** Format: date-time */
-        toDate: string | null
-      }
+        toDate: string | null;
+      };
       residenceType: {
-        code: string
-        name: string
-        roomCount: number
-        kitchen: number
-      }
-      quantityValues: {
-        value: number
-        quantityTypeId: string
-        quantityType: {
-          name: string
-          unitId: string | null
-        }
-      }[]
-    }
+        code: string;
+        name: string;
+        roomCount: number;
+        kitchen: number;
+      };
+      quantityValues: ({
+          value: number;
+          quantityTypeId: string;
+          quantityType: {
+            name: string;
+            unitId: string | null;
+          };
+        })[];
+    };
     Staircase: {
-      id: string
-      code: string
-      name: string | null
+      id: string;
+      code: string;
+      name: string | null;
       features: {
-        floorPlan: string | null
-        accessibleByElevator: boolean
-      }
+        floorPlan: string | null;
+        accessibleByElevator: boolean;
+      };
       dates: {
         /** Format: date-time */
-        from: string
+        from: string;
         /** Format: date-time */
-        to: string
-      }
+        to: string;
+      };
       property?: {
-        propertyId: string | null
-        propertyName: string | null
-        propertyCode: string | null
-      }
+        propertyId: string | null;
+        propertyName: string | null;
+        propertyCode: string | null;
+      };
       building?: {
-        buildingId: string | null
-        buildingName: string | null
-        buildingCode: string | null
-      }
-      deleted: boolean
-      timestamp: string
-    }
+        buildingId: string | null;
+        buildingName: string | null;
+        buildingCode: string | null;
+      };
+      deleted: boolean;
+      timestamp: string;
+    };
     Room: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string | null
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string | null;
       usage: {
-        shared: boolean
-        allowPeriodicWorks: boolean
-        spaceType: number
-      }
+        shared: boolean;
+        allowPeriodicWorks: boolean;
+        spaceType: number;
+      };
       features: {
-        hasToilet: boolean
-        isHeated: boolean
-        hasThermostatValve: boolean
-        orientation: number
-      }
+        hasToilet: boolean;
+        isHeated: boolean;
+        hasThermostatValve: boolean;
+        orientation: number;
+      };
       dates: {
         /** Format: date-time */
-        installation: string | null
+        installation: string | null;
         /** Format: date-time */
-        from: string
+        from: string;
         /** Format: date-time */
-        to: string
+        to: string;
         /** Format: date-time */
-        availableFrom: string | null
+        availableFrom: string | null;
         /** Format: date-time */
-        availableTo: string | null
-      }
-      sortingOrder: number
-      deleted: boolean
-      timestamp: string
-      roomType: {
-        id: string
-        code: string
-        name: string | null
-        use: number
-        optionAllowed: number
-        isSystemStandard: number
-        allowSmallRoomsInValuation: number
-        timestamp: string
-      } | null
-      area?: number
-    }
+        availableTo: string | null;
+      };
+      sortingOrder: number;
+      deleted: boolean;
+      timestamp: string;
+      roomType: ({
+        id: string;
+        code: string;
+        name: string | null;
+        use: number;
+        optionAllowed: number;
+        isSystemStandard: number;
+        allowSmallRoomsInValuation: number;
+        timestamp: string;
+      }) | null;
+      area?: number;
+    };
     CreateRoomRequest: {
-      rentalId: string
+      rentalId: string;
       /** @enum {string} */
-      roomTypeCode:
-        | 'BAD'
-        | 'BAL'
-        | 'BRS'
-        | 'DUSCH'
-        | 'FÖR'
-        | 'GROV'
-        | 'HALL'
-        | 'KLÄD'
-        | 'KÖK'
-        | 'KOV'
-        | 'KV'
-        | 'MAT'
-        | 'PA'
-        | 'RUM'
-        | 'TRAPP'
-        | 'UP'
-        | 'VARD'
-        | 'WC'
-        | 'WC/DU1'
-      code?: string
-      caption?: string
+      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
+      code?: string;
+      caption?: string;
       features?: {
-        hasToilet?: boolean
-        isHeated?: boolean
-        hasThermostatValve?: boolean
-        orientation?: number
-      }
+        hasToilet?: boolean;
+        isHeated?: boolean;
+        hasThermostatValve?: boolean;
+        orientation?: number;
+      };
       usage?: {
-        shared?: boolean
-        allowPeriodicWorks?: boolean
-        spaceType?: number
-      }
-    }
+        shared?: boolean;
+        allowPeriodicWorks?: boolean;
+        spaceType?: number;
+      };
+    };
     ParkingSpace: {
-      rentalId: string
-      companyCode: string
-      companyName: string
-      managementUnitCode: string
-      managementUnitName: string
-      propertyCode: string
-      propertyName: string
-      buildingCode: string | null
-      buildingName: string | null
+      rentalId: string;
+      companyCode: string;
+      companyName: string;
+      managementUnitCode: string;
+      managementUnitName: string;
+      propertyCode: string;
+      propertyName: string;
+      buildingCode: string | null;
+      buildingName: string | null;
       parkingSpace: {
-        propertyObjectId: string
-        code: string
-        name: string
-        parkingNumber: string
+        propertyObjectId: string;
+        code: string;
+        name: string;
+        parkingNumber: string;
         parkingSpaceType: {
-          code: string
-          name: string
-        }
-      }
+          code: string;
+          name: string;
+        };
+      };
       address: {
-        streetAddress: string | null
-        streetAddress2: string | null
-        postalCode: string | null
-        city: string | null
-      }
-    }
+        streetAddress: string | null;
+        streetAddress2: string | null;
+        postalCode: string | null;
+        city: string | null;
+      };
+    };
     MaintenanceUnit: {
-      id: string
-      propertyObjectId: string
-      rentalPropertyId?: string
-      code: string
-      caption: string | null
-      type?: string | null
-      estateCode: string | null
-      estate: string | null
-    }
+      id: string;
+      propertyObjectId: string;
+      rentalPropertyId?: string;
+      code: string;
+      caption: string | null;
+      type?: string | null;
+      estateCode: string | null;
+      estate: string | null;
+    };
     FacilityDetails: {
-      id: string
-      propertyObjectId: string
-      code: string
-      name: string | null
-      entrance: string | null
-      deleted: boolean
+      id: string;
+      propertyObjectId: string;
+      code: string;
+      name: string | null;
+      entrance: string | null;
+      deleted: boolean;
       type: {
-        code: string
-        name: string | null
-      }
-      rentalInformation: {
-        apartmentNumber: string | null
-        rentalId: string | null
+        code: string;
+        name: string | null;
+      };
+      rentalInformation: ({
+        apartmentNumber: string | null;
+        rentalId: string | null;
         type: {
-          code: string
-          name: string | null
-        }
-      } | null
+          code: string;
+          name: string | null;
+        };
+      }) | null;
       property: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
       building: {
-        id: string | null
-        name: string | null
-        code: string | null
-      }
-      areaSize: number | null
-    }
+        id: string | null;
+        name: string | null;
+        code: string | null;
+      };
+      areaSize: number | null;
+    };
     RentalBlock: {
-      id: string
-      blockReasonId: string
-      blockReason: string
+      id: string;
+      blockReasonId: string;
+      blockReason: string;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string | null
-      amount: number | null
-    }
+      toDate: string | null;
+      amount: number | null;
+    };
     RentalBlockWithRentalObject: {
-      id: string
-      blockReasonId: string | null
-      blockReason: string | null
+      id: string;
+      blockReasonId: string | null;
+      blockReason: string | null;
       /** Format: date-time */
-      fromDate: string
+      fromDate: string;
       /** Format: date-time */
-      toDate: string | null
-      amount: number | null
-      distrikt: string | null
+      toDate: string | null;
+      amount: number | null;
+      distrikt: string | null;
       rentalObject: {
-        code: string | null
-        name: string | null
+        code: string | null;
+        name: string | null;
         /** @enum {string} */
-        category: 'Bostad' | 'Bilplats' | 'Lokal' | 'Förråd' | 'Övrigt'
-        address: string | null
-        rentalId: string | null
-        residenceId: string | null
-        yearlyRent: number
-        type: string | null
-      }
+        category: "Bostad" | "Bilplats" | "Lokal" | "Förråd" | "Övrigt";
+        address: string | null;
+        rentalId: string | null;
+        residenceId: string | null;
+        yearlyRent: number;
+        type: string | null;
+      };
       building: {
-        code: string | null
-        name: string | null
-      }
+        code: string | null;
+        name: string | null;
+      };
       property: {
-        code: string | null
-        name: string | null
-      }
-    }
+        code: string | null;
+        name: string | null;
+      };
+    };
     FacilitySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a facility result
        * @enum {string}
        */
-      type: 'facility'
+      type: "facility";
       /** @description Name of the facility */
-      name: string | null
+      name: string | null;
       /** @description Rental ID of the facility */
-      rentalId: string
+      rentalId: string;
       /** @description Code of the facility */
-      code: string
+      code: string;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the facility */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the facility */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     ResidenceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a residence result
        * @enum {string}
        */
-      type: 'residence'
+      type: "residence";
       /** @description Name of the residence */
-      name: string | null
+      name: string | null;
       /** @description Rental object ID of the residence */
-      rentalId: string | null
+      rentalId: string | null;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the residence */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the residence */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     ParkingSpaceSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a parking space result
        * @enum {string}
        */
-      type: 'parking-space'
+      type: "parking-space";
       /** @description Name of the parking space */
-      name: string | null
+      name: string | null;
       /** @description Rental ID of the parking space */
-      rentalId: string
+      rentalId: string;
       /** @description Code of the parking space */
-      code: string
+      code: string;
       property: {
-        code: string | null
+        code: string | null;
         /** @description Name of property associated with the parking space */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string | null
+        code: string | null;
         /** @description Name of building associated with the parking space */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     Component: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      modelId: string
-      serialNumber: string | null
-      specifications?: string | null
-      additionalInformation?: string | null
-      warrantyStartDate: string | null
-      warrantyMonths: number
-      priceAtPurchase: number
-      depreciationPriceAtPurchase: number
-      ncsCode?: string | null
+      modelId: string;
+      serialNumber: string | null;
+      specifications?: string | null;
+      additionalInformation?: string | null;
+      warrantyStartDate: string | null;
+      warrantyMonths: number;
+      priceAtPurchase: number;
+      depreciationPriceAtPurchase: number;
+      ncsCode?: string | null;
       /** @enum {string} */
-      status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-      lastInspectionDate?: string | null
-      quantity: number
-      economicLifespan: number
-      createdAt: string
-      updatedAt: string
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      lastInspectionDate?: string | null;
+      quantity: number;
+      economicLifespan: number;
+      createdAt: string;
+      updatedAt: string;
       model?: {
         /** Format: uuid */
-        id: string
-        modelName: string
+        id: string;
+        modelName: string;
         /** Format: uuid */
-        componentSubtypeId: string
-        currentPrice: number
-        currentInstallPrice: number
-        warrantyMonths: number
-        manufacturer: string
-        technicalSpecification: string | null
-        installationInstructions: string | null
-        dimensions: string | null
-        coclassCode: string | null
-        createdAt: string
-        updatedAt: string
+        componentSubtypeId: string;
+        currentPrice: number;
+        currentInstallPrice: number;
+        warrantyMonths: number;
+        manufacturer: string;
+        technicalSpecification: string | null;
+        installationInstructions: string | null;
+        dimensions: string | null;
+        coclassCode: string | null;
+        createdAt: string;
+        updatedAt: string;
         subtype?: {
           /** Format: uuid */
-          id: string
-          subTypeName: string
+          id: string;
+          subTypeName: string;
           /** Format: uuid */
-          typeId: string
-          xpandCode: string | null
-          depreciationPrice: number
-          technicalLifespan: number
-          economicLifespan: number
-          replacementIntervalMonths: number
+          typeId: string;
+          xpandCode: string | null;
+          depreciationPrice: number;
+          technicalLifespan: number;
+          economicLifespan: number;
+          replacementIntervalMonths: number;
           /** @enum {string} */
-          quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-          createdAt: string
-          updatedAt: string
+          quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+          createdAt: string;
+          updatedAt: string;
           componentType?: {
             /** Format: uuid */
-            id: string
-            typeName: string
+            id: string;
+            typeName: string;
             /** Format: uuid */
-            categoryId: string
-            description: string | null
-            createdAt: string
-            updatedAt: string
+            categoryId: string;
+            description: string | null;
+            createdAt: string;
+            updatedAt: string;
             category?: {
               /** Format: uuid */
-              id: string
-              categoryName: string
-              description: string
-              createdAt: string
-              updatedAt: string
-            }
-          }
-        }
-      }
-      componentInstallations?: {
-        /** Format: uuid */
-        id: string
-        /** Format: uuid */
-        componentId: string
-        spaceId: string | null
-        /** @enum {string} */
-        spaceType: 'OBJECT' | 'PropertyObject'
-        installationDate: string | null
-        deinstallationDate: string | null
-        orderNumber?: string | null
-        cost: number
-        createdAt: string
-        updatedAt: string
-        propertyObject?: {
-          id: string
-          propertyStructures?: {
-            roomId?: string | null
-            roomCode?: string | null
-            roomName?: string | null
-            residenceId?: string | null
-            residenceCode?: string | null
-            residenceName?: string | null
-            rentalId?: string | null
-            buildingCode?: string | null
-            buildingName?: string | null
-            residence?: {
-              id: string
-            } | null
-          }[]
-        } | null
-      }[]
-    }
+              id: string;
+              categoryName: string;
+              description: string;
+              createdAt: string;
+              updatedAt: string;
+            };
+          };
+        };
+      };
+      componentInstallations?: ({
+          /** Format: uuid */
+          id: string;
+          /** Format: uuid */
+          componentId: string;
+          spaceId: string | null;
+          /** @enum {string} */
+          spaceType: "OBJECT" | "PropertyObject";
+          installationDate: string | null;
+          deinstallationDate: string | null;
+          orderNumber?: string | null;
+          cost: number;
+          createdAt: string;
+          updatedAt: string;
+          propertyObject?: ({
+            id: string;
+            propertyStructures?: ({
+                roomId?: string | null;
+                roomCode?: string | null;
+                roomName?: string | null;
+                residenceId?: string | null;
+                residenceCode?: string | null;
+                residenceName?: string | null;
+                rentalId?: string | null;
+                buildingCode?: string | null;
+                buildingName?: string | null;
+                residence?: {
+                  id: string;
+                } | null;
+              })[];
+          }) | null;
+        })[];
+    };
     ComponentCategory: {
       /** Format: uuid */
-      id: string
-      categoryName: string
-      description: string
-      createdAt: string
-      updatedAt: string
-    }
+      id: string;
+      categoryName: string;
+      description: string;
+      createdAt: string;
+      updatedAt: string;
+    };
     ComponentType: {
       /** Format: uuid */
-      id: string
-      typeName: string
+      id: string;
+      typeName: string;
       /** Format: uuid */
-      categoryId: string
-      description: string | null
-      createdAt: string
-      updatedAt: string
+      categoryId: string;
+      description: string | null;
+      createdAt: string;
+      updatedAt: string;
       category?: {
         /** Format: uuid */
-        id: string
-        categoryName: string
-        description: string
-        createdAt: string
-        updatedAt: string
-      }
-    }
+        id: string;
+        categoryName: string;
+        description: string;
+        createdAt: string;
+        updatedAt: string;
+      };
+    };
     ComponentSubtype: {
       /** Format: uuid */
-      id: string
-      subTypeName: string
+      id: string;
+      subTypeName: string;
       /** Format: uuid */
-      typeId: string
-      xpandCode: string | null
-      depreciationPrice: number
-      technicalLifespan: number
-      economicLifespan: number
-      replacementIntervalMonths: number
+      typeId: string;
+      xpandCode: string | null;
+      depreciationPrice: number;
+      technicalLifespan: number;
+      economicLifespan: number;
+      replacementIntervalMonths: number;
       /** @enum {string} */
-      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-      createdAt: string
-      updatedAt: string
+      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+      createdAt: string;
+      updatedAt: string;
       componentType?: {
         /** Format: uuid */
-        id: string
-        typeName: string
+        id: string;
+        typeName: string;
         /** Format: uuid */
-        categoryId: string
-        description: string | null
-        createdAt: string
-        updatedAt: string
+        categoryId: string;
+        description: string | null;
+        createdAt: string;
+        updatedAt: string;
         category?: {
           /** Format: uuid */
-          id: string
-          categoryName: string
-          description: string
-          createdAt: string
-          updatedAt: string
-        }
-      }
-    }
+          id: string;
+          categoryName: string;
+          description: string;
+          createdAt: string;
+          updatedAt: string;
+        };
+      };
+    };
     ComponentModel: {
       /** Format: uuid */
-      id: string
-      modelName: string
+      id: string;
+      modelName: string;
       /** Format: uuid */
-      componentSubtypeId: string
-      currentPrice: number
-      currentInstallPrice: number
-      warrantyMonths: number
-      manufacturer: string
-      technicalSpecification: string | null
-      installationInstructions: string | null
-      dimensions: string | null
-      coclassCode: string | null
-      createdAt: string
-      updatedAt: string
+      componentSubtypeId: string;
+      currentPrice: number;
+      currentInstallPrice: number;
+      warrantyMonths: number;
+      manufacturer: string;
+      technicalSpecification: string | null;
+      installationInstructions: string | null;
+      dimensions: string | null;
+      coclassCode: string | null;
+      createdAt: string;
+      updatedAt: string;
       subtype?: {
         /** Format: uuid */
-        id: string
-        subTypeName: string
+        id: string;
+        subTypeName: string;
         /** Format: uuid */
-        typeId: string
-        xpandCode: string | null
-        depreciationPrice: number
-        technicalLifespan: number
-        economicLifespan: number
-        replacementIntervalMonths: number
+        typeId: string;
+        xpandCode: string | null;
+        depreciationPrice: number;
+        technicalLifespan: number;
+        economicLifespan: number;
+        replacementIntervalMonths: number;
         /** @enum {string} */
-        quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-        createdAt: string
-        updatedAt: string
+        quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+        createdAt: string;
+        updatedAt: string;
         componentType?: {
           /** Format: uuid */
-          id: string
-          typeName: string
+          id: string;
+          typeName: string;
           /** Format: uuid */
-          categoryId: string
-          description: string | null
-          createdAt: string
-          updatedAt: string
+          categoryId: string;
+          description: string | null;
+          createdAt: string;
+          updatedAt: string;
           category?: {
             /** Format: uuid */
-            id: string
-            categoryName: string
-            description: string
-            createdAt: string
-            updatedAt: string
-          }
-        }
-      }
-    }
+            id: string;
+            categoryName: string;
+            description: string;
+            createdAt: string;
+            updatedAt: string;
+          };
+        };
+      };
+    };
     ComponentInstallation: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      componentId: string
-      spaceId: string | null
+      componentId: string;
+      spaceId: string | null;
       /** @enum {string} */
-      spaceType: 'OBJECT' | 'PropertyObject'
-      installationDate: string | null
-      deinstallationDate: string | null
-      orderNumber?: string | null
-      cost: number
-      createdAt: string
-      updatedAt: string
+      spaceType: "OBJECT" | "PropertyObject";
+      installationDate: string | null;
+      deinstallationDate: string | null;
+      orderNumber?: string | null;
+      cost: number;
+      createdAt: string;
+      updatedAt: string;
       component?: {
         /** Format: uuid */
-        id: string
+        id: string;
         /** Format: uuid */
-        modelId: string
-        serialNumber: string | null
-        specifications?: string | null
-        additionalInformation?: string | null
-        warrantyStartDate: string | null
-        warrantyMonths: number
-        priceAtPurchase: number
-        depreciationPriceAtPurchase: number
-        ncsCode?: string | null
+        modelId: string;
+        serialNumber: string | null;
+        specifications?: string | null;
+        additionalInformation?: string | null;
+        warrantyStartDate: string | null;
+        warrantyMonths: number;
+        priceAtPurchase: number;
+        depreciationPriceAtPurchase: number;
+        ncsCode?: string | null;
         /** @enum {string} */
-        status: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+        status: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
         /** @enum {string|null} */
-        condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-        lastInspectionDate?: string | null
-        quantity: number
-        economicLifespan: number
-        createdAt: string
-        updatedAt: string
+        condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+        lastInspectionDate?: string | null;
+        quantity: number;
+        economicLifespan: number;
+        createdAt: string;
+        updatedAt: string;
         model?: {
           /** Format: uuid */
-          id: string
-          modelName: string
+          id: string;
+          modelName: string;
           /** Format: uuid */
-          componentSubtypeId: string
-          currentPrice: number
-          currentInstallPrice: number
-          warrantyMonths: number
-          manufacturer: string
-          technicalSpecification: string | null
-          installationInstructions: string | null
-          dimensions: string | null
-          coclassCode: string | null
-          createdAt: string
-          updatedAt: string
+          componentSubtypeId: string;
+          currentPrice: number;
+          currentInstallPrice: number;
+          warrantyMonths: number;
+          manufacturer: string;
+          technicalSpecification: string | null;
+          installationInstructions: string | null;
+          dimensions: string | null;
+          coclassCode: string | null;
+          createdAt: string;
+          updatedAt: string;
           subtype?: {
             /** Format: uuid */
-            id: string
-            subTypeName: string
+            id: string;
+            subTypeName: string;
             /** Format: uuid */
-            typeId: string
-            xpandCode: string | null
-            depreciationPrice: number
-            technicalLifespan: number
-            economicLifespan: number
-            replacementIntervalMonths: number
+            typeId: string;
+            xpandCode: string | null;
+            depreciationPrice: number;
+            technicalLifespan: number;
+            economicLifespan: number;
+            replacementIntervalMonths: number;
             /** @enum {string} */
-            quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-            createdAt: string
-            updatedAt: string
+            quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+            createdAt: string;
+            updatedAt: string;
             componentType?: {
               /** Format: uuid */
-              id: string
-              typeName: string
+              id: string;
+              typeName: string;
               /** Format: uuid */
-              categoryId: string
-              description: string | null
-              createdAt: string
-              updatedAt: string
+              categoryId: string;
+              description: string | null;
+              createdAt: string;
+              updatedAt: string;
               category?: {
                 /** Format: uuid */
-                id: string
-                categoryName: string
-                description: string
-                createdAt: string
-                updatedAt: string
-              }
-            }
-          }
-        }
-        componentInstallations?: {
-          /** Format: uuid */
-          id: string
-          /** Format: uuid */
-          componentId: string
-          spaceId: string | null
-          spaceType: components['schemas']['ComponentInstallation']['spaceType']
-          installationDate: string | null
-          deinstallationDate: string | null
-          orderNumber?: string | null
-          cost: number
-          createdAt: string
-          updatedAt: string
-          propertyObject?: {
-            id: string
-            propertyStructures?: {
-              roomId?: string | null
-              roomCode?: string | null
-              roomName?: string | null
-              residenceId?: string | null
-              residenceCode?: string | null
-              residenceName?: string | null
-              rentalId?: string | null
-              buildingCode?: string | null
-              buildingName?: string | null
-              residence?: {
-                id: string
-              } | null
-            }[]
-          } | null
-        }[]
-      }
-    }
+                id: string;
+                categoryName: string;
+                description: string;
+                createdAt: string;
+                updatedAt: string;
+              };
+            };
+          };
+        };
+        componentInstallations?: ({
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            componentId: string;
+            spaceId: string | null;
+            spaceType: components["schemas"]["ComponentInstallation"]["spaceType"];
+            installationDate: string | null;
+            deinstallationDate: string | null;
+            orderNumber?: string | null;
+            cost: number;
+            createdAt: string;
+            updatedAt: string;
+            propertyObject?: ({
+              id: string;
+              propertyStructures?: ({
+                  roomId?: string | null;
+                  roomCode?: string | null;
+                  roomName?: string | null;
+                  residenceId?: string | null;
+                  residenceCode?: string | null;
+                  residenceName?: string | null;
+                  rentalId?: string | null;
+                  buildingCode?: string | null;
+                  buildingName?: string | null;
+                  residence?: {
+                    id: string;
+                  } | null;
+                })[];
+            }) | null;
+          })[];
+      };
+    };
     CreateComponentCategoryRequest: {
-      categoryName: string
-      description: string
-    }
+      categoryName: string;
+      description: string;
+    };
     UpdateComponentCategoryRequest: {
-      categoryName?: string
-      description?: string
-    }
+      categoryName?: string;
+      description?: string;
+    };
     CreateComponentTypeRequest: {
-      typeName: string
+      typeName: string;
       /** Format: uuid */
-      categoryId: string
-      description?: string
-    }
+      categoryId: string;
+      description?: string;
+    };
     UpdateComponentTypeRequest: {
-      typeName?: string
+      typeName?: string;
       /** Format: uuid */
-      categoryId?: string
-      description?: string
-    }
+      categoryId?: string;
+      description?: string;
+    };
     CreateComponentSubtypeRequest: {
-      subTypeName: string
+      subTypeName: string;
       /** Format: uuid */
-      typeId: string
-      xpandCode?: string
+      typeId: string;
+      xpandCode?: string;
       /** @default 0 */
-      depreciationPrice?: number
+      depreciationPrice?: number;
       /** @default 0 */
-      technicalLifespan?: number
+      technicalLifespan?: number;
       /** @default 0 */
-      economicLifespan?: number
+      economicLifespan?: number;
       /** @default 0 */
-      replacementIntervalMonths?: number
+      replacementIntervalMonths?: number;
       /** @enum {string} */
-      quantityType: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-    }
+      quantityType: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+    };
     UpdateComponentSubtypeRequest: {
-      subTypeName?: string
+      subTypeName?: string;
       /** Format: uuid */
-      typeId?: string
-      xpandCode?: string
-      depreciationPrice?: number
-      technicalLifespan?: number
-      economicLifespan?: number
-      replacementIntervalMonths?: number
+      typeId?: string;
+      xpandCode?: string;
+      depreciationPrice?: number;
+      technicalLifespan?: number;
+      economicLifespan?: number;
+      replacementIntervalMonths?: number;
       /** @enum {string} */
-      quantityType?: 'UNIT' | 'METER' | 'SQUARE_METER' | 'CUBIC_METER'
-    }
+      quantityType?: "UNIT" | "METER" | "SQUARE_METER" | "CUBIC_METER";
+    };
     CreateComponentModelRequest: {
-      modelName: string
+      modelName: string;
       /** Format: uuid */
-      componentSubtypeId: string
+      componentSubtypeId: string;
       /** @default 0 */
-      currentPrice?: number
+      currentPrice?: number;
       /** @default 0 */
-      currentInstallPrice?: number
+      currentInstallPrice?: number;
       /** @default 0 */
-      warrantyMonths?: number
+      warrantyMonths?: number;
       /** @default */
-      manufacturer?: string
-      technicalSpecification?: string
-      installationInstructions?: string
-      dimensions?: string
-      coclassCode?: string
-    }
+      manufacturer?: string;
+      technicalSpecification?: string;
+      installationInstructions?: string;
+      dimensions?: string;
+      coclassCode?: string;
+    };
     UpdateComponentModelRequest: {
-      modelName?: string
+      modelName?: string;
       /** Format: uuid */
-      componentSubtypeId?: string
-      currentPrice?: number
-      currentInstallPrice?: number
-      warrantyMonths?: number
-      manufacturer?: string
-      technicalSpecification?: string
-      installationInstructions?: string
-      dimensions?: string
-      coclassCode?: string
-    }
+      componentSubtypeId?: string;
+      currentPrice?: number;
+      currentInstallPrice?: number;
+      warrantyMonths?: number;
+      manufacturer?: string;
+      technicalSpecification?: string;
+      installationInstructions?: string;
+      dimensions?: string;
+      coclassCode?: string;
+    };
     CreateComponentRequest: {
       /** Format: uuid */
-      modelId: string
-      serialNumber?: string | null
-      specifications?: string
-      additionalInformation?: string
+      modelId: string;
+      serialNumber?: string | null;
+      specifications?: string;
+      additionalInformation?: string;
       /** Format: date-time */
-      warrantyStartDate?: string
+      warrantyStartDate?: string;
       /** @default 0 */
-      warrantyMonths?: number
+      warrantyMonths?: number;
       /** @default 0 */
-      priceAtPurchase?: number
+      priceAtPurchase?: number;
       /** @default 0 */
-      depreciationPriceAtPurchase?: number
-      ncsCode?: string
+      depreciationPriceAtPurchase?: number;
+      ncsCode?: string;
       /**
        * @default ACTIVE
        * @enum {string}
        */
-      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
       /** @default 1 */
-      quantity?: number
+      quantity?: number;
       /** @default 0 */
-      economicLifespan?: number
-      files?: string
-    }
+      economicLifespan?: number;
+      files?: string;
+    };
     UpdateComponentRequest: {
       /** Format: uuid */
-      modelId?: string
-      serialNumber?: string | null
-      specifications?: string
-      additionalInformation?: string
+      modelId?: string;
+      serialNumber?: string | null;
+      specifications?: string;
+      additionalInformation?: string;
       /** Format: date-time */
-      warrantyStartDate?: string
-      warrantyMonths?: number
-      priceAtPurchase?: number
-      depreciationPriceAtPurchase?: number
-      ncsCode?: string
+      warrantyStartDate?: string;
+      warrantyMonths?: number;
+      priceAtPurchase?: number;
+      depreciationPriceAtPurchase?: number;
+      ncsCode?: string;
       /** @enum {string} */
-      status?: 'ACTIVE' | 'INACTIVE' | 'MAINTENANCE' | 'DECOMMISSIONED'
+      status?: "ACTIVE" | "INACTIVE" | "MAINTENANCE" | "DECOMMISSIONED";
       /** @enum {string|null} */
-      condition?: 'NEW' | 'GOOD' | 'FAIR' | 'POOR' | 'DAMAGED' | null
-      quantity?: number
-      economicLifespan?: number
-      files?: string
-    }
+      condition?: "NEW" | "GOOD" | "FAIR" | "POOR" | "DAMAGED" | null;
+      quantity?: number;
+      economicLifespan?: number;
+      files?: string;
+    };
     CreateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId: string
-      spaceId?: string
+      componentId: string;
+      spaceId?: string;
       /** @enum {string} */
-      spaceType: 'OBJECT' | 'PropertyObject'
+      spaceType: "OBJECT" | "PropertyObject";
       /** Format: date-time */
-      installationDate?: string | null
+      installationDate?: string | null;
       /** Format: date-time */
-      deinstallationDate?: string
-      orderNumber?: string
-      cost: number
-    }
+      deinstallationDate?: string;
+      orderNumber?: string;
+      cost: number;
+    };
     UpdateComponentInstallationRequest: {
       /** Format: uuid */
-      componentId?: string
-      spaceId?: string
+      componentId?: string;
+      spaceId?: string;
       /** @enum {string} */
-      spaceType?: 'OBJECT' | 'PropertyObject'
+      spaceType?: "OBJECT" | "PropertyObject";
       /** Format: date-time */
-      installationDate?: string
+      installationDate?: string;
       /** Format: date-time */
-      deinstallationDate?: string
-      orderNumber?: string
-      cost?: number
-    }
+      deinstallationDate?: string;
+      orderNumber?: string;
+      cost?: number;
+    };
     DocumentWithUrl: {
-      id: string
-      fileId: string
-      originalName: string
-      mimeType: string
-      size: number
-      createdAt: string
-      url: string
-      uploadedAt?: string
-      caption?: string
-    }
+      id: string;
+      fileId: string;
+      originalName: string;
+      mimeType: string;
+      size: number;
+      createdAt: string;
+      url: string;
+      uploadedAt?: string;
+      caption?: string;
+    };
     AnalyzeComponentImageRequest: {
-      image: string
-      additionalImage?: string
-    }
+      image: string;
+      additionalImage?: string;
+    };
     AIComponentAnalysis: {
-      componentType: string | null
-      componentSubtype: string | null
-      manufacturer: string | null
-      model: string | null
-      serialNumber: string | null
-      estimatedAge: string | null
-      condition: string | null
-      specifications: string | null
-      dimensions: string | null
-      warrantyMonths: number | null
-      ncsCode: string | null
-      additionalInformation: string | null
-      confidence: number
-    }
+      componentType: string | null;
+      componentSubtype: string | null;
+      manufacturer: string | null;
+      model: string | null;
+      serialNumber: string | null;
+      estimatedAge: string | null;
+      condition: string | null;
+      specifications: string | null;
+      dimensions: string | null;
+      warrantyMonths: number | null;
+      ncsCode: string | null;
+      additionalInformation: string | null;
+      confidence: number;
+    };
     ApartmentTemperaturePoint: {
-      time: number
-      avg: number | null
-      min: number | null
-      max: number | null
-    }
+      time: number;
+      avg: number | null;
+      min: number | null;
+      max: number | null;
+    };
     ApartmentTemperatureSeries: {
-      subNodeId: number
-      subNodeName: string
-      points: {
-        time: number
-        avg: number | null
-        min: number | null
-        max: number | null
-      }[]
-    }
+      subNodeId: number;
+      subNodeName: string;
+      points: ({
+          time: number;
+          avg: number | null;
+          min: number | null;
+          max: number | null;
+        })[];
+    };
     ApartmentTemperaturesResponse: {
-      objectNumber: string
-      nodeId: number
-      from: number
-      to: number
+      objectNumber: string;
+      nodeId: number;
+      from: number;
+      to: number;
       /** @enum {string} */
-      interval: 'H' | 'D'
-      unit: string
-      series: {
-        subNodeId: number
-        subNodeName: string
-        points: {
-          time: number
-          avg: number | null
-          min: number | null
-          max: number | null
-        }[]
-      }[]
-    }
+      interval: "H" | "D";
+      unit: string;
+      series: ({
+          subNodeId: number;
+          subNodeName: string;
+          points: ({
+              time: number;
+              avg: number | null;
+              min: number | null;
+              max: number | null;
+            })[];
+        })[];
+    };
     Key: {
       /** Format: uuid */
-      id: string
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      id: string;
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
+      keySystemId?: string | null;
       /** @default false */
-      disposed?: boolean
-      notes?: string | null
+      disposed?: boolean;
+      notes?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     KeySystem: {
       /** Format: uuid */
-      id: string
-      systemCode: string
-      name: string
-      manufacturer: string
-      managingSupplier?: string | null
+      id: string;
+      systemCode: string;
+      name: string;
+      manufacturer: string;
+      managingSupplier?: string | null;
       /** @enum {string} */
-      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-      schemaFileId?: string | null
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+      schemaFileId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-    }
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+    };
     KeyLoan: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-      keyCount?: number
-      cardCount?: number
-    }
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+      keyCount?: number;
+      cardCount?: number;
+    };
     KeyDetails: {
       /** Format: uuid */
-      id: string
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      id: string;
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
+      keySystemId?: string | null;
       /** @default false */
-      disposed?: boolean
-      notes?: string | null
+      disposed?: boolean;
+      notes?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      keySystem?: components['schemas']['KeySystem'] | null
-      loans?: components['schemas']['KeyLoan'][] | null
-      events?:
-        | {
-            /** Format: uuid */
-            id: string
-            /** @enum {string} */
-            type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
-            /** @enum {string} */
-            status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
-            /** Format: uuid */
-            workOrderId?: string | null
-            /** Format: date-time */
-            createdAt: string
-            /** Format: date-time */
-            updatedAt: string
-          }[]
-        | null
-      activeLoanContact?: string | null
-    }
+      updatedAt: string;
+      keySystem?: components["schemas"]["KeySystem"] | null;
+      loans?: components["schemas"]["KeyLoan"][] | null;
+      events?: (({
+          /** Format: uuid */
+          id: string;
+          /** @enum {string} */
+          type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
+          /** @enum {string} */
+          status: "ORDERED" | "RECEIVED" | "COMPLETED";
+          /** Format: uuid */
+          workOrderId?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+        })[]) | null;
+      activeLoanContact?: string | null;
+    };
     KeyLoanWithDetails: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-      createdBy?: string | null
-      updatedBy?: string | null
-      keyCount?: number
-      cardCount?: number
-      keysArray: {
-        /** Format: uuid */
-        id: string
-        keyName: string
-        keySequenceNumber?: number | null
-        flexNumber?: number | null
-        rentalObjectCode?: string | null
-        /** @enum {string} */
-        keyType:
-          | 'HN'
-          | 'FS'
-          | 'MV'
-          | 'LGH'
-          | 'PB'
-          | 'GAR'
-          | 'LOK'
-          | 'HL'
-          | 'FÖR'
-          | 'SOP'
-          | 'ÖVR'
-        /** Format: uuid */
-        keySystemId?: string | null
-        /** @default false */
-        disposed?: boolean
-        notes?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-        keySystem?: {
+      updatedAt: string;
+      createdBy?: string | null;
+      updatedBy?: string | null;
+      keyCount?: number;
+      cardCount?: number;
+      keysArray: ({
           /** Format: uuid */
-          id: string
-          systemCode: string
-          name: string
-          manufacturer: string
-          managingSupplier?: string | null
+          id: string;
+          keyName: string;
+          keySequenceNumber?: number | null;
+          flexNumber?: number | null;
+          rentalObjectCode?: string | null;
           /** @enum {string} */
-          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-          propertyIds?: string
+          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+          /** Format: uuid */
+          keySystemId?: string | null;
+          /** @default false */
+          disposed?: boolean;
+          notes?: string | null;
           /** Format: date-time */
-          installationDate?: string | null
-          isActive?: boolean
-          notes?: string | null
-          schemaFileId?: string | null
+          createdAt: string;
           /** Format: date-time */
-          createdAt: string
-          /** Format: date-time */
-          updatedAt: string
-          createdBy?: string | null
-          updatedBy?: string | null
-        } | null
-        loans?:
-          | {
-              id: components['schemas']['KeyLoanWithDetails']['id']
-              loanType: components['schemas']['KeyLoanWithDetails']['loanType']
-              contact?: components['schemas']['KeyLoanWithDetails']['contact']
-              contact2?: components['schemas']['KeyLoanWithDetails']['contact2']
-              contactPerson?: components['schemas']['KeyLoanWithDetails']['contactPerson']
-              notes?: components['schemas']['KeyLoanWithDetails']['notes']
-              returnedAt?: components['schemas']['KeyLoanWithDetails']['returnedAt']
-              availableToNextTenantFrom?: components['schemas']['KeyLoanWithDetails']['availableToNextTenantFrom']
-              pickedUpAt?: components['schemas']['KeyLoanWithDetails']['pickedUpAt']
-              createdAt: components['schemas']['KeyLoanWithDetails']['createdAt']
-              updatedAt: components['schemas']['KeyLoanWithDetails']['updatedAt']
-              createdBy?: components['schemas']['KeyLoanWithDetails']['createdBy']
-              updatedBy?: components['schemas']['KeyLoanWithDetails']['updatedBy']
-              keyCount?: components['schemas']['KeyLoanWithDetails']['keyCount']
-              cardCount?: components['schemas']['KeyLoanWithDetails']['cardCount']
-            }[]
-          | null
-        events?:
-          | {
+          updatedAt: string;
+          keySystem?: ({
+            /** Format: uuid */
+            id: string;
+            systemCode: string;
+            name: string;
+            manufacturer: string;
+            managingSupplier?: string | null;
+            /** @enum {string} */
+            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+            propertyIds?: string;
+            /** Format: date-time */
+            installationDate?: string | null;
+            isActive?: boolean;
+            notes?: string | null;
+            schemaFileId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            createdBy?: string | null;
+            updatedBy?: string | null;
+          }) | null;
+          loans?: {
+              id: components["schemas"]["KeyLoanWithDetails"]["id"];
+              loanType: components["schemas"]["KeyLoanWithDetails"]["loanType"];
+              contact?: components["schemas"]["KeyLoanWithDetails"]["contact"];
+              contact2?: components["schemas"]["KeyLoanWithDetails"]["contact2"];
+              contactPerson?: components["schemas"]["KeyLoanWithDetails"]["contactPerson"];
+              notes?: components["schemas"]["KeyLoanWithDetails"]["notes"];
+              returnedAt?: components["schemas"]["KeyLoanWithDetails"]["returnedAt"];
+              availableToNextTenantFrom?: components["schemas"]["KeyLoanWithDetails"]["availableToNextTenantFrom"];
+              pickedUpAt?: components["schemas"]["KeyLoanWithDetails"]["pickedUpAt"];
+              createdAt: components["schemas"]["KeyLoanWithDetails"]["createdAt"];
+              updatedAt: components["schemas"]["KeyLoanWithDetails"]["updatedAt"];
+              createdBy?: components["schemas"]["KeyLoanWithDetails"]["createdBy"];
+              updatedBy?: components["schemas"]["KeyLoanWithDetails"]["updatedBy"];
+              keyCount?: components["schemas"]["KeyLoanWithDetails"]["keyCount"];
+              cardCount?: components["schemas"]["KeyLoanWithDetails"]["cardCount"];
+            }[] | null;
+          events?: (({
               /** Format: uuid */
-              id: string
+              id: string;
               /** @enum {string} */
-              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
               /** @enum {string} */
-              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+              status: "ORDERED" | "RECEIVED" | "COMPLETED";
               /** Format: uuid */
-              workOrderId?: string | null
+              workOrderId?: string | null;
               /** Format: date-time */
-              createdAt: string
+              createdAt: string;
               /** Format: date-time */
-              updatedAt: string
-            }[]
-          | null
-        activeLoanContact?: string | null
-      }[]
-      keyCardsArray: {
-        cardId: string
-        name?: string | null
-        owner?: unknown
-        appearanceCode?: string | null
-        classification?: string | null
-        disabled?: boolean
-        startTime?: string | null
-        stopTime?: string | null
-        createTime: string
-        pinCode?: string | null
-        state?: string | null
-        archivedAt?: string | null
-        codes?: unknown[] | null
-      }[]
-      receipts: {
-        /** Format: uuid */
-        id: string
-        /** Format: uuid */
-        keyLoanId: string
-        /** @enum {string} */
-        receiptType: 'LOAN' | 'RETURN'
-        /** @enum {string} */
-        type: 'DIGITAL' | 'PHYSICAL'
-        fileId?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-      }[]
-    }
+              updatedAt: string;
+            })[]) | null;
+          activeLoanContact?: string | null;
+        })[];
+      keyCardsArray: ({
+          cardId: string;
+          name?: string | null;
+          owner?: unknown;
+          appearanceCode?: string | null;
+          classification?: string | null;
+          disabled?: boolean;
+          startTime?: string | null;
+          stopTime?: string | null;
+          createTime: string;
+          pinCode?: string | null;
+          state?: string | null;
+          archivedAt?: string | null;
+          codes?: unknown[] | null;
+        })[];
+      receipts: ({
+          /** Format: uuid */
+          id: string;
+          /** Format: uuid */
+          keyLoanId: string;
+          /** @enum {string} */
+          receiptType: "LOAN" | "RETURN";
+          /** @enum {string} */
+          type: "DIGITAL" | "PHYSICAL";
+          fileId?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+        })[];
+    };
     Log: {
       /** Format: uuid */
-      id: string
-      userName: string
+      id: string;
+      userName: string;
       /** @enum {string} */
-      eventType: 'creation' | 'update' | 'delete'
+      eventType: "creation" | "update" | "delete";
       /** @enum {string} */
-      objectType:
-        | 'key'
-        | 'keySystem'
-        | 'keyLoan'
-        | 'keyBundle'
-        | 'receipt'
-        | 'keyEvent'
-        | 'signature'
-        | 'keyNote'
+      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
       /** Format: uuid */
-      objectId?: string | null
+      objectId?: string | null;
       /** Format: date-time */
-      eventTime: string
-      description?: string | null
-      eventTypeLabel?: string
-      objectTypeLabel?: string
-    }
+      eventTime: string;
+      description?: string | null;
+      eventTypeLabel?: string;
+      objectTypeLabel?: string;
+    };
     KeyNote: {
       /** Format: uuid */
-      id: string
-      rentalObjectCode: string
-      description: string
-    }
+      id: string;
+      rentalObjectCode: string;
+      description: string;
+    };
     Receipt: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** Format: uuid */
-      keyLoanId: string
+      keyLoanId: string;
       /** @enum {string} */
-      receiptType: 'LOAN' | 'RETURN'
+      receiptType: "LOAN" | "RETURN";
       /** @enum {string} */
-      type: 'DIGITAL' | 'PHYSICAL'
-      fileId?: string | null
+      type: "DIGITAL" | "PHYSICAL";
+      fileId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     KeyEvent: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
+      workOrderId?: string | null;
       /** Format: date-time */
-      createdAt: string
+      createdAt: string;
       /** Format: date-time */
-      updatedAt: string
-    }
+      updatedAt: string;
+    };
     Signature: {
       /** Format: uuid */
-      id: string
+      id: string;
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
-      simpleSignDocumentId: number
+      resourceId: string;
+      simpleSignDocumentId: number;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string | null
-      status: string
+      recipientEmail: string;
+      recipientName?: string | null;
+      status: string;
       /** Format: date-time */
-      sentAt: string
+      sentAt: string;
       /** Format: date-time */
-      completedAt?: string | null
+      completedAt?: string | null;
       /** Format: date-time */
-      lastSyncedAt?: string | null
-    }
+      lastSyncedAt?: string | null;
+    };
     CreateKeyRequest: {
-      keyName: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      keyName: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
-      notes?: string | null
-    }
+      keySystemId?: string | null;
+      notes?: string | null;
+    };
     UpdateKeyRequest: {
-      keyName?: string
-      keySequenceNumber?: number | null
-      flexNumber?: number | null
-      rentalObjectCode?: string | null
+      keyName?: string;
+      keySequenceNumber?: number | null;
+      flexNumber?: number | null;
+      rentalObjectCode?: string | null;
       /** @enum {string} */
-      keyType?:
-        | 'HN'
-        | 'FS'
-        | 'MV'
-        | 'LGH'
-        | 'PB'
-        | 'GAR'
-        | 'LOK'
-        | 'HL'
-        | 'FÖR'
-        | 'SOP'
-        | 'ÖVR'
+      keyType?: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
       /** Format: uuid */
-      keySystemId?: string | null
-      disposed?: boolean
-      notes?: string | null
-    }
+      keySystemId?: string | null;
+      disposed?: boolean;
+      notes?: string | null;
+    };
     BulkUpdateFlexRequest: {
-      rentalObjectCode: string
-      flexNumber: number
-    }
+      rentalObjectCode: string;
+      flexNumber: number;
+    };
     BulkUpdateKeysRequest: {
-      keyIds: string[]
+      keyIds: string[];
       updates: {
-        keyName?: string
-        flexNumber?: number | null
+        keyName?: string;
+        flexNumber?: number | null;
         /** Format: uuid */
-        keySystemId?: string | null
-        rentalObjectCode?: string
-        disposed?: boolean
-        notes?: string | null
-        clearNotes?: boolean
-      }
-    }
+        keySystemId?: string | null;
+        rentalObjectCode?: string;
+        disposed?: boolean;
+        notes?: string | null;
+        clearNotes?: boolean;
+      };
+    };
     CreateKeyLoanRequest: {
-      keys?: string[]
-      keyCards?: string[]
+      keys?: string[];
+      keyCards?: string[];
       /** @enum {string} */
-      loanType: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
+      pickedUpAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
-      createdBy?: string | null
-    }
+      availableToNextTenantFrom?: string | null;
+      createdBy?: string | null;
+    };
     UpdateKeyLoanRequest: {
-      keys?: string[]
-      keyCards?: string[]
+      keys?: string[];
+      keyCards?: string[];
       /** @enum {string} */
-      loanType?: 'TENANT' | 'MAINTENANCE'
-      contact?: string | null
-      contact2?: string | null
-      contactPerson?: string | null
-      notes?: string | null
+      loanType?: "TENANT" | "MAINTENANCE";
+      contact?: string | null;
+      contact2?: string | null;
+      contactPerson?: string | null;
+      notes?: string | null;
       /** Format: date-time */
-      returnedAt?: string | null
+      returnedAt?: string | null;
       /** Format: date-time */
-      availableToNextTenantFrom?: string | null
+      availableToNextTenantFrom?: string | null;
       /** Format: date-time */
-      pickedUpAt?: string | null
-      updatedBy?: string | null
-    }
+      pickedUpAt?: string | null;
+      updatedBy?: string | null;
+    };
     CreateKeySystemRequest: {
-      systemCode: string
-      name: string
-      manufacturer: string
+      systemCode: string;
+      name: string;
+      manufacturer: string;
       /** @enum {string} */
-      type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-    }
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+    };
     UpdateKeySystemRequest: {
-      systemCode?: string
-      name?: string
-      manufacturer?: string
+      systemCode?: string;
+      name?: string;
+      manufacturer?: string;
       /** @enum {string} */
-      type?: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-      propertyIds?: string
+      type?: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+      propertyIds?: string;
       /** Format: date-time */
-      installationDate?: string | null
-      isActive?: boolean
-      notes?: string | null
-      schemaFileId?: string | null
-    }
+      installationDate?: string | null;
+      isActive?: boolean;
+      notes?: string | null;
+      schemaFileId?: string | null;
+    };
     CreateLogRequest: {
-      userName: string
+      userName: string;
       /** @enum {string} */
-      eventType: 'creation' | 'update' | 'delete'
+      eventType: "creation" | "update" | "delete";
       /** @enum {string} */
-      objectType:
-        | 'key'
-        | 'keySystem'
-        | 'keyLoan'
-        | 'keyBundle'
-        | 'receipt'
-        | 'keyEvent'
-        | 'signature'
-        | 'keyNote'
+      objectType: "key" | "keySystem" | "keyLoan" | "keyBundle" | "receipt" | "keyEvent" | "signature" | "keyNote";
       /** Format: uuid */
-      objectId?: string | null
-      description?: string | null
-      autoGenerateDescription?: boolean
-      entityData?: unknown
+      objectId?: string | null;
+      description?: string | null;
+      autoGenerateDescription?: boolean;
+      entityData?: unknown;
       /** @enum {string} */
-      action?: 'Skapad' | 'Uppdaterad' | 'Kasserad' | 'Raderad'
+      action?: "Skapad" | "Uppdaterad" | "Kasserad" | "Raderad";
       /** Format: date-time */
-      eventTime?: string
-    }
+      eventTime?: string;
+    };
     CreateKeyNoteRequest: {
-      rentalObjectCode: string
-      description: string
-    }
+      rentalObjectCode: string;
+      description: string;
+    };
     UpdateKeyNoteRequest: {
-      rentalObjectCode?: string
-      description?: string
-    }
+      rentalObjectCode?: string;
+      description?: string;
+    };
     KeyBundle: {
       /** Format: uuid */
-      id: string
-      name: string
-      description?: string | null
-      keyCount?: number
-    }
+      id: string;
+      name: string;
+      description?: string | null;
+      keyCount?: number;
+    };
     BundleWithLoanedKeysInfo: {
       /** Format: uuid */
-      id: string
-      name: string
-      description: string | null
-      loanedKeyCount: number
-      totalKeyCount: number
-    }
+      id: string;
+      name: string;
+      description: string | null;
+      loanedKeyCount: number;
+      totalKeyCount: number;
+    };
     CreateKeyBundleRequest: {
-      name: string
-      keys: string[]
-      description?: string | null
-    }
+      name: string;
+      keys: string[];
+      description?: string | null;
+    };
     UpdateKeyBundleRequest: {
-      name?: string
-      keys?: string[]
-      description?: string | null
-    }
+      name?: string;
+      keys?: string[];
+      description?: string | null;
+    };
     KeyBundleDetailsResponse: {
       bundle: {
         /** Format: uuid */
-        id: string
-        name: string
-        description?: string | null
-        keyCount?: number
-      }
-      keys: {
-        /** Format: uuid */
-        id: string
-        keyName: string
-        keySequenceNumber?: number | null
-        flexNumber?: number | null
-        rentalObjectCode?: string | null
-        /** @enum {string} */
-        keyType:
-          | 'HN'
-          | 'FS'
-          | 'MV'
-          | 'LGH'
-          | 'PB'
-          | 'GAR'
-          | 'LOK'
-          | 'HL'
-          | 'FÖR'
-          | 'SOP'
-          | 'ÖVR'
-        /** Format: uuid */
-        keySystemId?: string | null
-        /** @default false */
-        disposed?: boolean
-        notes?: string | null
-        /** Format: date-time */
-        createdAt: string
-        /** Format: date-time */
-        updatedAt: string
-        keySystem?: {
+        id: string;
+        name: string;
+        description?: string | null;
+        keyCount?: number;
+      };
+      keys: ({
           /** Format: uuid */
-          id: string
-          systemCode: string
-          name: string
-          manufacturer: string
-          managingSupplier?: string | null
+          id: string;
+          keyName: string;
+          keySequenceNumber?: number | null;
+          flexNumber?: number | null;
+          rentalObjectCode?: string | null;
           /** @enum {string} */
-          type: 'MECHANICAL' | 'ELECTRONIC' | 'HYBRID'
-          propertyIds?: string
+          keyType: "HN" | "FS" | "MV" | "LGH" | "PB" | "GAR" | "LOK" | "HL" | "FÖR" | "SOP" | "ÖVR";
+          /** Format: uuid */
+          keySystemId?: string | null;
+          /** @default false */
+          disposed?: boolean;
+          notes?: string | null;
           /** Format: date-time */
-          installationDate?: string | null
-          isActive?: boolean
-          notes?: string | null
-          schemaFileId?: string | null
+          createdAt: string;
           /** Format: date-time */
-          createdAt: string
-          /** Format: date-time */
-          updatedAt: string
-          createdBy?: string | null
-          updatedBy?: string | null
-        } | null
-        loans?: components['schemas']['KeyLoan'][] | null
-        events?:
-          | {
+          updatedAt: string;
+          keySystem?: ({
+            /** Format: uuid */
+            id: string;
+            systemCode: string;
+            name: string;
+            manufacturer: string;
+            managingSupplier?: string | null;
+            /** @enum {string} */
+            type: "MECHANICAL" | "ELECTRONIC" | "HYBRID";
+            propertyIds?: string;
+            /** Format: date-time */
+            installationDate?: string | null;
+            isActive?: boolean;
+            notes?: string | null;
+            schemaFileId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            createdBy?: string | null;
+            updatedBy?: string | null;
+          }) | null;
+          loans?: components["schemas"]["KeyLoan"][] | null;
+          events?: (({
               /** Format: uuid */
-              id: string
+              id: string;
               /** @enum {string} */
-              type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+              type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
               /** @enum {string} */
-              status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+              status: "ORDERED" | "RECEIVED" | "COMPLETED";
               /** Format: uuid */
-              workOrderId?: string | null
+              workOrderId?: string | null;
               /** Format: date-time */
-              createdAt: string
+              createdAt: string;
               /** Format: date-time */
-              updatedAt: string
-            }[]
-          | null
-        activeLoanContact?: string | null
-      }[]
-    }
+              updatedAt: string;
+            })[]) | null;
+          activeLoanContact?: string | null;
+        })[];
+    };
     CreateKeyEventRequest: {
-      keys: string[]
+      keys: string[];
       /** @enum {string} */
-      type: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
-    }
+      workOrderId?: string | null;
+    };
     UpdateKeyEventRequest: {
-      keys?: string[]
+      keys?: string[];
       /** @enum {string} */
-      type?: 'FLEX' | 'ORDER' | 'LOST' | 'REPLACEMENT'
+      type?: "FLEX" | "ORDER" | "LOST" | "REPLACEMENT";
       /** @enum {string} */
-      status?: 'ORDERED' | 'RECEIVED' | 'COMPLETED'
+      status?: "ORDERED" | "RECEIVED" | "COMPLETED";
       /** Format: uuid */
-      workOrderId?: string | null
-    }
+      workOrderId?: string | null;
+    };
     CreateSignatureRequest: {
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
-      simpleSignDocumentId: number
+      resourceId: string;
+      simpleSignDocumentId: number;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string | null
+      recipientEmail: string;
+      recipientName?: string | null;
       /** @default sent */
-      status?: string
-    }
+      status?: string;
+    };
     UpdateSignatureRequest: {
-      status?: string
+      status?: string;
       /** Format: date-time */
-      completedAt?: string | null
+      completedAt?: string | null;
       /** Format: date-time */
-      lastSyncedAt?: string | null
-    }
+      lastSyncedAt?: string | null;
+    };
     SendSignatureRequest: {
       /** @enum {string} */
-      resourceType: 'receipt'
+      resourceType: "receipt";
       /** Format: uuid */
-      resourceId: string
+      resourceId: string;
       /** Format: email */
-      recipientEmail: string
-      recipientName?: string
-      pdfBase64: string
-    }
+      recipientEmail: string;
+      recipientName?: string;
+      pdfBase64: string;
+    };
     SimpleSignWebhookPayload: {
-      id: number
-      status: string
-      status_updated_at: string
-    }
+      id: number;
+      status: string;
+      status_updated_at: string;
+    };
     CreateReceiptRequest: {
       /** Format: uuid */
-      keyLoanId: string
+      keyLoanId: string;
       /** @enum {string} */
-      receiptType: 'LOAN' | 'RETURN'
+      receiptType: "LOAN" | "RETURN";
       /** @enum {string} */
-      type?: 'DIGITAL' | 'PHYSICAL'
-      fileId?: string
-      fileData?: string
-      fileContentType?: string
-    }
+      type?: "DIGITAL" | "PHYSICAL";
+      fileId?: string;
+      fileData?: string;
+      fileContentType?: string;
+    };
     UpdateReceiptRequest: {
-      fileId?: string
-    }
+      fileId?: string;
+    };
     /** @enum {string} */
-    ReceiptType: 'LOAN' | 'RETURN'
+    ReceiptType: "LOAN" | "RETURN";
     /** @enum {string} */
-    ReceiptFormat: 'DIGITAL' | 'PHYSICAL'
+    ReceiptFormat: "DIGITAL" | "PHYSICAL";
     ErrorResponse: {
       /** @example Internal server error */
-      error?: string
-      reason?: string
-    }
+      error?: string;
+      reason?: string;
+    };
     NotFoundResponse: {
       /** @example Resource not found */
-      reason: string
-    }
+      reason: string;
+    };
     BadRequestResponse: {
-      reason: string
-    }
+      reason: string;
+    };
     SchemaDownloadUrlResponse: {
-      url: string
-      expiresIn: number
-    }
+      url: string;
+      expiresIn: number;
+    };
     CardOwner: {
-      cardOwnerId: string
-      cardOwnerType?: string | null
-      familyName?: string | null
-      specificName?: string | null
-      primaryOrganization?: unknown
-      cards?:
-        | {
-            cardId: string
-            name?: string | null
-            owner?: unknown
-            appearanceCode?: string | null
-            classification?: string | null
-            disabled?: boolean
-            startTime?: string | null
-            stopTime?: string | null
-            createTime: string
-            pinCode?: string | null
-            state?: string | null
-            archivedAt?: string | null
-            codes?: unknown[] | null
-          }[]
-        | null
-      comment?: string | null
-      folderId?: number | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      pinCode?: string | null
+      cardOwnerId: string;
+      cardOwnerType?: string | null;
+      familyName?: string | null;
+      specificName?: string | null;
+      primaryOrganization?: unknown;
+      cards?: (({
+          cardId: string;
+          name?: string | null;
+          owner?: unknown;
+          appearanceCode?: string | null;
+          classification?: string | null;
+          disabled?: boolean;
+          startTime?: string | null;
+          stopTime?: string | null;
+          createTime: string;
+          pinCode?: string | null;
+          state?: string | null;
+          archivedAt?: string | null;
+          codes?: unknown[] | null;
+        })[]) | null;
+      comment?: string | null;
+      folderId?: number | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      pinCode?: string | null;
       attributes?: {
-        [key: string]: string
-      } | null
-      state?: string | null
-      archivedAt?: string | null
-      createTime?: string
-    }
+        [key: string]: string;
+      } | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      createTime?: string;
+    };
     Card: {
-      cardId: string
-      name?: string | null
-      owner?: unknown
-      appearanceCode?: string | null
-      classification?: string | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      createTime: string
-      pinCode?: string | null
-      state?: string | null
-      archivedAt?: string | null
-      codes?: unknown[] | null
-    }
+      cardId: string;
+      name?: string | null;
+      owner?: unknown;
+      appearanceCode?: string | null;
+      classification?: string | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      createTime: string;
+      pinCode?: string | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      codes?: unknown[] | null;
+    };
     CardDetails: {
-      cardId: string
-      name?: string | null
-      owner?: unknown
-      appearanceCode?: string | null
-      classification?: string | null
-      disabled?: boolean
-      startTime?: string | null
-      stopTime?: string | null
-      createTime: string
-      pinCode?: string | null
-      state?: string | null
-      archivedAt?: string | null
-      codes?: unknown[] | null
-      loans?:
-        | {
-            /** Format: uuid */
-            id: string
-            /** @enum {string} */
-            loanType: 'TENANT' | 'MAINTENANCE'
-            contact?: string | null
-            contact2?: string | null
-            contactPerson?: string | null
-            notes?: string | null
-            /** Format: date-time */
-            returnedAt?: string | null
-            /** Format: date-time */
-            availableToNextTenantFrom?: string | null
-            /** Format: date-time */
-            pickedUpAt?: string | null
-            /** Format: date-time */
-            createdAt: string
-            /** Format: date-time */
-            updatedAt: string
-            createdBy?: string | null
-            updatedBy?: string | null
-            keyCount?: number
-            cardCount?: number
-          }[]
-        | null
-    }
+      cardId: string;
+      name?: string | null;
+      owner?: unknown;
+      appearanceCode?: string | null;
+      classification?: string | null;
+      disabled?: boolean;
+      startTime?: string | null;
+      stopTime?: string | null;
+      createTime: string;
+      pinCode?: string | null;
+      state?: string | null;
+      archivedAt?: string | null;
+      codes?: unknown[] | null;
+      loans?: (({
+          /** Format: uuid */
+          id: string;
+          /** @enum {string} */
+          loanType: "TENANT" | "MAINTENANCE";
+          contact?: string | null;
+          contact2?: string | null;
+          contactPerson?: string | null;
+          notes?: string | null;
+          /** Format: date-time */
+          returnedAt?: string | null;
+          /** Format: date-time */
+          availableToNextTenantFrom?: string | null;
+          /** Format: date-time */
+          pickedUpAt?: string | null;
+          /** Format: date-time */
+          createdAt: string;
+          /** Format: date-time */
+          updatedAt: string;
+          createdBy?: string | null;
+          updatedBy?: string | null;
+          keyCount?: number;
+          cardCount?: number;
+        })[]) | null;
+    };
     QueryCardOwnersParams: {
-      nameFilter?: string
-      expand?: string
-      idfilter?: string
-      attributeFilter?: string
-      selectedAttributes?: string
-      folderFilter?: string
-      organisationFilter?: string
-      offset?: number
-      limit?: number
-    }
+      nameFilter?: string;
+      expand?: string;
+      idfilter?: string;
+      attributeFilter?: string;
+      selectedAttributes?: string;
+      folderFilter?: string;
+      organisationFilter?: string;
+      offset?: number;
+      limit?: number;
+    };
     PaginatedResponse: {
-      content: unknown[]
+      content: unknown[];
       _meta: {
-        totalRecords: number
-        page: number
-        limit: number
-        count: number
-      }
-      _links: {
-        href: string
-        /** @enum {string} */
-        rel: 'self' | 'first' | 'last' | 'prev' | 'next'
-      }[]
-    }
+        totalRecords: number;
+        page: number;
+        limit: number;
+        count: number;
+      };
+      _links: ({
+          href: string;
+          /** @enum {string} */
+          rel: "self" | "first" | "last" | "prev" | "next";
+        })[];
+    };
     SearchQueryParams: {
       /** @description The search query string used to find properties, buildings and residences */
-      q: string
-    }
+      q: string;
+    };
     PropertySearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a property result
        * @enum {string}
        */
-      type: 'property'
+      type: "property";
       /** @description Property code */
-      code: string
+      code: string;
       /** @description Name or designation of the property */
-      name: string
-    }
+      name: string;
+    };
     BuildingSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a building result
        * @enum {string}
        */
-      type: 'building'
+      type: "building";
       /** @description Building code */
-      code: string
+      code: string;
       /** @description Name of the building */
-      name: string | null
-      property?: {
+      name: string | null;
+      property?: ({
         /** @description Property associated with the building */
-        name: string | null
-        id: string
-        code: string
-      } | null
-    }
+        name: string | null;
+        id: string;
+        code: string;
+      }) | null;
+    };
     MaintenanceUnitSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a maintenance unit result
        * @enum {string}
        */
-      type: 'maintenance-unit'
+      type: "maintenance-unit";
       /** @description Code of the maintenance unit */
-      code: string
+      code: string;
       /** @description Caption/name of the maintenance unit */
-      caption: string | null
+      caption: string | null;
       /** @description Type of maintenance unit */
-      maintenanceType: string | null
+      maintenanceType: string | null;
       /** @description Property code */
-      estateCode: string | null
+      estateCode: string | null;
       /** @description Property name */
-      estate: string | null
-    }
+      estate: string | null;
+    };
     StaircaseSearchResult: {
       /** @description Unique identifier for the search result */
-      id: string
+      id: string;
       /**
        * @description Indicates this is a staircase result
        * @enum {string}
        */
-      type: 'staircase'
+      type: "staircase";
       /** @description Code of the staircase */
-      code: string
+      code: string;
       /** @description Name (caption) of the staircase */
-      name: string | null
+      name: string | null;
       property: {
-        code: string
+        code: string;
         /** @description Name of property associated with the staircase */
-        name: string | null
-      }
+        name: string | null;
+      };
       building: {
-        code: string
+        code: string;
         /** @description Name of building associated with the staircase */
-        name: string | null
-      }
-    }
+        name: string | null;
+      };
+    };
     /** @description A search result that can be either a property, building, residence, parking space, maintenance unit, facility or staircase */
-    SearchResult:
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a property result
-           * @enum {string}
-           */
-          type: 'property'
-          /** @description Property code */
-          code: string
-          /** @description Name or designation of the property */
-          name: string
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a building result
-           * @enum {string}
-           */
-          type: 'building'
-          /** @description Building code */
-          code: string
-          /** @description Name of the building */
-          name: string | null
-          property?: {
-            /** @description Property associated with the building */
-            name: string | null
-            id: string
-            code: string
-          } | null
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a residence result
-           * @enum {string}
-           */
-          type: 'residence'
-          /** @description Name of the residence */
-          name: string | null
-          /** @description Rental object ID of the residence */
-          rentalId: string | null
-          property: {
-            code: string | null
-            /** @description Name of property associated with the residence */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the residence */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a parking space result
-           * @enum {string}
-           */
-          type: 'parking-space'
-          /** @description Name of the parking space */
-          name: string | null
-          /** @description Rental ID of the parking space */
-          rentalId: string
-          /** @description Code of the parking space */
-          code: string
-          property: {
-            code: string | null
-            /** @description Name of property associated with the parking space */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the parking space */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a maintenance unit result
-           * @enum {string}
-           */
-          type: 'maintenance-unit'
-          /** @description Code of the maintenance unit */
-          code: string
-          /** @description Caption/name of the maintenance unit */
-          caption: string | null
-          /** @description Type of maintenance unit */
-          maintenanceType: string | null
-          /** @description Property code */
-          estateCode: string | null
-          /** @description Property name */
-          estate: string | null
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a facility result
-           * @enum {string}
-           */
-          type: 'facility'
-          /** @description Name of the facility */
-          name: string | null
-          /** @description Rental ID of the facility */
-          rentalId: string
-          /** @description Code of the facility */
-          code: string
-          property: {
-            code: string | null
-            /** @description Name of property associated with the facility */
-            name: string | null
-          }
-          building: {
-            code: string | null
-            /** @description Name of building associated with the facility */
-            name: string | null
-          }
-        }
-      | {
-          /** @description Unique identifier for the search result */
-          id: string
-          /**
-           * @description Indicates this is a staircase result
-           * @enum {string}
-           */
-          type: 'staircase'
-          /** @description Code of the staircase */
-          code: string
-          /** @description Name (caption) of the staircase */
-          name: string | null
-          property: {
-            code: string
-            /** @description Name of property associated with the staircase */
-            name: string | null
-          }
-          building: {
-            code: string
-            /** @description Name of building associated with the staircase */
-            name: string | null
-          }
-        }
+    SearchResult: {
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a property result
+       * @enum {string}
+       */
+      type: "property";
+      /** @description Property code */
+      code: string;
+      /** @description Name or designation of the property */
+      name: string;
+    } | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a building result
+       * @enum {string}
+       */
+      type: "building";
+      /** @description Building code */
+      code: string;
+      /** @description Name of the building */
+      name: string | null;
+      property?: ({
+        /** @description Property associated with the building */
+        name: string | null;
+        id: string;
+        code: string;
+      }) | null;
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a residence result
+       * @enum {string}
+       */
+      type: "residence";
+      /** @description Name of the residence */
+      name: string | null;
+      /** @description Rental object ID of the residence */
+      rentalId: string | null;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the residence */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the residence */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a parking space result
+       * @enum {string}
+       */
+      type: "parking-space";
+      /** @description Name of the parking space */
+      name: string | null;
+      /** @description Rental ID of the parking space */
+      rentalId: string;
+      /** @description Code of the parking space */
+      code: string;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the parking space */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the parking space */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a maintenance unit result
+       * @enum {string}
+       */
+      type: "maintenance-unit";
+      /** @description Code of the maintenance unit */
+      code: string;
+      /** @description Caption/name of the maintenance unit */
+      caption: string | null;
+      /** @description Type of maintenance unit */
+      maintenanceType: string | null;
+      /** @description Property code */
+      estateCode: string | null;
+      /** @description Property name */
+      estate: string | null;
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a facility result
+       * @enum {string}
+       */
+      type: "facility";
+      /** @description Name of the facility */
+      name: string | null;
+      /** @description Rental ID of the facility */
+      rentalId: string;
+      /** @description Code of the facility */
+      code: string;
+      property: {
+        code: string | null;
+        /** @description Name of property associated with the facility */
+        name: string | null;
+      };
+      building: {
+        code: string | null;
+        /** @description Name of building associated with the facility */
+        name: string | null;
+      };
+    }) | ({
+      /** @description Unique identifier for the search result */
+      id: string;
+      /**
+       * @description Indicates this is a staircase result
+       * @enum {string}
+       */
+      type: "staircase";
+      /** @description Code of the staircase */
+      code: string;
+      /** @description Name (caption) of the staircase */
+      name: string | null;
+      property: {
+        code: string;
+        /** @description Name of property associated with the staircase */
+        name: string | null;
+      };
+      building: {
+        code: string;
+        /** @description Name of building associated with the staircase */
+        name: string | null;
+      };
+    });
     Inspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
-      lease: {
-        leaseId: string
-        leaseNumber: string
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
         /** Format: date-time */
-        leaseStartDate: string
+        leaseStartDate: string;
         /** Format: date-time */
-        leaseEndDate?: string
+        leaseEndDate?: string;
         /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
         rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
           address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
           roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
+              roomTypeId: string;
+              name: string;
+            }[];
           /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
+          lastUpdated?: string;
+        };
+        type: string;
         rentInfo?: {
           currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
             /** Format: date-time */
-            rentStartDate?: string
+            rentStartDate?: string;
             /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
+            rentEndDate?: string;
+          };
+        };
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
         /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
         /** Format: date-time */
-        preferredMoveOutDate?: string
+        preferredMoveOutDate?: string;
         /** Format: date-time */
-        terminationDate?: string
+        terminationDate?: string;
         /** Format: date-time */
-        contractDate?: string
+        contractDate?: string;
         /** Format: date-time */
-        lastDebitDate?: string
+        lastDebitDate?: string;
         /** Format: date-time */
-        approvalDate?: string
+        approvalDate?: string;
         residentialArea?: {
-          code: string
-          caption: string
-        }
+          code: string;
+          caption: string;
+        };
         tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
             /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-      rooms:
-        | {
-            roomId: string
-            name?: string
-            conditions: {
-              details: string
-            }
-            actions: {
-              details: string[]
-            }
-            componentNotes: {
-              details: string
-            }
-            componentCosts: {
-              /** @default 0 */
-              details?: number
-            }
-            componentPhotos: {
-              details: string[]
-            }
-            componentCostResponsibilities: {
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              details?: 'tenant' | 'landlord' | null
-            }
-            photos: string[]
-            isApproved: boolean
-            isHandled: boolean
-            /** @default [] */
-            detailComponents?: {
-              id: string
-              type: string
-              label: string
-              note: string
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+      rooms: (({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
               /** @default */
-              condition?: string
-              cost?: number
+              condition?: string;
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default [] */
-            components?: {
-              componentId: string
-              label: string
-              condition: string
-              action: string[]
-              note: string
-              photos: string[]
-              cost?: number
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default false */
-            isAddedInThisInspection?: boolean
-          }[]
-        | null
-    }
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[]) | null;
+    };
     InspectionComponent: {
-      componentId: string
-      label: string
-      condition: string
-      action: string[]
-      note: string
-      photos: string[]
-      cost?: number
+      componentId: string;
+      label: string;
+      condition: string;
+      action: string[];
+      note: string;
+      photos: string[];
+      cost?: number;
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: 'tenant' | 'landlord' | null
-    }
+      costResponsibility?: "tenant" | "landlord" | null;
+    };
     InspectionRoom: {
-      roomId: string
-      name?: string
+      roomId: string;
+      name?: string;
       conditions: {
-        details: string
-      }
+        details: string;
+      };
       actions: {
-        details: string[]
-      }
+        details: string[];
+      };
       componentNotes: {
-        details: string
-      }
+        details: string;
+      };
       componentCosts: {
         /** @default 0 */
-        details?: number
-      }
+        details?: number;
+      };
       componentPhotos: {
-        details: string[]
-      }
+        details: string[];
+      };
       componentCostResponsibilities: {
         /**
          * @default null
          * @enum {string|null}
          */
-        details?: 'tenant' | 'landlord' | null
-      }
-      photos: string[]
-      isApproved: boolean
-      isHandled: boolean
+        details?: "tenant" | "landlord" | null;
+      };
+      photos: string[];
+      isApproved: boolean;
+      isHandled: boolean;
       /** @default [] */
-      detailComponents?: {
-        id: string
-        type: string
-        label: string
-        note: string
-        /** @default */
-        condition?: string
-        cost?: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-      }[]
+      detailComponents?: ({
+          id: string;
+          type: string;
+          label: string;
+          note: string;
+          /** @default */
+          condition?: string;
+          cost?: number;
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: "tenant" | "landlord" | null;
+        })[];
       /** @default [] */
-      components?: {
-        componentId: string
-        label: string
-        condition: string
-        action: string[]
-        note: string
-        photos: string[]
-        cost?: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-      }[]
+      components?: ({
+          componentId: string;
+          label: string;
+          condition: string;
+          action: string[];
+          note: string;
+          photos: string[];
+          cost?: number;
+          /**
+           * @default null
+           * @enum {string|null}
+           */
+          costResponsibility?: "tenant" | "landlord" | null;
+        })[];
       /** @default false */
-      isAddedInThisInspection?: boolean
-    }
+      isAddedInThisInspection?: boolean;
+    };
     DetailedInspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
+      date: string;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      inspector: string
-      type: string
-      residenceId: string
-      address: string
-      apartmentCode: string | null
-      isFurnished: boolean
-      leaseId: string
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      masterKeyAccess: string | null
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
-      remarkCount: number
+      endedAt: string | null;
+      inspector: string;
+      type: string;
+      residenceId: string;
+      address: string;
+      apartmentCode: string | null;
+      isFurnished: boolean;
+      leaseId: string;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      masterKeyAccess: string | null;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
+      remarkCount: number;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12496,379 +12334,379 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms: {
-        room: string
-        remarks: {
-          remarkId: string
-          location: string | null
-          buildingComponent: string | null
-          notes: string | null
-          remarkGrade: number
-          remarkStatus: string | null
-          cost: number
+        electricalSystem?: boolean;
+      };
+      rooms: ({
+          room: string;
+          remarks: ({
+              remarkId: string;
+              location: string | null;
+              buildingComponent: string | null;
+              notes: string | null;
+              remarkGrade: number;
+              remarkStatus: string | null;
+              cost: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+              invoice: boolean;
+              quantity: number;
+              isMissing: boolean;
+              /** Format: date-time */
+              fixedDate: string | null;
+              workOrderCreated: boolean;
+              workOrderStatus: number | null;
+            })[];
+        })[];
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
+        /** Format: date-time */
+        leaseStartDate: string;
+        /** Format: date-time */
+        leaseEndDate?: string;
+        /** @enum {string} */
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
+        rentalProperty?: {
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
+          address?: {
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
+          roomTypes?: {
+              roomTypeId: string;
+              name: string;
+            }[];
+          /** Format: date-time */
+          lastUpdated?: string;
+        };
+        type: string;
+        rentInfo?: {
+          currentRent: {
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
+            /** Format: date-time */
+            rentStartDate?: string;
+            /** Format: date-time */
+            rentEndDate?: string;
+          };
+        };
+        address?: {
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
+        /** Format: date-time */
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
+        /** Format: date-time */
+        preferredMoveOutDate?: string;
+        /** Format: date-time */
+        terminationDate?: string;
+        /** Format: date-time */
+        contractDate?: string;
+        /** Format: date-time */
+        lastDebitDate?: string;
+        /** Format: date-time */
+        approvalDate?: string;
+        residentialArea?: {
+          code: string;
+          caption: string;
+        };
+        tenants?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
+            /** Format: date-time */
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+      residence: ({
+        id: string;
+        code: string;
+        name: string | null;
+        /** @enum {string|null} */
+        status: "VACANT" | "LEASED" | null;
+        entrance: string | null;
+        location: string | null;
+        floor: string | null;
+        partNo: number | null;
+        part: string | null;
+        deleted: boolean;
+        validityPeriod: {
+          /** Format: date-time */
+          fromDate: string;
+          /** Format: date-time */
+          toDate: string;
+        };
+        accessibility: {
+          wheelchairAccessible: boolean;
+          elevator: boolean;
+          residenceAdapted: boolean;
+        };
+        features: {
+          hygieneFacility: string | null;
+          balcony1?: {
+            location: string;
+            type: string;
+          };
+          balcony2?: {
+            location: string;
+            type: string;
+          };
+          patioLocation: string | null;
+          sauna: boolean;
+          extraToilet: boolean;
+          sharedKitchen: boolean;
+          petAllergyFree: boolean;
+          /** @description Is the apartment checked for electric allergy intolerance? */
+          electricAllergyIntolerance: boolean;
+          smokeFree: boolean;
+          asbestos: boolean;
+        };
+        type: {
+          code: string;
+          name: string | null;
+          roomCount: number | null;
+          kitchen: number;
+        };
+        residenceType: {
+          residenceTypeId: string;
+          code: string;
+          name: string | null;
+          roomCount: number | null;
+          kitchen: number;
+          systemStandard: number;
+          checklistId: string | null;
+          componentTypeActionId: string | null;
+          statisticsGroupSCBId: string | null;
+          statisticsGroup2Id: string | null;
+          statisticsGroup3Id: string | null;
+          statisticsGroup4Id: string | null;
+          timestamp: string;
+        };
+        rentalInformation: ({
+          apartmentNumber: string | null;
+          rentalId: string | null;
+          type: {
+            code: string;
+            name: string | null;
+          };
+        }) | null;
+        propertyObject: {
+          energy: {
+            energyClass: number;
+            /** Format: date-time */
+            energyRegistered?: string;
+            /** Format: date-time */
+            energyReceived?: string;
+            energyIndex?: number;
+          };
+          rentalId: string | null;
+          rentalInformation: ({
+            type: {
+              code: string;
+              name: string | null;
+            };
+          }) | null;
+          rentalBlocks: ({
+              id: string;
+              blockReasonId: string | null;
+              blockReason: string | null;
+              /** Format: date-time */
+              fromDate: string;
+              /** Format: date-time */
+              toDate: string | null;
+              amount: number | null;
+            })[];
+        };
+        property: {
+          id: string | null;
+          name: string | null;
+          code: string | null;
+        };
+        building: {
+          id: string | null;
+          name: string | null;
+          code: string | null;
+        };
+        staircase: ({
+          id: string;
+          code: string;
+          name: string | null;
+          features: {
+            floorPlan: string | null;
+            accessibleByElevator: boolean;
+          };
+          dates: {
+            /** Format: date-time */
+            from: string;
+            /** Format: date-time */
+            to: string;
+          };
+          property?: {
+            propertyId: string | null;
+            propertyName: string | null;
+            propertyCode: string | null;
+          };
+          building?: {
+            buildingId: string | null;
+            buildingName: string | null;
+            buildingCode: string | null;
+          };
+          deleted: boolean;
+          timestamp: string;
+        }) | null;
+        areaSize: number | null;
+        malarEnergiFacilityId: string | null;
+      }) | null;
+    };
+    DetailedInspectionRoom: {
+      room: string;
+      remarks: ({
+          remarkId: string;
+          location: string | null;
+          buildingComponent: string | null;
+          notes: string | null;
+          remarkGrade: number;
+          remarkStatus: string | null;
+          cost: number;
           /**
            * @default null
            * @enum {string|null}
            */
-          costResponsibility?: 'tenant' | 'landlord' | null
-          invoice: boolean
-          quantity: number
-          isMissing: boolean
+          costResponsibility?: "tenant" | "landlord" | null;
+          invoice: boolean;
+          quantity: number;
+          isMissing: boolean;
           /** Format: date-time */
-          fixedDate: string | null
-          workOrderCreated: boolean
-          workOrderStatus: number | null
-        }[]
-      }[]
-      lease: {
-        leaseId: string
-        leaseNumber: string
-        /** Format: date-time */
-        leaseStartDate: string
-        /** Format: date-time */
-        leaseEndDate?: string
-        /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
-        rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
-          roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
-          /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
-        rentInfo?: {
-          currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
-            /** Format: date-time */
-            rentStartDate?: string
-            /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
-        address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
-        /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
-        /** Format: date-time */
-        preferredMoveOutDate?: string
-        /** Format: date-time */
-        terminationDate?: string
-        /** Format: date-time */
-        contractDate?: string
-        /** Format: date-time */
-        lastDebitDate?: string
-        /** Format: date-time */
-        approvalDate?: string
-        residentialArea?: {
-          code: string
-          caption: string
-        }
-        tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
-            /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-      residence: {
-        id: string
-        code: string
-        name: string | null
-        /** @enum {string|null} */
-        status: 'VACANT' | 'LEASED' | null
-        entrance: string | null
-        location: string | null
-        floor: string | null
-        partNo: number | null
-        part: string | null
-        deleted: boolean
-        validityPeriod: {
-          /** Format: date-time */
-          fromDate: string
-          /** Format: date-time */
-          toDate: string
-        }
-        accessibility: {
-          wheelchairAccessible: boolean
-          elevator: boolean
-          residenceAdapted: boolean
-        }
-        features: {
-          hygieneFacility: string | null
-          balcony1?: {
-            location: string
-            type: string
-          }
-          balcony2?: {
-            location: string
-            type: string
-          }
-          patioLocation: string | null
-          sauna: boolean
-          extraToilet: boolean
-          sharedKitchen: boolean
-          petAllergyFree: boolean
-          /** @description Is the apartment checked for electric allergy intolerance? */
-          electricAllergyIntolerance: boolean
-          smokeFree: boolean
-          asbestos: boolean
-        }
-        type: {
-          code: string
-          name: string | null
-          roomCount: number | null
-          kitchen: number
-        }
-        residenceType: {
-          residenceTypeId: string
-          code: string
-          name: string | null
-          roomCount: number | null
-          kitchen: number
-          systemStandard: number
-          checklistId: string | null
-          componentTypeActionId: string | null
-          statisticsGroupSCBId: string | null
-          statisticsGroup2Id: string | null
-          statisticsGroup3Id: string | null
-          statisticsGroup4Id: string | null
-          timestamp: string
-        }
-        rentalInformation: {
-          apartmentNumber: string | null
-          rentalId: string | null
-          type: {
-            code: string
-            name: string | null
-          }
-        } | null
-        propertyObject: {
-          energy: {
-            energyClass: number
-            /** Format: date-time */
-            energyRegistered?: string
-            /** Format: date-time */
-            energyReceived?: string
-            energyIndex?: number
-          }
-          rentalId: string | null
-          rentalInformation: {
-            type: {
-              code: string
-              name: string | null
-            }
-          } | null
-          rentalBlocks: {
-            id: string
-            blockReasonId: string | null
-            blockReason: string | null
-            /** Format: date-time */
-            fromDate: string
-            /** Format: date-time */
-            toDate: string | null
-            amount: number | null
-          }[]
-        }
-        property: {
-          id: string | null
-          name: string | null
-          code: string | null
-        }
-        building: {
-          id: string | null
-          name: string | null
-          code: string | null
-        }
-        staircase: {
-          id: string
-          code: string
-          name: string | null
-          features: {
-            floorPlan: string | null
-            accessibleByElevator: boolean
-          }
-          dates: {
-            /** Format: date-time */
-            from: string
-            /** Format: date-time */
-            to: string
-          }
-          property?: {
-            propertyId: string | null
-            propertyName: string | null
-            propertyCode: string | null
-          }
-          building?: {
-            buildingId: string | null
-            buildingName: string | null
-            buildingCode: string | null
-          }
-          deleted: boolean
-          timestamp: string
-        } | null
-        areaSize: number | null
-        malarEnergiFacilityId: string | null
-      } | null
-    }
-    DetailedInspectionRoom: {
-      room: string
-      remarks: {
-        remarkId: string
-        location: string | null
-        buildingComponent: string | null
-        notes: string | null
-        remarkGrade: number
-        remarkStatus: string | null
-        cost: number
-        /**
-         * @default null
-         * @enum {string|null}
-         */
-        costResponsibility?: 'tenant' | 'landlord' | null
-        invoice: boolean
-        quantity: number
-        isMissing: boolean
-        /** Format: date-time */
-        fixedDate: string | null
-        workOrderCreated: boolean
-        workOrderStatus: number | null
-      }[]
-    }
+          fixedDate: string | null;
+          workOrderCreated: boolean;
+          workOrderStatus: number | null;
+        })[];
+    };
     DetailedInspectionRemark: {
-      remarkId: string
-      location: string | null
-      buildingComponent: string | null
-      notes: string | null
-      remarkGrade: number
-      remarkStatus: string | null
-      cost: number
+      remarkId: string;
+      location: string | null;
+      buildingComponent: string | null;
+      notes: string | null;
+      remarkGrade: number;
+      remarkStatus: string | null;
+      cost: number;
       /**
        * @default null
        * @enum {string|null}
        */
-      costResponsibility?: 'tenant' | 'landlord' | null
-      invoice: boolean
-      quantity: number
-      isMissing: boolean
+      costResponsibility?: "tenant" | "landlord" | null;
+      invoice: boolean;
+      quantity: number;
+      isMissing: boolean;
       /** Format: date-time */
-      fixedDate: string | null
-      workOrderCreated: boolean
-      workOrderStatus: number | null
-    }
+      fixedDate: string | null;
+      workOrderCreated: boolean;
+      workOrderStatus: number | null;
+    };
     TenantContactsResponse: {
       inspection: {
-        id: string
-        address: string
-        apartmentCode: string | null
-      }
+        id: string;
+        address: string;
+        apartmentCode: string | null;
+      };
       new_tenant?: {
         contacts: {
-          fullName: string
-          emailAddress: string
-          contactCode: string
-        }[]
-        contractId: string
-      }
-      tenant?: components['schemas']['TenantContactsResponse']['new_tenant']
-    }
+            fullName: string;
+            emailAddress: string;
+            contactCode: string;
+          }[];
+        contractId: string;
+      };
+      tenant?: components["schemas"]["TenantContactsResponse"]["new_tenant"];
+    };
     SendProtocolRequest: {
       /** @enum {string} */
-      recipient: 'tenant' | 'new-tenant'
-    }
+      recipient: "tenant" | "new-tenant";
+    };
     SendProtocolResponse: {
-      success: boolean
+      success: boolean;
       /** @enum {string} */
-      recipient: 'tenant' | 'new-tenant'
+      recipient: "tenant" | "new-tenant";
       sentTo: {
-        emails: string[]
-        contactNames: string[]
-        contractId: string
-      }
-      error?: string
-    }
+        emails: string[];
+        contactNames: string[];
+        contractId: string;
+      };
+      error?: string;
+    };
     CreateInspectionRequest: {
-      status: string
+      status: string;
       /** Format: date-time */
-      date: string
+      date: string;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      inspector: string
-      type: string
-      residenceId: string
-      address: string
-      apartmentCode: string | null
-      isFurnished: boolean
-      leaseId: string
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      masterKeyAccess: string | null
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
+      endedAt: string | null;
+      inspector: string;
+      type: string;
+      residenceId: string;
+      address: string;
+      apartmentCode: string | null;
+      isFurnished: boolean;
+      leaseId: string;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      masterKeyAccess: string | null;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -12879,185 +12717,185 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms: {
-        room: string
-        remarks: {
-          remarkId: string
-          location: string | null
-          buildingComponent: string | null
-          notes: string | null
-          remarkGrade: number
-          remarkStatus: string | null
-          cost: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-          invoice: boolean
-          quantity: number
-          isMissing: boolean
-          /** Format: date-time */
-          fixedDate: string | null
-          workOrderCreated: boolean
-          workOrderStatus: number | null
-        }[]
-      }[]
-    }
+        electricalSystem?: boolean;
+      };
+      rooms: ({
+          room: string;
+          remarks: ({
+              remarkId: string;
+              location: string | null;
+              buildingComponent: string | null;
+              notes: string | null;
+              remarkGrade: number;
+              remarkStatus: string | null;
+              cost: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+              invoice: boolean;
+              quantity: number;
+              isMissing: boolean;
+              /** Format: date-time */
+              fixedDate: string | null;
+              workOrderCreated: boolean;
+              workOrderStatus: number | null;
+            })[];
+        })[];
+    };
     UpdateInspectionStatusRequest: {
       /** @enum {string} */
-      status?: 'Registrerad' | 'Påbörjad' | 'Genomförd'
-      inspector?: string
-    }
+      status?: "Registrerad" | "Påbörjad" | "Genomförd";
+      inspector?: string;
+    };
     InspectionWithSource: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
       /** @enum {string} */
-      source: 'xpand' | 'internal'
-      lease: {
-        leaseId: string
-        leaseNumber: string
+      source: "xpand" | "internal";
+      lease: ({
+        leaseId: string;
+        leaseNumber: string;
         /** Format: date-time */
-        leaseStartDate: string
+        leaseStartDate: string;
         /** Format: date-time */
-        leaseEndDate?: string
+        leaseEndDate?: string;
         /** @enum {string} */
-        status: 'Current' | 'Upcoming' | 'AboutToEnd' | 'Ended'
-        tenantContactIds?: string[]
-        rentalPropertyId: string
+        status: "Current" | "Upcoming" | "AboutToEnd" | "Ended";
+        tenantContactIds?: string[];
+        rentalPropertyId: string;
         rentalProperty?: {
-          rentalPropertyId: string
-          apartmentNumber: number
-          size: number
-          type: string
+          rentalPropertyId: string;
+          apartmentNumber: number;
+          size: number;
+          type: string;
           address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          rentalPropertyType: string
-          additionsIncludedInRent: string
-          otherInfo?: string
+            street?: string;
+            number: string;
+            postalCode: string;
+            city: string;
+          };
+          rentalPropertyType: string;
+          additionsIncludedInRent: string;
+          otherInfo?: string;
           roomTypes?: {
-            roomTypeId: string
-            name: string
-          }[]
+              roomTypeId: string;
+              name: string;
+            }[];
           /** Format: date-time */
-          lastUpdated?: string
-        }
-        type: string
+          lastUpdated?: string;
+        };
+        type: string;
         rentInfo?: {
           currentRent: {
-            rentId?: string
-            leaseId?: string
-            currentRent: number
-            vat: number
-            additionalChargeDescription?: string
-            additionalChargeAmount?: number
+            rentId?: string;
+            leaseId?: string;
+            currentRent: number;
+            vat: number;
+            additionalChargeDescription?: string;
+            additionalChargeAmount?: number;
             /** Format: date-time */
-            rentStartDate?: string
+            rentStartDate?: string;
             /** Format: date-time */
-            rentEndDate?: string
-          }
-        }
+            rentEndDate?: string;
+          };
+        };
         address?: {
-          street?: string
-          number: string
-          postalCode: string
-          city: string
-        }
-        noticeGivenBy?: string
+          street?: string;
+          number: string;
+          postalCode: string;
+          city: string;
+        };
+        noticeGivenBy?: string;
         /** Format: date-time */
-        noticeDate?: string
-        noticeTimeTenant?: string | number
+        noticeDate?: string;
+        noticeTimeTenant?: string | number;
         /** Format: date-time */
-        preferredMoveOutDate?: string
+        preferredMoveOutDate?: string;
         /** Format: date-time */
-        terminationDate?: string
+        terminationDate?: string;
         /** Format: date-time */
-        contractDate?: string
+        contractDate?: string;
         /** Format: date-time */
-        lastDebitDate?: string
+        lastDebitDate?: string;
         /** Format: date-time */
-        approvalDate?: string
+        approvalDate?: string;
         residentialArea?: {
-          code: string
-          caption: string
-        }
+          code: string;
+          caption: string;
+        };
         tenants?: {
-          contactCode: string
-          contactKey: string
-          leaseIds?: string[]
-          firstName: string
-          lastName: string
-          fullName: string
-          nationalRegistrationNumber: string
-          /** Format: date-time */
-          birthDate: string
-          address?: {
-            street?: string
-            number: string
-            postalCode: string
-            city: string
-          }
-          phoneNumbers?: {
-            phoneNumber: string
-            type: string
-            isMainNumber: boolean
-          }[]
-          emailAddress?: string
-          isTenant: boolean
-          parkingSpaceWaitingList?: {
+            contactCode: string;
+            contactKey: string;
+            leaseIds?: string[];
+            firstName: string;
+            lastName: string;
+            fullName: string;
+            nationalRegistrationNumber: string;
             /** Format: date-time */
-            queueTime: string
-            queuePoints: number
-            type: number
-          }
-          specialAttention?: boolean
-          leaseContactType?: string
-        }[]
-      } | null
-    }
+            birthDate: string;
+            address?: {
+              street?: string;
+              number: string;
+              postalCode: string;
+              city: string;
+            };
+            phoneNumbers?: {
+                phoneNumber: string;
+                type: string;
+                isMainNumber: boolean;
+              }[];
+            emailAddress?: string;
+            isTenant: boolean;
+            parkingSpaceWaitingList?: {
+              /** Format: date-time */
+              queueTime: string;
+              queuePoints: number;
+              type: number;
+            };
+            specialAttention?: boolean;
+            leaseContactType?: string;
+          }[];
+      }) | null;
+    };
     InternalInspection: {
-      id: string
-      status: string
+      id: string;
+      status: string;
       /** Format: date-time */
-      date: string
-      inspector: string
-      type: string
-      address: string
-      apartmentCode: string | null
-      leaseId: string
-      masterKeyAccess: string | null
-      residenceId: string
-      isFurnished: boolean
+      date: string;
+      inspector: string;
+      type: string;
+      address: string;
+      apartmentCode: string | null;
+      leaseId: string;
+      masterKeyAccess: string | null;
+      residenceId: string;
+      isFurnished: boolean;
       /** Format: date-time */
-      startedAt: string | null
+      startedAt: string | null;
       /** Format: date-time */
-      endedAt: string | null
-      isTenantPresent: boolean
-      isNewTenantPresent: boolean
-      hasRemarks: boolean
-      notes: string | null
-      totalCost: number | null
-      remarkCount: number
+      endedAt: string | null;
+      isTenantPresent: boolean;
+      isNewTenantPresent: boolean;
+      hasRemarks: boolean;
+      notes: string | null;
+      totalCost: number | null;
+      remarkCount: number;
       /**
        * @default {
        *   "groundFaultBreaker": false,
@@ -13068,425 +12906,388 @@ export interface components {
        */
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
-      rooms:
-        | {
-            roomId: string
-            name?: string
-            conditions: {
-              details: string
-            }
-            actions: {
-              details: string[]
-            }
-            componentNotes: {
-              details: string
-            }
-            componentCosts: {
-              /** @default 0 */
-              details?: number
-            }
-            componentPhotos: {
-              details: string[]
-            }
-            componentCostResponsibilities: {
-              /**
-               * @default null
-               * @enum {string|null}
-               */
-              details?: 'tenant' | 'landlord' | null
-            }
-            photos: string[]
-            isApproved: boolean
-            isHandled: boolean
-            /** @default [] */
-            detailComponents?: {
-              id: string
-              type: string
-              label: string
-              note: string
+        electricalSystem?: boolean;
+      };
+      rooms: (({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
               /** @default */
-              condition?: string
-              cost?: number
+              condition?: string;
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default [] */
-            components?: {
-              componentId: string
-              label: string
-              condition: string
-              action: string[]
-              note: string
-              photos: string[]
-              cost?: number
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
               /**
                * @default null
                * @enum {string|null}
                */
-              costResponsibility?: 'tenant' | 'landlord' | null
-            }[]
-            /** @default false */
-            isAddedInThisInspection?: boolean
-          }[]
-        | null
-    }
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[]) | null;
+    };
     SaveInspectionDraftRequest: {
-      inspectorName: string
-      rooms: {
-        roomId: string
-        name?: string
-        conditions: {
-          details: string
-        }
-        actions: {
-          details: string[]
-        }
-        componentNotes: {
-          details: string
-        }
-        componentCosts: {
-          /** @default 0 */
-          details?: number
-        }
-        componentPhotos: {
-          details: string[]
-        }
-        componentCostResponsibilities: {
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          details?: 'tenant' | 'landlord' | null
-        }
-        photos: string[]
-        isApproved: boolean
-        isHandled: boolean
-        /** @default [] */
-        detailComponents?: {
-          id: string
-          type: string
-          label: string
-          note: string
-          /** @default */
-          condition?: string
-          cost?: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-        }[]
-        /** @default [] */
-        components?: {
-          componentId: string
-          label: string
-          condition: string
-          action: string[]
-          note: string
-          photos: string[]
-          cost?: number
-          /**
-           * @default null
-           * @enum {string|null}
-           */
-          costResponsibility?: 'tenant' | 'landlord' | null
-        }[]
-        /** @default false */
-        isAddedInThisInspection?: boolean
-      }[]
-      isFurnished: boolean
-      isTenantPresent?: boolean
-      isNewTenantPresent?: boolean
+      inspectorName: string;
+      rooms: ({
+          roomId: string;
+          name?: string;
+          conditions: {
+            details: string;
+          };
+          actions: {
+            details: string[];
+          };
+          componentNotes: {
+            details: string;
+          };
+          componentCosts: {
+            /** @default 0 */
+            details?: number;
+          };
+          componentPhotos: {
+            details: string[];
+          };
+          componentCostResponsibilities: {
+            /**
+             * @default null
+             * @enum {string|null}
+             */
+            details?: "tenant" | "landlord" | null;
+          };
+          photos: string[];
+          isApproved: boolean;
+          isHandled: boolean;
+          /** @default [] */
+          detailComponents?: ({
+              id: string;
+              type: string;
+              label: string;
+              note: string;
+              /** @default */
+              condition?: string;
+              cost?: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default [] */
+          components?: ({
+              componentId: string;
+              label: string;
+              condition: string;
+              action: string[];
+              note: string;
+              photos: string[];
+              cost?: number;
+              /**
+               * @default null
+               * @enum {string|null}
+               */
+              costResponsibility?: "tenant" | "landlord" | null;
+            })[];
+          /** @default false */
+          isAddedInThisInspection?: boolean;
+        })[];
+      isFurnished: boolean;
+      isTenantPresent?: boolean;
+      isNewTenantPresent?: boolean;
       checklist?: {
         /** @default false */
-        groundFaultBreaker?: boolean
+        groundFaultBreaker?: boolean;
         /** @default false */
-        smokeDetector?: boolean
+        smokeDetector?: boolean;
         /** @default false */
-        electricalSchema?: boolean
+        electricalSchema?: boolean;
         /** @default false */
-        electricalSystem?: boolean
-      }
+        electricalSystem?: boolean;
+      };
       /** Format: date-time */
-      date?: string
-      type?: string
-    }
+      date?: string;
+      type?: string;
+    };
     ComponentWriteBackError: {
-      componentId: string
-      componentLabel: string
-      message: string
-    }
+      componentId: string;
+      componentLabel: string;
+      message: string;
+    };
     AddInspectionRoomRequest: {
       /** @enum {string} */
-      roomTypeCode:
-        | 'BAD'
-        | 'BAL'
-        | 'BRS'
-        | 'DUSCH'
-        | 'FÖR'
-        | 'GROV'
-        | 'HALL'
-        | 'KLÄD'
-        | 'KÖK'
-        | 'KOV'
-        | 'KV'
-        | 'MAT'
-        | 'PA'
-        | 'RUM'
-        | 'TRAPP'
-        | 'UP'
-        | 'VARD'
-        | 'WC'
-        | 'WC/DU1'
-      caption?: string
-    }
+      roomTypeCode: "BAD" | "BAL" | "BRS" | "DUSCH" | "FÖR" | "GROV" | "HALL" | "KLÄD" | "KÖK" | "KOV" | "KV" | "MAT" | "PA" | "RUM" | "TRAPP" | "UP" | "VARD" | "WC" | "WC/DU1";
+      caption?: string;
+    };
     FileListItem: {
       /** @description Full file path/name */
-      name: string
+      name: string;
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string
+      lastModified: string;
       /** @description ETag for file version */
-      etag: string
+      etag: string;
       /** @description File size in bytes */
-      size: number
-    }
+      size: number;
+    };
     FileMetadata: {
       /** @description Full file path/name */
-      name: string
+      name: string;
       /**
        * Format: date-time
        * @description ISO 8601 timestamp
        */
-      lastModified: string
+      lastModified: string;
       /** @description ETag for file version */
-      etag: string
+      etag: string;
       /** @description File size in bytes */
-      size: number
+      size: number;
       /** @description Custom metadata key-value pairs */
       metaData?: {
-        [key: string]: string
-      }
-    }
+        [key: string]: string;
+      };
+    };
     FileUploadRequest: {
       /** @description Target file name/path */
-      fileName: string
+      fileName: string;
       /** @description Base64 encoded file content */
-      fileData: string
+      fileData: string;
       /** @description MIME type of the file */
-      contentType: string
-    }
+      contentType: string;
+    };
     FileUploadResponse: {
       /** @description Stored file name/path */
-      fileName: string
+      fileName: string;
       /** @description Success message */
-      message: string
-    }
+      message: string;
+    };
     FileUrlResponse: {
       /**
        * Format: uri
        * @description Presigned download URL
        */
-      url: string
+      url: string;
       /** @description URL expiry time in seconds */
-      expiresIn: number
-    }
+      expiresIn: number;
+    };
     FileExistsResponse: {
       /** @description Whether the file exists */
-      exists: boolean
-    }
+      exists: boolean;
+    };
     ListFilesResponse: {
       /** @description Array of file metadata objects */
       files: {
-        /** @description Full file path/name */
-        name: string
-        /**
-         * Format: date-time
-         * @description ISO 8601 timestamp
-         */
-        lastModified: string
-        /** @description ETag for file version */
-        etag: string
-        /** @description File size in bytes */
-        size: number
-      }[]
-    }
+          /** @description Full file path/name */
+          name: string;
+          /**
+           * Format: date-time
+           * @description ISO 8601 timestamp
+           */
+          lastModified: string;
+          /** @description ETag for file version */
+          etag: string;
+          /** @description File size in bytes */
+          size: number;
+        }[];
+    };
     ListFilesQuery: {
       /** @description Filter files by prefix */
-      prefix?: string
-    }
+      prefix?: string;
+    };
     FileUrlQuery: {
       /**
        * @description URL expiry time
        * @default 3600
        */
-      expirySeconds?: number
-    }
+      expirySeconds?: number;
+    };
     BulkSmsResult: {
       /** @description Phone numbers that received SMS */
-      successful: string[]
+      successful: string[];
       /** @description Invalid phone numbers */
-      invalid: string[]
-      totalSent: number
-      totalInvalid: number
-    }
+      invalid: string[];
+      totalSent: number;
+      totalInvalid: number;
+    };
     BulkEmailResult: {
       /** @description Email addresses that received email */
-      successful: string[]
+      successful: string[];
       /** @description Invalid email addresses */
-      invalid: string[]
-      totalSent: number
-      totalInvalid: number
-    }
+      invalid: string[];
+      totalSent: number;
+      totalInvalid: number;
+    };
     KeycloakUser: {
-      id?: string
-      username?: string
-      firstName?: string
-      lastName?: string
-      email?: string
-    }
+      id?: string;
+      username?: string;
+      firstName?: string;
+      lastName?: string;
+      email?: string;
+    };
     RentalPropertyResponse: {
       content?: {
-        id?: string
-        type?: string
+        id?: string;
+        type?: string;
         property?: {
-          rentalTypeCode?: string
-          rentalType?: string
-          address?: string
-          code?: string
-          number?: string
-          type?: string
-          roomTypeCode?: string
-          entrance?: string
-          floor?: string
-          hasElevator?: boolean
-          washSpace?: string
-          area?: number
-          estateCode?: string
-          estate?: string
-          buildingCode?: string
-          building?: string
-        }
-      }
+          rentalTypeCode?: string;
+          rentalType?: string;
+          address?: string;
+          code?: string;
+          number?: string;
+          type?: string;
+          roomTypeCode?: string;
+          entrance?: string;
+          floor?: string;
+          hasElevator?: boolean;
+          washSpace?: string;
+          area?: number;
+          estateCode?: string;
+          estate?: string;
+          buildingCode?: string;
+          building?: string;
+        };
+      };
       _links?: {
         self?: {
-          href?: string
-        }
+          href?: string;
+        };
         link?: {
-          href?: string
-          templated?: boolean
-        }
-      }
-    }
-    ContactV1:
-      | {
-          contactCode: string
-          communication: {
-            phoneNumbers: {
-              phoneNumber: string
-              /** @enum {string} */
-              type:
-                | 'work'
-                | 'home'
-                | 'mobile'
-                | 'direct-line'
-                | 'fax'
-                | 'pager'
-                | 'unspecified'
-              comment?: string
-              isPrimary: boolean
-            }[]
-            emailAddresses: {
-              emailAddress: string
-              type: string
-              isPrimary: boolean
-            }[]
-            specialAttention: boolean
-          }
-          addresses: {
-            careOf?: string
-            street: string | null
-            zipCode: string | null
-            city: string | null
-            region: string | null
-            country: string | null
-          }[]
-          /** @enum {string} */
-          type: 'individual'
-          personal: {
-            nationalRegistrationNumber: string | null
-            birthDate: string | null
-            firstName: string | null
-            lastName: string | null
-            fullName: string
-          }
-          trustee?: {
-            contactCode: string
-            fullName?: string
-          }
-        }
-      | {
-          contactCode: string
-          communication: {
-            phoneNumbers: {
-              phoneNumber: string
-              /** @enum {string} */
-              type:
-                | 'work'
-                | 'home'
-                | 'mobile'
-                | 'direct-line'
-                | 'fax'
-                | 'pager'
-                | 'unspecified'
-              comment?: string
-              isPrimary: boolean
-            }[]
-            emailAddresses: {
-              emailAddress: string
-              type: string
-              isPrimary: boolean
-            }[]
-            specialAttention: boolean
-          }
-          addresses: {
-            careOf?: string
-            street: string | null
-            zipCode: string | null
-            city: string | null
-            region: string | null
-            country: string | null
-          }[]
-          /** @enum {string} */
-          type: 'organisation'
-          organisation: {
-            organisationNumber: string
-            name: string
-          }
-        }
-  }
-  responses: never
-  parameters: never
-  requestBodies: never
-  headers: never
-  pathItems: never
+          href?: string;
+          templated?: boolean;
+        };
+      };
+    };
+    ContactV1: ({
+      contactCode: string;
+      communication: {
+        phoneNumbers: ({
+            phoneNumber: string;
+            /** @enum {string} */
+            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
+            comment?: string;
+            isPrimary: boolean;
+          })[];
+        emailAddresses: {
+            emailAddress: string;
+            type: string;
+            isPrimary: boolean;
+          }[];
+        specialAttention: boolean;
+      };
+      addresses: ({
+          careOf?: string;
+          street: string | null;
+          zipCode: string | null;
+          city: string | null;
+          region: string | null;
+          country: string | null;
+        })[];
+      /** @enum {string} */
+      type: "individual";
+      personal: {
+        nationalRegistrationNumber: string | null;
+        birthDate: string | null;
+        firstName: string | null;
+        lastName: string | null;
+        fullName: string;
+      };
+      trustee?: {
+        contactCode: string;
+        fullName?: string;
+      };
+    }) | ({
+      contactCode: string;
+      communication: {
+        phoneNumbers: ({
+            phoneNumber: string;
+            /** @enum {string} */
+            type: "work" | "home" | "mobile" | "direct-line" | "fax" | "pager" | "unspecified";
+            comment?: string;
+            isPrimary: boolean;
+          })[];
+        emailAddresses: {
+            emailAddress: string;
+            type: string;
+            isPrimary: boolean;
+          }[];
+        specialAttention: boolean;
+      };
+      addresses: ({
+          careOf?: string;
+          street: string | null;
+          zipCode: string | null;
+          city: string | null;
+          region: string | null;
+          country: string | null;
+        })[];
+      /** @enum {string} */
+      type: "organisation";
+      organisation: {
+        organisationNumber: string;
+        name: string;
+      };
+    });
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 
-export type $defs = Record<string, never>
+export type $defs = Record<string, never>;
 
-export type external = Record<string, never>
+export type external = Record<string, never>;
 
-export type operations = Record<string, never>
+export type operations = Record<string, never>;

--- a/apps/property-tree/src/services/api/core/workOrderService.ts
+++ b/apps/property-tree/src/services/api/core/workOrderService.ts
@@ -1,4 +1,4 @@
-import { GET } from './baseApi'
+import { GET, POST } from './baseApi'
 import { components } from './generated/api-types'
 
 export type InternalWorkOrder = {
@@ -8,6 +8,12 @@ export type ExternalWorkOrder = {
   _tag: 'external'
 } & components['schemas']['XpandWorkOrder']
 export type WorkOrder = InternalWorkOrder | ExternalWorkOrder
+
+export type MaintenanceTeam = components['schemas']['MaintenanceTeam']
+export type CreateInspectionWorkOrdersRequest =
+  components['schemas']['CreateInspectionWorkOrdersRequest']
+export type CreateInspectionWorkOrdersResponse =
+  components['schemas']['CreateInspectionWorkOrdersResponse']
 
 export const workOrderService = {
   async getWorkOrderForProperty(propertyId: string): Promise<WorkOrder[]> {
@@ -185,5 +191,28 @@ export const workOrderService = {
         ...v,
       })),
     ]
+  },
+
+  // Resursgrupper (maintenance teams) for the inspection work-order picker.
+  async getMaintenanceTeams(): Promise<MaintenanceTeam[]> {
+    const response = await GET('/work-orders/maintenance-teams', {})
+
+    if (response.error) throw new Error('Failed to fetch maintenance teams')
+    if (!response.data.content) throw new Error('No data returned from API')
+
+    return response.data.content
+  },
+
+  // Creates one work order per resursgrupp from an inspection (see core route).
+  async createInspectionWorkOrders(
+    body: CreateInspectionWorkOrdersRequest
+  ): Promise<CreateInspectionWorkOrdersResponse> {
+    const response = await POST('/work-orders/from-inspection', { body })
+
+    if (response.error)
+      throw new Error('Failed to create inspection work orders')
+    if (!response.data.content) throw new Error('No data returned from API')
+
+    return response.data.content
   },
 }

--- a/core/src/adapters/work-order-adapter/generated/api-types.ts
+++ b/core/src/adapters/work-order-adapter/generated/api-types.ts
@@ -3,11 +3,9 @@
  * Do not make direct changes to the file.
  */
 
-
 export interface paths {
-  "openapi": {
-  };
-  "/health": {
+  openapi: {}
+  '/health': {
     /**
      * Check system health status
      * @description Retrieves the health status of the system and its subsystems.
@@ -17,61 +15,60 @@ export interface paths {
         /** @description Successful response with system health status */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               /**
                * @description Name of the system.
                * @example work-order
                */
-              name?: string;
+              name?: string
               /**
                * @description Overall status of the system ('active', 'impaired', 'failure', 'unknown').
                * @example active
                */
-              status?: string;
-              subsystems?: ({
-                  /** @description Name of the subsystem. */
-                  name?: string;
-                  /**
-                   * @description Status of the subsystem.
-                   * @enum {string}
-                   */
-                  status?: "active" | "impaired" | "failure" | "unknown";
-                  /** @description Additional details about the subsystem status. */
-                  details?: string;
-                })[];
-            };
-          };
-        };
-      };
-    };
-  };
-  "/health/db": {
+              status?: string
+              subsystems?: {
+                /** @description Name of the subsystem. */
+                name?: string
+                /**
+                 * @description Status of the subsystem.
+                 * @enum {string}
+                 */
+                status?: 'active' | 'impaired' | 'failure' | 'unknown'
+                /** @description Additional details about the subsystem status. */
+                details?: string
+              }[]
+            }
+          }
+        }
+      }
+    }
+  }
+  '/health/db': {
     /** Database connection pool metrics */
     get: {
       responses: {
         /** @description Connection pool stats per configured DB connection. */
         200: {
           content: {
-            "application/json": {
-              connectionPools?: number;
+            'application/json': {
+              connectionPools?: number
               metrics?: {
-                  name?: string;
-                  pool?: {
-                    used?: number;
-                    free?: number;
-                    pendingCreates?: number;
-                    pendingAcquires?: number;
-                  };
-                }[];
-            };
-          };
-        };
-      };
-    };
-  };
-  "security": {
-  };
-  "/workOrders/contactCode/{contactCode}": {
+                name?: string
+                pool?: {
+                  used?: number
+                  free?: number
+                  pendingCreates?: number
+                  pendingAcquires?: number
+                }
+              }[]
+            }
+          }
+        }
+      }
+    }
+  }
+  security: {}
+  '/workOrders/contactCode/{contactCode}': {
     /**
      * Get work orders by contact code
      * @description Retrieves work orders based on the provided contact code.
@@ -80,37 +77,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The contact code to filter work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/contactCode/{contactCode}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/contactCode/{contactCode}': {
     /**
      * Get work orders by contact code from xpand
      * @description Retrieves work orders from xpand based on the provided contact code.
@@ -119,45 +116,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The contact code to filter work orders. */
-          contactCode: string;
-        };
-      };
+          contactCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/residenceId/{residenceId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/residenceId/{residenceId}': {
     /**
      * Get work orders by residence id
      * @description Retrieves work orders based on the provided residence id.
@@ -166,37 +163,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The residence id to filter work orders. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/propertyId/{propertyId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/propertyId/{propertyId}': {
     /**
      * Get work orders by property id
      * @description Retrieves work orders based on the provided property id.
@@ -205,37 +202,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The property id to filter work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/buildingId/{buildingId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/buildingId/{buildingId}': {
     /**
      * Get work orders by building id
      * @description Retrieves work orders based on the provided building id.
@@ -244,37 +241,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The building id to filter work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/maintenanceUnitCode/{maintenanceUnitCode}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/maintenanceUnitCode/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code
      * @description Retrieves a list of work orders based on maintenance unit code.
@@ -283,37 +280,37 @@ export interface paths {
       parameters: {
         path: {
           /** @description The maintenance unit code to filter work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["WorkOrder"][];
-              };
+                workOrders?: components['schemas']['WorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/residenceId/{residenceId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/residenceId/{residenceId}': {
     /**
      * Get work orders by residence id from xpand
      * @description Retrieves work orders from xpand based on the provided residence id.
@@ -322,45 +319,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The residence id to filter work orders. */
-          residenceId: string;
-        };
-      };
+          residenceId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/propertyId/{propertyId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/propertyId/{propertyId}': {
     /**
      * Get work orders by property id from xpand
      * @description Retrieves work orders from xpand based on the provided property id.
@@ -369,45 +366,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The property id to filter work orders. */
-          propertyId: string;
-        };
-      };
+          propertyId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/buildingId/{buildingId}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/buildingId/{buildingId}': {
     /**
      * Get work orders by building id from xpand
      * @description Retrieves work orders from xpand based on the provided building id.
@@ -416,45 +413,45 @@ export interface paths {
       parameters: {
         query?: {
           /** @description The number of work orders to skip. */
-          skip?: number;
+          skip?: number
           /** @description The number of work orders to fetch. */
-          limit?: number;
+          limit?: number
           /** @description Whether to sort the work orders by ascending creation date. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The building id to filter work orders. */
-          buildingId: string;
-        };
-      };
+          buildingId: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/maintenanceUnitCode/{maintenanceUnitCode}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/maintenanceUnitCode/{maintenanceUnitCode}': {
     /**
      * Get work orders by maintenance unit code from xpand
      * @description Retrieves a list of work orders from xpand based on maintenance unit code.
@@ -463,56 +460,56 @@ export interface paths {
       parameters: {
         query?: {
           /** @description Number of records to skip for pagination. */
-          skip?: number;
+          skip?: number
           /** @description Maximum number of records to return. */
-          limit?: number;
+          limit?: number
           /** @description Sort results in ascending order by creation time. */
-          sortAscending?: boolean;
-        };
+          sortAscending?: boolean
+        }
         path: {
           /** @description The maintenance unit code to filter work orders. */
-          maintenanceUnitCode: string;
-        };
-      };
+          maintenanceUnitCode: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work orders. */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
-                workOrders?: components["schemas"]["XpandWorkOrder"][];
-              };
+                workOrders?: components['schemas']['XpandWorkOrder'][]
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Bad request. Invalid query parameters. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @description Validation error details */
-              error?: Record<string, never>;
+              error?: Record<string, never>
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work orders. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/xpand/{code}": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/xpand/{code}': {
     /**
      * Get work order details by work order code from xpand
      * @description Retrieves work order details from xpand.
@@ -521,44 +518,44 @@ export interface paths {
       parameters: {
         path: {
           /** @description The work order code to fetch details for. */
-          code: string;
-        };
-      };
+          code: string
+        }
+      }
       responses: {
         /** @description Successfully retrieved work order. */
         200: {
           content: {
-            "application/json": {
-              content?: components["schemas"]["XpandWorkOrderDetails"];
+            'application/json': {
+              content?: components['schemas']['XpandWorkOrderDetails']
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Work order not found. */
         404: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Work order not found */
-              error?: string;
-            };
-          };
-        };
+              error?: string
+            }
+          }
+        }
         /** @description Internal server error. Failed to retrieve work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders': {
     /**
      * Create a new work order
      * @description Creates a new work order based on the provided request body.
@@ -566,49 +563,102 @@ export interface paths {
     post: {
       requestBody: {
         content: {
-          "application/json": components["schemas"]["CreateWorkOrderBody"];
-        };
-      };
+          'application/json': components['schemas']['CreateWorkOrderBody']
+        }
+      }
       responses: {
         /** @description Work order created successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @example 123 */
-                newWorkOrderId?: number;
-              };
+                newWorkOrderId?: number
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Bad request. Failed to create work order. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Error message from the adapter */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to create work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/{workOrderId}/update": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/maintenanceTeams': {
+    /**
+     * List maintenance teams (resursgrupper)
+     * @description Returns the selectable Odoo maintenance teams (resursgrupper).
+     */
+    get: {
+      responses: {
+        /** @description Maintenance teams retrieved successfully */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['MaintenanceTeam'][]
+            }
+          }
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/workOrders/fromInspection': {
+    /**
+     * Create work orders from an inspection (one per resursgrupp)
+     * @description Creates one maintenance.request per resursgrupp group. Each group is an independent Odoo commit, so the response reports per-group success/failure.
+     */
+    post: {
+      requestBody: {
+        content: {
+          'application/json': components['schemas']['CreateInspectionWorkOrdersBody']
+        }
+      }
+      responses: {
+        /** @description Work orders processed (see per-group results) */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['CreateInspectionWorkOrdersResponse']
+            }
+          }
+        }
+        /** @description Bad request. Invalid body. */
+        400: {
+          content: never
+        }
+        /** @description Internal server error. */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
+  '/workOrders/{workOrderId}/update': {
     /**
      * Add a message to a work order
      * @description Adds a message to a work order based on the provided work order ID.
@@ -617,60 +667,60 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to which the message will be added. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       requestBody: {
         content: {
-          "application/json": {
+          'application/json': {
             /**
              * @description The message to be added to the work order.
              * @example This is a new message for the work order.
              */
-            message?: string;
-          };
-        };
-      };
+            message?: string
+          }
+        }
+      }
       responses: {
         /** @description Message added to the work order successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @example Message added to work order with ID {workOrderId} */
-                message?: string;
-              };
+                message?: string
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Bad request. Message is missing from the request body. */
         400: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Message is missing from the request body */
-              reason?: string;
+              reason?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to add message to the work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Internal server error */
-              error?: string;
+              error?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
-  "/workOrders/{workOrderId}/close": {
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
+  '/workOrders/{workOrderId}/close': {
     /**
      * Close a work order
      * @description Closes a work order based on the provided work order ID.
@@ -679,269 +729,314 @@ export interface paths {
       parameters: {
         path: {
           /** @description The ID of the work order to be closed. */
-          workOrderId: string;
-        };
-      };
+          workOrderId: string
+        }
+      }
       responses: {
         /** @description Work order closed successfully */
         200: {
           content: {
-            "application/json": {
+            'application/json': {
               content?: {
                 /** @example Work order with ID {workOrderId} updated successfully */
-                message?: string;
-              };
+                message?: string
+              }
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
+              metadata?: Record<string, never>
+            }
+          }
+        }
         /** @description Internal server error. Failed to close work order. */
         500: {
           content: {
-            "application/json": {
+            'application/json': {
               /** @example Failed to update work order with ID {workOrderId} */
-              message?: string;
+              message?: string
               /** @description Route metadata */
-              metadata?: Record<string, never>;
-            };
-          };
-        };
-      };
-    };
-  };
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
-export type webhooks = Record<string, never>;
+export type webhooks = Record<string, never>
 
 export interface components {
   schemas: {
     WorkOrder: {
-      AccessCaption: string;
-      Caption: string;
-      Code: string;
-      ContactCode: string;
-      Description: string;
-      DetailsCaption: string;
-      ExternalResource: boolean;
-      Id: string;
+      AccessCaption: string
+      Caption: string
+      Code: string
+      ContactCode: string
+      Description: string
+      DetailsCaption: string
+      ExternalResource: boolean
+      Id: string
       /** Format: date-time */
-      LastChanged: string;
-      Priority: string;
+      LastChanged: string
+      Priority: string
       /** Format: date-time */
-      Registered: string;
-      DueDate: null | string;
-      RentalObjectCode: string;
-      Status: string;
-      UseMasterKey: boolean;
-      HiddenFromMyPages?: boolean;
-      WorkOrderRows: ({
-          Description: string | null;
-          LocationCode: string | null;
-          EquipmentCode: string | null;
-        })[];
+      Registered: string
+      DueDate: null | string
+      RentalObjectCode: string
+      Status: string
+      UseMasterKey: boolean
+      HiddenFromMyPages?: boolean
+      WorkOrderRows: {
+        Description: string | null
+        LocationCode: string | null
+        EquipmentCode: string | null
+      }[]
       Messages?: {
-          id: number;
-          body: string;
-          messageType: string;
-          author: string;
-          /** Format: date-time */
-          createDate: string;
-        }[];
-      Url?: string;
-    };
+        id: number
+        body: string
+        messageType: string
+        author: string
+        /** Format: date-time */
+        createDate: string
+      }[]
+      Url?: string
+    }
     XpandWorkOrder: {
-      AccessCaption: string;
-      Caption: string | null;
-      Code: string;
-      ContactCode: string | null;
-      Id: string;
+      AccessCaption: string
+      Caption: string | null
+      Code: string
+      ContactCode: string | null
+      Id: string
       /** Format: date-time */
-      LastChanged: string;
-      Priority: string | null;
+      LastChanged: string
+      Priority: string | null
       /** Format: date-time */
-      Registered: string;
-      DueDate: null | string;
-      RentalObjectCode: string;
-      Status: string;
-    };
+      Registered: string
+      DueDate: null | string
+      RentalObjectCode: string
+      Status: string
+    }
     XpandWorkOrderDetails: {
-      AccessCaption: string;
-      Caption: string | null;
-      Code: string;
-      ContactCode: string | null;
-      Description: string;
-      Id: string;
+      AccessCaption: string
+      Caption: string | null
+      Code: string
+      ContactCode: string | null
+      Description: string
+      Id: string
       /** Format: date-time */
-      LastChanged: string;
-      Priority: string | null;
+      LastChanged: string
+      Priority: string | null
       /** Format: date-time */
-      Registered: string;
-      DueDate: null | string;
-      RentalObjectCode: string;
-      Status: string;
-      WorkOrderRows: ({
-          Description: string | null;
-          LocationCode: string | null;
-          EquipmentCode: string | null;
-        })[];
-    };
+      Registered: string
+      DueDate: null | string
+      RentalObjectCode: string
+      Status: string
+      WorkOrderRows: {
+        Description: string | null
+        LocationCode: string | null
+        EquipmentCode: string | null
+      }[]
+    }
     CreateWorkOrderBody: {
       rentalProperty: {
-        id: string;
-        type: string;
+        id: string
+        type: string
         property: {
-          address: string;
-          code: string;
-          entrance: string;
-          floor: string;
-          hasElevator: boolean;
-          washSpace: string | null;
-          area: number;
-          estateCode: string | null;
-          estate: string | null;
-          buildingCode: string;
-          building: string;
-        };
-        maintenanceUnits?: ({
-            id: string;
-            rentalPropertyId: string;
-            code: string;
-            caption: string;
-            type: string;
-            estateCode: string | null;
-            estate: string | null;
-          })[];
-      };
+          address: string
+          code: string
+          entrance: string
+          floor: string
+          hasElevator: boolean
+          washSpace: string | null
+          area: number
+          estateCode: string | null
+          estate: string | null
+          buildingCode: string
+          building: string
+        }
+        maintenanceUnits?: {
+          id: string
+          rentalPropertyId: string
+          code: string
+          caption: string
+          type: string
+          estateCode: string | null
+          estate: string | null
+        }[]
+      }
       tenant: {
-        contactCode: string;
-        contactKey: string;
-        firstName?: string;
-        lastName?: string;
-        nationalRegistrationNumber?: string;
+        contactCode: string
+        contactKey: string
+        firstName?: string
+        lastName?: string
+        nationalRegistrationNumber?: string
         phoneNumbers?: {
-            phoneNumber: string;
-            type: string;
-            isMainNumber: number;
-          }[];
-        emailAddress?: string;
-      };
+          phoneNumber: string
+          type: string
+          isMainNumber: number
+        }[]
+        emailAddress?: string
+      }
       lease: {
-        leaseId: string;
-        leaseNumber: string;
-        type: string;
-        leaseStartDate: string;
-        leaseEndDate?: unknown;
-        contractDate?: string;
-        approvalDate?: string;
-      };
+        leaseId: string
+        leaseNumber: string
+        type: string
+        leaseStartDate: string
+        leaseEndDate?: unknown
+        contractDate?: string
+        approvalDate?: string
+      }
       details: {
-        ContactCode: string;
-        RentalObjectCode: string;
+        ContactCode: string
+        RentalObjectCode: string
         AccessOptions: {
-          Type: number;
-          PhoneNumber: string | null;
-          Email: string;
-          CallBetween: string;
-        };
-        HearingImpaired: boolean;
-        Pet: string;
+          Type: number
+          PhoneNumber: string | null
+          Email: string
+          CallBetween: string
+        }
+        HearingImpaired: boolean
+        Pet: string
         Rows: {
-            LocationCode: string;
-            PartOfBuildingCode: string;
-            Description: string;
-            MaintenanceUnitCode?: unknown;
-            MaintenanceUnitCaption?: unknown;
-          }[];
+          LocationCode: string
+          PartOfBuildingCode: string
+          Description: string
+          MaintenanceUnitCode?: unknown
+          MaintenanceUnitCaption?: unknown
+        }[]
         Images: {
-            Filename: string;
-            ImageType: number;
-            Base64String: string;
-          }[];
-      };
-    };
+          Filename: string
+          ImageType: number
+          Base64String: string
+        }[]
+      }
+    }
     CreateWorkOrderDetails: {
-      ContactCode: string;
-      RentalObjectCode: string;
+      ContactCode: string
+      RentalObjectCode: string
       AccessOptions: {
-        Type: number;
-        PhoneNumber: string | null;
-        Email: string;
-        CallBetween: string;
-      };
-      HearingImpaired: boolean;
-      Pet: string;
+        Type: number
+        PhoneNumber: string | null
+        Email: string
+        CallBetween: string
+      }
+      HearingImpaired: boolean
+      Pet: string
       Rows: {
-          LocationCode: string;
-          PartOfBuildingCode: string;
-          Description: string;
-          MaintenanceUnitCode?: unknown;
-          MaintenanceUnitCaption?: unknown;
-        }[];
+        LocationCode: string
+        PartOfBuildingCode: string
+        Description: string
+        MaintenanceUnitCode?: unknown
+        MaintenanceUnitCaption?: unknown
+      }[]
       Images: {
-          Filename: string;
-          ImageType: number;
-          Base64String: string;
-        }[];
-    };
+        Filename: string
+        ImageType: number
+        Base64String: string
+      }[]
+    }
     Lease: {
-      leaseId: string;
-      leaseNumber: string;
-      type: string;
-      leaseStartDate: string;
-      leaseEndDate?: unknown;
-      contractDate?: string;
-      approvalDate?: string;
-    };
+      leaseId: string
+      leaseNumber: string
+      type: string
+      leaseStartDate: string
+      leaseEndDate?: unknown
+      contractDate?: string
+      approvalDate?: string
+    }
     Tenant: {
-      contactCode: string;
-      contactKey: string;
-      firstName?: string;
-      lastName?: string;
-      nationalRegistrationNumber?: string;
+      contactCode: string
+      contactKey: string
+      firstName?: string
+      lastName?: string
+      nationalRegistrationNumber?: string
       phoneNumbers?: {
-          phoneNumber: string;
-          type: string;
-          isMainNumber: number;
-        }[];
-      emailAddress?: string;
-    };
+        phoneNumber: string
+        type: string
+        isMainNumber: number
+      }[]
+      emailAddress?: string
+    }
     RentalProperty: {
-      id: string;
-      type: string;
+      id: string
+      type: string
       property: {
-        address: string;
-        code: string;
-        entrance: string;
-        floor: string;
-        hasElevator: boolean;
-        washSpace: string | null;
-        area: number;
-        estateCode: string | null;
-        estate: string | null;
-        buildingCode: string;
-        building: string;
-      };
-      maintenanceUnits?: ({
-          id: string;
-          rentalPropertyId: string;
-          code: string;
-          caption: string;
-          type: string;
-          estateCode: string | null;
-          estate: string | null;
-        })[];
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+        address: string
+        code: string
+        entrance: string
+        floor: string
+        hasElevator: boolean
+        washSpace: string | null
+        area: number
+        estateCode: string | null
+        estate: string | null
+        buildingCode: string
+        building: string
+      }
+      maintenanceUnits?: {
+        id: string
+        rentalPropertyId: string
+        code: string
+        caption: string
+        type: string
+        estateCode: string | null
+        estate: string | null
+      }[]
+    }
+    MaintenanceTeam: {
+      id: number
+      name: string
+    }
+    CreateInspectionWorkOrdersBody: {
+      rentalProperty: {
+        id: string
+        type: string
+        property: {
+          address: string
+          code: string
+          entrance: string
+          floor: string
+          hasElevator: boolean
+          washSpace: string | null
+          area: number
+          estateCode: string | null
+          estate: string | null
+          buildingCode: string
+          building: string
+        }
+        maintenanceUnits?: {
+          id: string
+          rentalPropertyId: string
+          code: string
+          caption: string
+          type: string
+          estateCode: string | null
+          estate: string | null
+        }[]
+      }
+      groups: {
+        maintenanceTeamId: number
+        maintenanceTeamName: string
+        descriptionHtml: string
+      }[]
+    }
+    CreateInspectionWorkOrdersResponse: {
+      results: {
+        maintenanceTeamId: number
+        ok: boolean
+        workOrderId?: number
+        err?: string
+      }[]
+    }
+  }
+  responses: never
+  parameters: never
+  requestBodies: never
+  headers: never
+  pathItems: never
 }
 
-export type $defs = Record<string, never>;
+export type $defs = Record<string, never>
 
-export type external = Record<string, never>;
+export type external = Record<string, never>
 
-export type operations = Record<string, never>;
+export type operations = Record<string, never>

--- a/core/src/adapters/work-order-adapter/index.ts
+++ b/core/src/adapters/work-order-adapter/index.ts
@@ -1,10 +1,15 @@
 import createClient from 'openapi-fetch'
+import { z } from 'zod'
 import { logger } from '@onecore/utilities'
 import config from '../../common/config'
 import { AdapterResult } from '../types'
 import {
+  CreateInspectionWorkOrdersResponse,
+  CreateInspectionWorkOrdersResponseSchema,
   CreateWorkOrderResponse,
   CreateWorkOrderResponseSchema,
+  MaintenanceTeam,
+  MaintenanceTeamSchema,
 } from '../../services/work-order-service/schemas'
 import { components, paths } from './generated/api-types'
 
@@ -428,6 +433,63 @@ export const createWorkOrder = async (
     logger.error({ error }, 'work-order-adapter.createWorkOrder')
     const errorMessage = error instanceof Error ? error.message : 'unknown'
     return { ok: false, err: errorMessage }
+  }
+}
+
+export const getMaintenanceTeams = async (): Promise<
+  AdapterResult<
+    MaintenanceTeam[],
+    'request-failed' | 'schema-error' | 'request-error'
+  >
+> => {
+  try {
+    const fetchResponse = await client().GET('/workOrders/maintenanceTeams', {})
+
+    if (fetchResponse.error) {
+      return { ok: false, err: 'request-failed' }
+    }
+
+    const parsed = z
+      .array(MaintenanceTeamSchema)
+      .safeParse(fetchResponse.data?.content)
+    if (!parsed.success) {
+      return { ok: false, err: 'schema-error' }
+    }
+
+    return { ok: true, data: parsed.data }
+  } catch (error) {
+    logger.error({ error }, 'work-order-adapter.getMaintenanceTeams')
+    return { ok: false, err: 'request-error' }
+  }
+}
+
+export const createInspectionWorkOrders = async (
+  body: components['schemas']['CreateInspectionWorkOrdersBody']
+): Promise<
+  AdapterResult<
+    CreateInspectionWorkOrdersResponse,
+    'request-failed' | 'schema-error' | 'request-error'
+  >
+> => {
+  try {
+    const fetchResponse = await client().POST('/workOrders/fromInspection', {
+      body,
+    })
+
+    if (fetchResponse.data?.content) {
+      const parsed = CreateInspectionWorkOrdersResponseSchema.safeParse(
+        fetchResponse.data.content
+      )
+      if (!parsed.success) {
+        return { ok: false, err: 'schema-error' }
+      }
+      return { ok: true, data: parsed.data }
+    }
+
+    return { ok: false, err: 'request-failed' }
+  } catch (error) {
+    logger.error({ error }, 'work-order-adapter.createInspectionWorkOrders')
+    return { ok: false, err: 'request-error' }
   }
 }
 

--- a/core/src/services/work-order-service/index.ts
+++ b/core/src/services/work-order-service/index.ts
@@ -14,6 +14,18 @@ interface RentalPropertyInfoWithLeases extends RentalPropertyInfo {
   leases: Lease[]
 }
 
+/*
+  Work-order creation requires apartment fields (maintenance.rental.property in
+  Odoo). We know rentalPropertyInfo.property is of type ApartmentInfo when the
+  type is 'Lägenhet', but that is not reflected in the RentalPropertyInfo type,
+  so we do a little narrowing.
+*/
+const rentalPropertyIsApartment = (
+  rentalPropertyInfo: RentalPropertyInfo
+): rentalPropertyInfo is RentalPropertyInfo & {
+  property: ApartmentInfo
+} => rentalPropertyInfo.type === 'Lägenhet'
+
 /**
  * @swagger
  * openapi: 3.0.0
@@ -1597,16 +1609,6 @@ export const routes = (router: KoaRouter) => {
         return
       }
 
-      /*
-        We know that rentalPropertyInfo.property is of type ApartmentInfo here,
-        but that is not reflected in the RentalPropertyInfo type, so we do a little narrowing
-      */
-      const rentalPropertyIsApartment = (
-        rentalPropertyInfo: RentalPropertyInfo
-      ): rentalPropertyInfo is RentalPropertyInfo & {
-        property: ApartmentInfo
-      } => rentalPropertyInfo.type === 'Lägenhet'
-
       if (!rentalPropertyIsApartment(rentalPropertyInfo)) {
         ctx.status = 400
         ctx.body = {
@@ -1761,7 +1763,7 @@ export const routes = (router: KoaRouter) => {
       )
       if (!parsed.success) {
         ctx.status = 400
-        ctx.body = { error: 'Invalid request body', ...metadata }
+        ctx.body = { reason: 'Invalid request body', ...metadata }
         return
       }
 
@@ -1774,13 +1776,6 @@ export const routes = (router: KoaRouter) => {
         ctx.body = { reason: 'Rental property not found', ...metadata }
         return
       }
-
-      // maintenance.rental.property needs apartment fields; inspections are
-      // always apartments, so narrow the type (mirrors POST /work-orders).
-      const rentalPropertyIsApartment = (
-        info: RentalPropertyInfo
-      ): info is RentalPropertyInfo & { property: ApartmentInfo } =>
-        info.type === 'Lägenhet'
 
       if (!rentalPropertyIsApartment(rentalPropertyInfo)) {
         ctx.status = 400
@@ -1812,7 +1807,7 @@ export const routes = (router: KoaRouter) => {
       ctx.status = 200
       ctx.body = { content: result.data, ...metadata }
     } catch (error) {
-      logger.error(error, 'Error creating inspection work orders')
+      logger.error({ err: error }, 'Error creating inspection work orders')
       ctx.status = 500
       ctx.body = {
         error: 'Failed to create inspection work orders',

--- a/core/src/services/work-order-service/index.ts
+++ b/core/src/services/work-order-service/index.ts
@@ -32,6 +32,15 @@ interface RentalPropertyInfoWithLeases extends RentalPropertyInfo {
 export const routes = (router: KoaRouter) => {
   registerSchema('WorkOrder', schemas.CoreWorkOrderSchema)
   registerSchema('XpandWorkOrder', schemas.CoreXpandWorkOrderSchema)
+  registerSchema('MaintenanceTeam', schemas.MaintenanceTeamSchema)
+  registerSchema(
+    'CreateInspectionWorkOrdersRequest',
+    schemas.CreateInspectionWorkOrdersRequestSchema
+  )
+  registerSchema(
+    'CreateInspectionWorkOrdersResponse',
+    schemas.CreateInspectionWorkOrdersResponseSchema
+  )
 
   /**
    * @swagger
@@ -1663,6 +1672,150 @@ export const routes = (router: KoaRouter) => {
       ctx.status = 500
       ctx.body = {
         error: 'Failed to create new work orders',
+        ...metadata,
+      }
+    }
+  })
+
+  /**
+   * @swagger
+   * /work-orders/maintenance-teams:
+   *   get:
+   *     summary: List maintenance teams (resursgrupper)
+   *     tags:
+   *       - Work Order Service
+   *     description: Returns the selectable Odoo maintenance teams (resursgrupper) for the inspection work-order picker.
+   *     responses:
+   *       '200':
+   *         description: Maintenance teams retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/MaintenanceTeam'
+   *       '500':
+   *         description: Internal server error.
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('/work-orders/maintenance-teams', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const result = await workOrderAdapter.getMaintenanceTeams()
+
+    if (!result.ok) {
+      logger.error({ err: result.err }, 'Error fetching maintenance teams')
+      ctx.status = 500
+      ctx.body = { error: 'Failed to fetch maintenance teams', ...metadata }
+      return
+    }
+
+    ctx.status = 200
+    ctx.body = { content: result.data, ...metadata }
+  })
+
+  /**
+   * @swagger
+   * /work-orders/from-inspection:
+   *   post:
+   *     summary: Create work orders from an inspection (one per resursgrupp)
+   *     tags:
+   *       - Work Order Service
+   *     description: >
+   *       Resolves the apartment from rentalObjectCode, then creates one work order
+   *       per resursgrupp group. Each group is an independent Odoo commit, so the
+   *       response reports per-group success/failure.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/CreateInspectionWorkOrdersRequest'
+   *     responses:
+   *       '200':
+   *         description: Work orders processed (see per-group results)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   $ref: '#/components/schemas/CreateInspectionWorkOrdersResponse'
+   *       '400':
+   *         description: Bad request (invalid body or not an apartment).
+   *       '404':
+   *         description: Rental property not found.
+   *       '500':
+   *         description: Internal server error.
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.post('/work-orders/from-inspection', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    try {
+      const parsed = schemas.CreateInspectionWorkOrdersRequestSchema.safeParse(
+        ctx.request.body
+      )
+      if (!parsed.success) {
+        ctx.status = 400
+        ctx.body = { error: 'Invalid request body', ...metadata }
+        return
+      }
+
+      const { rentalObjectCode, groups } = parsed.data
+
+      const rentalPropertyInfo =
+        await propertyManagementAdapter.getRentalPropertyInfo(rentalObjectCode)
+      if (!rentalPropertyInfo) {
+        ctx.status = 404
+        ctx.body = { reason: 'Rental property not found', ...metadata }
+        return
+      }
+
+      // maintenance.rental.property needs apartment fields; inspections are
+      // always apartments, so narrow the type (mirrors POST /work-orders).
+      const rentalPropertyIsApartment = (
+        info: RentalPropertyInfo
+      ): info is RentalPropertyInfo & { property: ApartmentInfo } =>
+        info.type === 'Lägenhet'
+
+      if (!rentalPropertyIsApartment(rentalPropertyInfo)) {
+        ctx.status = 400
+        ctx.body = {
+          reason: 'Rental property is not an apartment',
+          ...metadata,
+        }
+        return
+      }
+
+      const result = await workOrderAdapter.createInspectionWorkOrders({
+        rentalProperty: rentalPropertyInfo,
+        groups,
+      })
+
+      if (!result.ok) {
+        logger.error(
+          { err: result.err },
+          'Error creating inspection work orders'
+        )
+        ctx.status = 500
+        ctx.body = {
+          error: 'Failed to create inspection work orders',
+          ...metadata,
+        }
+        return
+      }
+
+      ctx.status = 200
+      ctx.body = { content: result.data, ...metadata }
+    } catch (error) {
+      logger.error(error, 'Error creating inspection work orders')
+      ctx.status = 500
+      ctx.body = {
+        error: 'Failed to create inspection work orders',
         ...metadata,
       }
     }

--- a/core/src/services/work-order-service/schemas.ts
+++ b/core/src/services/work-order-service/schemas.ts
@@ -75,6 +75,36 @@ export const CreateWorkOrderResponseSchema = z.object({
   newWorkOrderId: z.number(),
 })
 
+// Odoo "Resursgrupp" (maintenance team) shown in the inspection picker.
+export const MaintenanceTeamSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+
+// Frontend → core: the inspector groups damaged components by resursgrupp. Core
+// resolves the rental property from `rentalObjectCode` before calling the service.
+export const CreateInspectionWorkOrdersGroupSchema = z.object({
+  maintenanceTeamId: z.number(),
+  maintenanceTeamName: z.string(),
+  descriptionHtml: z.string(),
+})
+
+export const CreateInspectionWorkOrdersRequestSchema = z.object({
+  rentalObjectCode: z.string(),
+  groups: z.array(CreateInspectionWorkOrdersGroupSchema).min(1),
+})
+
+export const CreateInspectionWorkOrderResultSchema = z.object({
+  maintenanceTeamId: z.number(),
+  ok: z.boolean(),
+  workOrderId: z.number().optional(),
+  err: z.string().optional(),
+})
+
+export const CreateInspectionWorkOrdersResponseSchema = z.object({
+  results: z.array(CreateInspectionWorkOrderResultSchema),
+})
+
 export const GetWorkOrdersFromXpandQuerySchema = z.object({
   skip: z.coerce.number().optional(),
   limit: z.coerce.number().optional(),
@@ -92,4 +122,11 @@ export type CoreXpandWorkOrderDetails = z.infer<
 >
 export type CreateWorkOrderResponse = z.infer<
   typeof CreateWorkOrderResponseSchema
+>
+export type MaintenanceTeam = z.infer<typeof MaintenanceTeamSchema>
+export type CreateInspectionWorkOrdersRequest = z.infer<
+  typeof CreateInspectionWorkOrdersRequestSchema
+>
+export type CreateInspectionWorkOrdersResponse = z.infer<
+  typeof CreateInspectionWorkOrdersResponseSchema
 >

--- a/core/src/services/work-order-service/schemas.ts
+++ b/core/src/services/work-order-service/schemas.ts
@@ -83,7 +83,7 @@ export const MaintenanceTeamSchema = z.object({
 
 // Frontend → core: the inspector groups damaged components by resursgrupp. Core
 // resolves the rental property from `rentalObjectCode` before calling the service.
-export const CreateInspectionWorkOrdersGroupSchema = z.object({
+const CreateInspectionWorkOrdersGroupSchema = z.object({
   maintenanceTeamId: z.number(),
   maintenanceTeamName: z.string(),
   descriptionHtml: z.string(),
@@ -94,7 +94,7 @@ export const CreateInspectionWorkOrdersRequestSchema = z.object({
   groups: z.array(CreateInspectionWorkOrdersGroupSchema).min(1),
 })
 
-export const CreateInspectionWorkOrderResultSchema = z.object({
+const CreateInspectionWorkOrderResultSchema = z.object({
   maintenanceTeamId: z.number(),
   ok: z.boolean(),
   workOrderId: z.number().optional(),
@@ -124,9 +124,6 @@ export type CreateWorkOrderResponse = z.infer<
   typeof CreateWorkOrderResponseSchema
 >
 export type MaintenanceTeam = z.infer<typeof MaintenanceTeamSchema>
-export type CreateInspectionWorkOrdersRequest = z.infer<
-  typeof CreateInspectionWorkOrdersRequestSchema
->
 export type CreateInspectionWorkOrdersResponse = z.infer<
   typeof CreateInspectionWorkOrdersResponseSchema
 >

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -2,6 +2,7 @@ import Odoo from 'odoo-await'
 import striptags from 'striptags'
 import { groupBy } from 'lodash'
 import z from 'zod'
+import { logger } from '@onecore/utilities'
 import Config from '../../../../common/config'
 import {
   transformWorkOrder,
@@ -10,9 +11,12 @@ import {
 } from './utils'
 import { AdapterResult } from '../../types'
 import {
+  CreateInspectionWorkOrderGroup,
+  CreateInspectionWorkOrderResult,
   CreateWorkOrderDetails,
   CreateWorkOrderRow,
   Lease,
+  MaintenanceTeam,
   MaintenanceUnit,
   OdooWorkOrder,
   OdooWorkOrderMessage,
@@ -21,6 +25,11 @@ import {
   WorkOrder,
   WorkOrderMessage,
 } from '../../schemas'
+
+// Inspection-origin work orders all use this category + space; resolved by name
+// at runtime because Odoo ids differ per environment.
+const INSPECTION_WORK_ORDER_CATEGORY = 'Besiktning'
+const INSPECTION_SPACE_CAPTION = 'Lägenhet'
 
 const odoo = new Odoo({
   baseUrl: Config.odoo.url,
@@ -538,6 +547,110 @@ const getMaintenanceRequestCategoryId = async (
   } catch (error) {
     console.error('Error getting maintenance request category id:', error)
     throw error
+  }
+}
+
+const getMaintenanceRequestCategoryIdByName = async (
+  name: string
+): Promise<number> => {
+  const categories: number[] = await odoo.search(
+    'maintenance.request.category',
+    { name }
+  )
+  if (categories.length === 0) {
+    throw new Error(`Maintenance request category "${name}" not found`)
+  }
+  return categories[0]
+}
+
+// Lists the selectable resursgrupper (maintenance teams) for the inspection UI.
+export const getMaintenanceTeams = async (): Promise<
+  AdapterResult<MaintenanceTeam[], unknown>
+> => {
+  try {
+    await odoo.connect()
+    const teams = await odoo.searchRead<MaintenanceTeam>(
+      'maintenance.team',
+      [],
+      ['id', 'name']
+    )
+    return { ok: true, data: teams }
+  } catch (error) {
+    logger.error({ err: error }, 'odooAdapter.getMaintenanceTeams')
+    return { ok: false, err: error }
+  }
+}
+
+/**
+ * Creates one work order per resursgrupp from an inspection. For each group we
+ * replicate what the Odoo create form's Save does server-side (its field
+ * population is @api.onchange UI-only and does not run on XML-RPC create):
+ * create a per-request maintenance.rental.property child from the residence
+ * info, then the maintenance.request with the chosen team + Besiktning category,
+ * then back-ref the child so it cascade-deletes with the request.
+ *
+ * Each group is an independent Odoo commit, so one failure does not abort the
+ * rest — the per-group outcome is returned to the caller.
+ */
+export const createInspectionWorkOrders = async (
+  rentalProperty: RentalProperty,
+  groups: CreateInspectionWorkOrderGroup[]
+): Promise<AdapterResult<CreateInspectionWorkOrderResult[], unknown>> => {
+  try {
+    await odoo.connect()
+    const categoryId = await getMaintenanceRequestCategoryIdByName(
+      INSPECTION_WORK_ORDER_CATEGORY
+    )
+
+    const results: CreateInspectionWorkOrderResult[] = []
+    for (const group of groups) {
+      try {
+        // One rental-property child per request (it cascade-deletes with it).
+        const rentalPropertyRecord =
+          await createRentalPropertyRecord(rentalProperty)
+
+        const workOrderId = await odoo.create('maintenance.request', {
+          name: `Besiktning ${rentalProperty.id} – ${group.maintenanceTeamName}`,
+          space_caption: INSPECTION_SPACE_CAPTION,
+          description: group.descriptionHtml,
+          rental_property_id: rentalPropertyRecord.toString(),
+          maintenance_team_id: group.maintenanceTeamId,
+          maintenance_request_category_id: categoryId,
+          priority_expanded: '7',
+          search_type: 'rentalObjectId',
+          search_value: rentalProperty.id,
+          // creation_origin: 'inspection' is intentionally omitted — Odoo rejects
+          // Selection values not in CREATION_ORIGINS. Re-add once the Odoo side
+          // adds the 'inspection' origin (the field is nullable, so omitting is safe).
+        })
+
+        // Back-ref so the child cascade-deletes with the request (matches Save).
+        await odoo.update('maintenance.rental.property', rentalPropertyRecord, {
+          maintenance_request_id: workOrderId,
+        })
+
+        results.push({
+          maintenanceTeamId: group.maintenanceTeamId,
+          ok: true,
+          workOrderId,
+        })
+      } catch (error) {
+        logger.error(
+          { err: error, maintenanceTeamId: group.maintenanceTeamId },
+          'odooAdapter.createInspectionWorkOrders.group'
+        )
+        results.push({
+          maintenanceTeamId: group.maintenanceTeamId,
+          ok: false,
+          err: error instanceof Error ? error.message : 'unknown',
+        })
+      }
+    }
+
+    return { ok: true, data: results }
+  } catch (error) {
+    logger.error({ err: error }, 'odooAdapter.createInspectionWorkOrders')
+    return { ok: false, err: error }
   }
 }
 

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -617,6 +617,9 @@ export const createInspectionWorkOrders = async (
           maintenance_team_id: group.maintenanceTeamId,
           maintenance_request_category_id: categoryId,
           priority_expanded: '7',
+          // search_type/search_value mirror what the Odoo create form stores
+          // when an agent looks up the property — odoo-onecore uses them to
+          // show how the request was matched to the rental object.
           search_type: 'rentalObjectId',
           search_value: rentalProperty.id,
           // creation_origin: 'inspection' is intentionally omitted — Odoo rejects

--- a/services/work-order/src/services/work-order-service/index.ts
+++ b/services/work-order/src/services/work-order-service/index.ts
@@ -2,10 +2,13 @@ import KoaRouter from '@koa/router'
 import { generateRouteMetadata, logger } from '@onecore/utilities'
 import * as odooAdapter from './adapters/odoo-adapter'
 import {
+  CreateInspectionWorkOrdersBodySchema,
+  CreateInspectionWorkOrdersResponseSchema,
   CreateWorkOrderBodySchema,
   CreateWorkOrderDetailsSchema,
   GetWorkOrdersFromXpandQuerySchema,
   LeaseSchema,
+  MaintenanceTeamSchema,
   RentalPropertySchema,
   TenantSchema,
   WorkOrder,
@@ -41,6 +44,15 @@ export const routes = (router: KoaRouter) => {
   registerSchema('Lease', LeaseSchema)
   registerSchema('Tenant', TenantSchema)
   registerSchema('RentalProperty', RentalPropertySchema)
+  registerSchema('MaintenanceTeam', MaintenanceTeamSchema)
+  registerSchema(
+    'CreateInspectionWorkOrdersBody',
+    CreateInspectionWorkOrdersBodySchema
+  )
+  registerSchema(
+    'CreateInspectionWorkOrdersResponse',
+    CreateInspectionWorkOrdersResponseSchema
+  )
 
   /**
    * @swagger
@@ -1223,6 +1235,122 @@ export const routes = (router: KoaRouter) => {
         ctx.status = 400
         ctx.body = {
           error: response.err,
+          ...metadata,
+        }
+      }
+    } catch (error: unknown) {
+      ctx.status = 500
+
+      if (error instanceof Error) {
+        ctx.body = {
+          error: error.message,
+          ...metadata,
+        }
+      }
+    }
+  })
+
+  /**
+   * @swagger
+   * /workOrders/maintenanceTeams:
+   *   get:
+   *     summary: List maintenance teams (resursgrupper)
+   *     tags:
+   *       - Work Order Service
+   *     description: Returns the selectable Odoo maintenance teams (resursgrupper).
+   *     responses:
+   *       '200':
+   *         description: Maintenance teams retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: array
+   *                   items:
+   *                     $ref: '#/components/schemas/MaintenanceTeam'
+   *       '500':
+   *         description: Internal server error.
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('(.*)/workOrders/maintenanceTeams', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    const result = await odooAdapter.getMaintenanceTeams()
+    if (result.ok) {
+      ctx.status = 200
+      ctx.body = { content: result.data, ...metadata }
+    } else {
+      ctx.status = 500
+      ctx.body = { error: 'Failed to get maintenance teams', ...metadata }
+    }
+  })
+
+  /**
+   * @swagger
+   * /workOrders/fromInspection:
+   *   post:
+   *     summary: Create work orders from an inspection (one per resursgrupp)
+   *     tags:
+   *       - Work Order Service
+   *     description: >
+   *       Creates one maintenance.request per resursgrupp group. Each group is an
+   *       independent Odoo commit, so the response reports per-group success/failure.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/CreateInspectionWorkOrdersBody'
+   *     responses:
+   *       '200':
+   *         description: Work orders processed (see per-group results)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   $ref: '#/components/schemas/CreateInspectionWorkOrdersResponse'
+   *       '400':
+   *         description: Bad request. Invalid body.
+   *       '500':
+   *         description: Internal server error.
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.post('(.*)/workOrders/fromInspection', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    try {
+      const parsedBody = CreateInspectionWorkOrdersBodySchema.safeParse(
+        ctx.request.body
+      )
+      if (!parsedBody.success) {
+        ctx.status = 400
+        ctx.body = {
+          error: parsedBody.error,
+          ...metadata,
+        }
+        return
+      }
+
+      const { rentalProperty, groups } = parsedBody.data
+      const result = await odooAdapter.createInspectionWorkOrders(
+        rentalProperty,
+        groups
+      )
+
+      if (result.ok) {
+        ctx.status = 200
+        ctx.body = {
+          content: { results: result.data },
+          ...metadata,
+        }
+      } else {
+        ctx.status = 500
+        ctx.body = {
+          error: 'Failed to create inspection work orders',
           ...metadata,
         }
       }

--- a/services/work-order/src/services/work-order-service/index.ts
+++ b/services/work-order/src/services/work-order-service/index.ts
@@ -1355,13 +1355,17 @@ export const routes = (router: KoaRouter) => {
         }
       }
     } catch (error: unknown) {
+      logger.error(
+        { err: error },
+        'work-order-service.createInspectionWorkOrders'
+      )
       ctx.status = 500
-
-      if (error instanceof Error) {
-        ctx.body = {
-          error: error.message,
-          ...metadata,
-        }
+      ctx.body = {
+        error:
+          error instanceof Error
+            ? error.message
+            : 'Failed to create inspection work orders',
+        ...metadata,
       }
     }
   })

--- a/services/work-order/src/services/work-order-service/schemas.ts
+++ b/services/work-order/src/services/work-order-service/schemas.ts
@@ -184,6 +184,38 @@ export const CreateWorkOrderBodySchema = z.object({
   details: CreateWorkOrderDetailsSchema,
 })
 
+// Odoo "Resursgrupp" (maintenance.team) — the board a work order is routed to.
+export const MaintenanceTeamSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+
+// One work order per resursgrupp: the components an inspector assigned to a
+// team are aggregated into `descriptionHtml` (HTML, <br>-joined).
+export const CreateInspectionWorkOrderGroupSchema = z.object({
+  maintenanceTeamId: z.number(),
+  maintenanceTeamName: z.string(),
+  descriptionHtml: z.string(),
+})
+
+export const CreateInspectionWorkOrdersBodySchema = z.object({
+  rentalProperty: RentalPropertySchema,
+  groups: z.array(CreateInspectionWorkOrderGroupSchema).min(1),
+})
+
+// Per-group outcome — the batch is N separate Odoo commits, not a transaction,
+// so each group succeeds or fails independently.
+export const CreateInspectionWorkOrderResultSchema = z.object({
+  maintenanceTeamId: z.number(),
+  ok: z.boolean(),
+  workOrderId: z.number().optional(),
+  err: z.string().optional(),
+})
+
+export const CreateInspectionWorkOrdersResponseSchema = z.object({
+  results: z.array(CreateInspectionWorkOrderResultSchema),
+})
+
 export const GetWorkOrdersFromXpandQuerySchema = z.object({
   skip: z.coerce.number().optional(),
   limit: z.coerce.number().optional(),
@@ -208,3 +240,16 @@ export type CreateWorkOrderDetails = z.infer<
 >
 export type CreateWorkOrderRow = z.infer<typeof CreateWorkOrderRowSchema>
 export type CreateWorkOrderBody = z.infer<typeof CreateWorkOrderBodySchema>
+export type MaintenanceTeam = z.infer<typeof MaintenanceTeamSchema>
+export type CreateInspectionWorkOrderGroup = z.infer<
+  typeof CreateInspectionWorkOrderGroupSchema
+>
+export type CreateInspectionWorkOrdersBody = z.infer<
+  typeof CreateInspectionWorkOrdersBodySchema
+>
+export type CreateInspectionWorkOrderResult = z.infer<
+  typeof CreateInspectionWorkOrderResultSchema
+>
+export type CreateInspectionWorkOrdersResponse = z.infer<
+  typeof CreateInspectionWorkOrdersResponseSchema
+>

--- a/services/work-order/src/services/work-order-service/schemas.ts
+++ b/services/work-order/src/services/work-order-service/schemas.ts
@@ -244,12 +244,6 @@ export type MaintenanceTeam = z.infer<typeof MaintenanceTeamSchema>
 export type CreateInspectionWorkOrderGroup = z.infer<
   typeof CreateInspectionWorkOrderGroupSchema
 >
-export type CreateInspectionWorkOrdersBody = z.infer<
-  typeof CreateInspectionWorkOrdersBodySchema
->
 export type CreateInspectionWorkOrderResult = z.infer<
   typeof CreateInspectionWorkOrderResultSchema
->
-export type CreateInspectionWorkOrdersResponse = z.infer<
-  typeof CreateInspectionWorkOrdersResponseSchema
 >


### PR DESCRIPTION
## Summary

Implements [MIM-1861](https://linear.app/mimer-onecore/issue/MIM-1861/create-odoo-work-order-from-inspection):
from a completed inspection, create Odoo work orders (ärenden) for the apartment —
one per resursgrupp — without manually filling out an Odoo form.

- **property-tree:** resursgrupp picker per Skadad component on the summary step
  (desktop + mobile), confirm/preview dialog on Slutför besiktning, grouped
  description per team (by room: component, åtgärd, note, cost/responsibility).
- **core:** `GET /work-orders/maintenance-teams` and `POST /work-orders/from-inspection`
  (resolves the rental property, apartment-only, then delegates to work-order).
- **work-order service:** lists `maintenance.team`s; creates one `maintenance.request`
  per group with a per-request `maintenance.rental.property` child (linked to the
  apartment), team pre-assigned, category **Besiktning** resolved by name at runtime.
  
  ### How to test

Prereqs: Odoo running with maintenance teams seeded and a **Besiktning**
maintenance category; core + work-order + property-tree running locally.

1. Start an inspection on an apartment in property-tree and mark at least two
   components in different rooms as **Skadad**.
2. On the **Sammanställning** step, assign resursgrupper: two components to the
   same team, one to another, and leave one unassigned.
3. Click **Slutför besiktning** → the dialog should show 2 ärenden to create
   and 1 skipped component.
4. Confirm → check Odoo: one maintenance request per team, on the right team,
   description grouped by room, linked to the apartment (visible under the
   residence's **Ärenden** tab in property-tree).
5. Repeat on mobile width.

  
NOTE: most of the line count is api-types regeneration (+ prettier on the app files, which are prettier-ignored in CI anyway). Follow-up card: add the remaining core adapter generated files to core/.prettierignore.