### PR TITLE
Feature/mim 1868 refaktorera ai analys for komponenter

### DIFF
--- a/core/.prettierignore
+++ b/core/.prettierignore
@@ -1,2 +1,4 @@
 src/adapters/property-base-adapter/generated/api-types.ts
 src/adapters/work-order-adapter/generated/api-types.ts
+src/adapters/inspection-adapter/generated/api-types.ts
+src/adapters/keys-adapter/generated/api-types.ts

--- a/core/src/adapters/property-base-adapter/generated/api-types.ts
+++ b/core/src/adapters/property-base-adapter/generated/api-types.ts
@@ -2426,6 +2426,11 @@ export interface paths {
             image: string
             /** @description Optional additional base64 encoded image (max 10MB) - combine typeplate + product photo for best results */
             additionalImage?: string
+            /**
+             * Format: uuid
+             * @description Optional component category id from the component library - the service uses it to select the analysis prompt and to constrain the classification to the component types under that category (falls back to a general prompt when omitted or unknown)
+             */
+            categoryId?: string
           }
         }
       }
@@ -4092,6 +4097,8 @@ export interface components {
     AnalyzeComponentImageRequest: {
       image: string
       additionalImage?: string
+      /** Format: uuid */
+      categoryId?: string
     }
     AIComponentAnalysis: {
       componentCategory: string | null

--- a/core/src/services/property-base-service/schemas.ts
+++ b/core/src/services/property-base-service/schemas.ts
@@ -973,40 +973,17 @@ export type UpdateComponentInstallation = z.infer<
   typeof UpdateComponentInstallationSchema
 >
 
-// AI Component Analysis schemas
-export const AnalyzeComponentImageRequestSchema = z.object({
-  image: z.string().max(10 * 1024 * 1024), // 10MB max base64 string
-  additionalImage: z
-    .string()
-    .max(10 * 1024 * 1024)
-    .optional(),
-  // Component category id from the component library. The property service uses
-  // it to select the analysis prompt and constrain the classification to the
-  // types under that category. Falls back to a general prompt when omitted.
-  categoryId: z.string().uuid().optional(),
-})
+// ==================== AI COMPONENT ANALYSIS ====================
+// Re-exported from @onecore/types (single source of truth shared with the
+// property service). Keep the local export names so consumers / swagger
+// registration are unaffected.
 
-export const AIComponentAnalysisSchema = z.object({
-  componentCategory: z.string().nullable(),
-  componentType: z.string().nullable(),
-  componentSubtype: z.string().nullable(),
-  manufacturer: z.string().nullable(),
-  model: z.string().nullable(),
-  serialNumber: z.string().nullable(),
-  estimatedAge: z.string().nullable(),
-  condition: z.string().nullable(),
-  specifications: z.string().nullable(),
-  dimensions: z.string().nullable(),
-  warrantyMonths: z.number().nullable(),
-  ncsCode: z.string().nullable(),
-  additionalInformation: z.string().nullable(),
-  confidence: z.number(),
-})
+export const AnalyzeComponentImageRequestSchema =
+  property.AnalyzeComponentImageRequestSchema
+export const AIComponentAnalysisSchema = property.AIComponentAnalysisSchema
 
-export type AnalyzeComponentImageRequest = z.infer<
-  typeof AnalyzeComponentImageRequestSchema
->
-export type AIComponentAnalysis = z.infer<typeof AIComponentAnalysisSchema>
+export type AnalyzeComponentImageRequest = property.AnalyzeComponentImageRequest
+export type AIComponentAnalysis = property.AIComponentAnalysis
 
 export const FacilitySearchResultSchema = z.object({
   id: z.string(),

--- a/core/src/services/property-base-service/schemas.ts
+++ b/core/src/services/property-base-service/schemas.ts
@@ -980,9 +980,14 @@ export const AnalyzeComponentImageRequestSchema = z.object({
     .string()
     .max(10 * 1024 * 1024)
     .optional(),
+  // Component category id from the component library. The property service uses
+  // it to select the analysis prompt and constrain the classification to the
+  // types under that category. Falls back to a general prompt when omitted.
+  categoryId: z.string().uuid().optional(),
 })
 
 export const AIComponentAnalysisSchema = z.object({
+  componentCategory: z.string().nullable(),
   componentType: z.string().nullable(),
   componentSubtype: z.string().nullable(),
   manufacturer: z.string().nullable(),

--- a/core/src/services/property-base-service/tests/components.test.ts
+++ b/core/src/services/property-base-service/tests/components.test.ts
@@ -14,7 +14,9 @@ import { ProcessStatus } from '../../../common/types'
 const app = new Koa()
 const router = new KoaRouter()
 routes(router)
-app.use(bodyParser())
+// Match the real app's 50mb limit (core/src/app.ts) — koa-bodyparser's
+// default 1mb would 413 large-image bodies before Zod validation runs
+app.use(bodyParser({ jsonLimit: '50mb' }))
 app.use(router.routes())
 
 beforeEach(jest.resetAllMocks)
@@ -168,6 +170,9 @@ describe('Component Categories API', () => {
   describe('DELETE /component-categories/:id', () => {
     it('returns 204 on success', async () => {
       jest
+        .spyOn(propertyBaseAdapter, 'getComponentTypes')
+        .mockResolvedValueOnce({ ok: true, data: [] })
+      jest
         .spyOn(propertyBaseAdapter, 'deleteComponentCategory')
         .mockResolvedValueOnce({ ok: true, data: undefined })
 
@@ -179,6 +184,9 @@ describe('Component Categories API', () => {
     })
 
     it('returns 404 when not found', async () => {
+      jest
+        .spyOn(propertyBaseAdapter, 'getComponentTypes')
+        .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(propertyBaseAdapter, 'deleteComponentCategory')
         .mockResolvedValueOnce({ ok: false, err: 'not_found' })
@@ -335,6 +343,9 @@ describe('Component Types API', () => {
   describe('DELETE /component-types/:id', () => {
     it('returns 204 on success', async () => {
       jest
+        .spyOn(propertyBaseAdapter, 'getComponentSubtypes')
+        .mockResolvedValueOnce({ ok: true, data: [] })
+      jest
         .spyOn(propertyBaseAdapter, 'deleteComponentType')
         .mockResolvedValueOnce({ ok: true, data: undefined })
 
@@ -346,6 +357,9 @@ describe('Component Types API', () => {
     })
 
     it('returns 404 when not found', async () => {
+      jest
+        .spyOn(propertyBaseAdapter, 'getComponentSubtypes')
+        .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(propertyBaseAdapter, 'deleteComponentType')
         .mockResolvedValueOnce({ ok: false, err: 'not_found' })
@@ -526,6 +540,9 @@ describe('Component Subtypes API', () => {
   describe('DELETE /component-subtypes/:id', () => {
     it('returns 204 on success', async () => {
       jest
+        .spyOn(propertyBaseAdapter, 'getComponentModels')
+        .mockResolvedValueOnce({ ok: true, data: [] })
+      jest
         .spyOn(propertyBaseAdapter, 'deleteComponentSubtype')
         .mockResolvedValueOnce({ ok: true, data: undefined })
 
@@ -537,6 +554,9 @@ describe('Component Subtypes API', () => {
     })
 
     it('returns 404 when not found', async () => {
+      jest
+        .spyOn(propertyBaseAdapter, 'getComponentModels')
+        .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(propertyBaseAdapter, 'deleteComponentSubtype')
         .mockResolvedValueOnce({ ok: false, err: 'not_found' })
@@ -719,6 +739,9 @@ describe('Component Models API', () => {
   describe('DELETE /component-models/:id', () => {
     it('returns 204 on success', async () => {
       jest
+        .spyOn(propertyBaseAdapter, 'getComponents')
+        .mockResolvedValueOnce({ ok: true, data: [] })
+      jest
         .spyOn(propertyBaseAdapter, 'deleteComponentModel')
         .mockResolvedValueOnce({ ok: true, data: undefined })
 
@@ -730,6 +753,9 @@ describe('Component Models API', () => {
     })
 
     it('returns 404 when not found', async () => {
+      jest
+        .spyOn(propertyBaseAdapter, 'getComponents')
+        .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(propertyBaseAdapter, 'deleteComponentModel')
         .mockResolvedValueOnce({ ok: false, err: 'not_found' })
@@ -959,6 +985,9 @@ describe('Components API', () => {
   describe('DELETE /components/:id', () => {
     it('returns 204 on success', async () => {
       jest
+        .spyOn(propertyBaseAdapter, 'getComponentInstallations')
+        .mockResolvedValueOnce({ ok: true, data: [] })
+      jest
         .spyOn(propertyBaseAdapter, 'deleteComponent')
         .mockResolvedValueOnce({ ok: true, data: undefined })
 
@@ -970,6 +999,9 @@ describe('Components API', () => {
     })
 
     it('returns 404 when not found', async () => {
+      jest
+        .spyOn(propertyBaseAdapter, 'getComponentInstallations')
+        .mockResolvedValueOnce({ ok: true, data: [] })
       jest
         .spyOn(propertyBaseAdapter, 'deleteComponent')
         .mockResolvedValueOnce({ ok: false, err: 'not_found' })
@@ -1397,6 +1429,43 @@ describe('POST /components/analyze-image', () => {
       image: 'base64imagedata',
       additionalImage: 'base64additionaldata',
     })
+  })
+
+  it('accepts a base64 image above 10MiB up to the shared 14M character limit', async () => {
+    const analysis = {
+      componentCategory: null,
+      componentType: null,
+      componentSubtype: null,
+      manufacturer: null,
+      model: null,
+      serialNumber: null,
+      estimatedAge: null,
+      condition: null,
+      specifications: null,
+      dimensions: null,
+      warrantyMonths: null,
+      ncsCode: null,
+      additionalInformation: null,
+      confidence: 0,
+    }
+    jest
+      .spyOn(propertyBaseAdapter, 'analyzeComponentImage')
+      .mockResolvedValueOnce({ ok: true, data: analysis })
+
+    const res = await request(app.callback())
+      .post('/components/analyze-image')
+      // Above core's old 10 * 1024 * 1024 limit, below property's 14_000_000
+      .send({ image: 'a'.repeat(11_000_000) })
+
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects a base64 image above the shared 14M character limit', async () => {
+    const res = await request(app.callback())
+      .post('/components/analyze-image')
+      .send({ image: 'a'.repeat(14_000_001) })
+
+    expect(res.status).toBe(400)
   })
 
   it('returns 500 when analysis fails', async () => {

--- a/libs/types/src/property/schema.ts
+++ b/libs/types/src/property/schema.ts
@@ -48,3 +48,44 @@ export const ApartmentTemperaturesResponseSchema = z.object({
   unit: z.string(),
   series: z.array(ApartmentTemperatureSeriesSchema),
 })
+
+// ---- AI component image analysis ----
+// Request/response shapes for POST /components/analyze-image, shared between
+// the property service and the core proxy. Source of truth — do not
+// re-declare these in either consumer.
+
+// Base64 encoding adds ~33% overhead: a 10MB file is ≈ 13.3MB of base64,
+// hence the 14_000_000 character limit.
+export const AnalyzeComponentImageRequestSchema = z.object({
+  image: z
+    .string()
+    .min(1, 'Base64 image data is required')
+    .max(14_000_000, 'Image too large (max 10MB)'),
+  additionalImage: z
+    .string()
+    .max(14_000_000, 'Additional image too large (max 10MB)')
+    .optional(),
+  // Component category id from the component library. The property service
+  // looks up the category (selects the analysis prompt) and its component
+  // types (constrains the classification). Falls back to a general prompt
+  // when omitted.
+  categoryId: z.string().uuid().optional(),
+})
+
+// All fields nullable except confidence (the AI might not detect everything)
+export const AIComponentAnalysisSchema = z.object({
+  componentCategory: z.string().nullable(),
+  componentType: z.string().nullable(),
+  componentSubtype: z.string().nullable(),
+  manufacturer: z.string().nullable(),
+  model: z.string().nullable(),
+  serialNumber: z.string().nullable(),
+  estimatedAge: z.string().nullable(),
+  condition: z.string().nullable(),
+  specifications: z.string().nullable(),
+  dimensions: z.string().nullable(),
+  warrantyMonths: z.number().int().min(0).nullable(),
+  ncsCode: z.string().nullable(),
+  additionalInformation: z.string().nullable(),
+  confidence: z.number().min(0).max(1),
+})

--- a/libs/types/src/property/types.ts
+++ b/libs/types/src/property/types.ts
@@ -6,6 +6,8 @@ import {
   ApartmentTemperaturePointSchema,
   ApartmentTemperatureSeriesSchema,
   ApartmentTemperaturesResponseSchema,
+  AnalyzeComponentImageRequestSchema,
+  AIComponentAnalysisSchema,
 } from './schema'
 
 export type ApartmentTemperaturesInterval = z.infer<
@@ -23,3 +25,7 @@ export type ApartmentTemperatureSeries = z.infer<
 export type ApartmentTemperaturesResponse = z.infer<
   typeof ApartmentTemperaturesResponseSchema
 >
+export type AnalyzeComponentImageRequest = z.infer<
+  typeof AnalyzeComponentImageRequestSchema
+>
+export type AIComponentAnalysis = z.infer<typeof AIComponentAnalysisSchema>

--- a/services/property/src/adapters/berget-adapter.test.ts
+++ b/services/property/src/adapters/berget-adapter.test.ts
@@ -1,0 +1,128 @@
+import axios from 'axios'
+import { analyzeComponentImage } from './berget-adapter'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+beforeEach(jest.clearAllMocks)
+
+const aiResponse = (content: string) => ({
+  data: { choices: [{ message: { content } }] },
+})
+
+const validAnalysis = {
+  componentCategory: 'Vitvaror',
+  componentType: 'Kylskåp',
+  componentSubtype: null,
+  manufacturer: 'Bosch',
+  model: 'KGN39VIDA',
+  serialNumber: null,
+  estimatedAge: '2-3 år',
+  condition: 'Gott',
+  specifications: null,
+  dimensions: null,
+  warrantyMonths: 24,
+  ncsCode: null,
+  additionalInformation: null,
+  confidence: 0.85,
+}
+
+describe('analyzeComponentImage', () => {
+  it('returns the parsed analysis for a valid AI response', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify(validAnalysis))
+    )
+
+    const result = await analyzeComponentImage('base64data')
+
+    expect(result).toEqual(validAnalysis)
+  })
+
+  it('parses JSON wrapped in markdown code fences', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse('```json\n' + JSON.stringify(validAnalysis) + '\n```')
+    )
+
+    const result = await analyzeComponentImage('base64data')
+
+    expect(result.componentType).toBe('Kylskåp')
+  })
+
+  it('clamps out-of-range confidence into [0, 1] and defaults missing confidence to 0', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, confidence: 1.4 }))
+    )
+    const clamped = await analyzeComponentImage('base64data')
+    expect(clamped.confidence).toBe(1)
+
+    const { confidence: _omitted, ...withoutConfidence } = validAnalysis
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify(withoutConfidence))
+    )
+    const defaulted = await analyzeComponentImage('base64data')
+    expect(defaulted.confidence).toBe(0)
+
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, confidence: -0.2 }))
+    )
+    const clampedNegative = await analyzeComponentImage('base64data')
+    expect(clampedNegative.confidence).toBe(0)
+
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, confidence: '0.85' }))
+    )
+    const stringConfidence = await analyzeComponentImage('base64data')
+    expect(stringConfidence.confidence).toBe(0)
+  })
+
+  it('rounds fractional warrantyMonths and nulls negative or non-numeric values', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, warrantyMonths: 24.6 }))
+    )
+    expect((await analyzeComponentImage('base64data')).warrantyMonths).toBe(25)
+
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, warrantyMonths: -3 }))
+    )
+    expect(
+      (await analyzeComponentImage('base64data')).warrantyMonths
+    ).toBeNull()
+
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, warrantyMonths: '24' }))
+    )
+    expect(
+      (await analyzeComponentImage('base64data')).warrantyMonths
+    ).toBeNull()
+  })
+
+  it('throws a curated error when the AI response does not match the schema', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse(JSON.stringify({ ...validAnalysis, componentCategory: 123 }))
+    )
+
+    await expect(analyzeComponentImage('base64data')).rejects.toThrow(
+      'AI response did not match the expected format'
+    )
+  })
+
+  it('throws when the AI response contains no JSON', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse('Jag kan tyvärr inte analysera den här bilden.')
+    )
+
+    await expect(analyzeComponentImage('base64data')).rejects.toThrow(
+      'AI analysis failed: Could not parse JSON from AI response'
+    )
+  })
+
+  it('throws the curated parse error when the extracted braces are not valid JSON', async () => {
+    mockedAxios.post.mockResolvedValueOnce(
+      aiResponse('Resultat: {oops, not json}')
+    )
+
+    await expect(analyzeComponentImage('base64data')).rejects.toThrow(
+      'AI analysis failed: Could not parse JSON from AI response'
+    )
+  })
+})

--- a/services/property/src/adapters/berget-adapter.ts
+++ b/services/property/src/adapters/berget-adapter.ts
@@ -1,72 +1,31 @@
 import axios from 'axios'
 import bergetConfig from '../config/berget'
 import type { AIComponentAnalysis } from '../types/component'
+import { resolveComponentAnalysisPrompt } from '../prompts/component-analysis'
 
-// MVP: AI-powered component analysis focused on Swedish appliances (vitvaror)
+// AI-powered component image analysis. The system prompt is selected per
+// component category (see ../prompts/component-analysis), with a general
+// fallback for categories without a dedicated prompt.
 // TODO: Future enhancement - Add TYPE_PLATE mode parameter for nameplate reading
-// TODO: Future enhancement - Add support for other component categories (HVAC, plumbing, etc.)
 // TODO: Future enhancement - Add confidence threshold warnings
 // TODO: Future enhancement - Implement retry logic with exponential backoff
 
-const SYSTEM_PROMPT = `Du är en expert på svenska vitvaror och hushållsapparater. Analysera bilden/bilderna och extrahera relevant information.
-
-Du kan få EN eller TVÅ bilder:
-
-Om EN bild (typskylt):
-- Extrahera all teknisk data (modell, serienummer, specifikationer, dimensioner, garanti)
-- Sätt componentType till null om du inte kan identifiera produkttypen från texten
-
-Om EN bild (produktbild):
-- Identifiera componentCategory, componentType och componentSubtype visuellt
-- Bedöm skick (condition) och uppskatta ålder (estimatedAge)
-- Extrahera synlig data om tillgänglig
-
-Om TVÅ bilder:
-- Kombinera information från båda bilderna
-- Använd produktbilden för att identifiera componentType och bedöma skick
-- Använd typskylten för exakta tekniska data (modell, serienummer, specifikationer)
-
-Fokusera på dessa typer av vitvaror:
-- Kylskåp, Kyl/Frys-kombinationer
-- Spisar, Ugnar, Häll
-- Diskmaskiner
-- Tvättmaskiner, Torktumlare, Torkskåp
-- Mikrovågsugnar
-- Fläktar, Köksfläktar
-- Värmepumpar
-
-Svara ENDAST med JSON i följande format (inget annat text):
-{
-  "componentCategory": "övergripande kategori (för vitvaror: 'Vitvaror')",
-  "componentType": "typ av komponent (t.ex. 'Kylskåp', 'Diskmaskin', 'Tvättmaskin', 'Spis')",
-  "componentSubtype": "specifik variant (t.ex. '60cm integrerad', 'Fristående 190-215 liter', 'Kyl/frys-kombination', annars null)",
-  "manufacturer": "tillverkare/märke (om synligt, annars null)",
-  "model": "modellnamn/nummer (om synligt, annars null)",
-  "serialNumber": "serienummer (om synligt på bild, annars null)",
-  "estimatedAge": "uppskattad ålder som text (t.ex. '5-10 år', 'Ny', 'Okänd')",
-  "condition": "visuellt skick som text (t.ex. 'Utmärkt', 'Gott', 'Normalt', 'Slitet')",
-  "specifications": "tekniska specifikationer om synliga (t.ex. 'Energiklass A++, Volym 343L')",
-  "dimensions": "fysiska mått om synliga på etikett (t.ex. 'BxDxH: 60x60x85 cm', annars null)",
-  "warrantyMonths": "garantitid i månader om synlig (t.ex. från garantietikett, annars null)",
-  "ncsCode": "NCS-färgkod om synlig (format XXX eller XXX.XXX, annars null)",
-  "additionalInformation": "övrig relevant information synlig på produkten (annars null)",
-  "confidence": 0.85
-}
-
-VIKTIGT: Fyll ENDAST i fält där information är synlig eller kan extraheras från bilden. Använd null för fält där du inte är säker. Var konservativ med confidence-värdet (0.0-1.0).`
-
 /**
  * Analyzes component image(s) using the Berget AI API
- * MVP version: Single or dual image mode, focused on Swedish appliances (vitvaror)
+ * Single or dual image mode. The prompt is built from the selected category and
+ * the component types available under it (see ../prompts/component-analysis).
  *
  * @param base64Image - Primary base64 encoded image string (with or without data URI prefix)
  * @param additionalImage - Optional additional base64 image (e.g., typeplate + product photo)
+ * @param taxonomy - Optional category context: the category name (selects the
+ *   prompt) and the component type names under it (constrains the classification)
  * @returns Promise<AIComponentAnalysis> - Structured analysis of the component
  * @throws Error on API failure, timeout, or invalid response
  */
 export const analyzeComponentImage = async (
   base64Image: string,
-  additionalImage?: string
+  additionalImage?: string,
+  taxonomy?: { categoryName?: string; availableTypes?: string[] }
 ): Promise<AIComponentAnalysis> => {
   try {
     // Ensure primary image has data URI prefix
@@ -82,7 +41,13 @@ export const analyzeComponentImage = async (
       text?: string
       image_url?: { url: string }
     }> = [
-      { type: 'text', text: SYSTEM_PROMPT },
+      {
+        type: 'text',
+        text: resolveComponentAnalysisPrompt(
+          taxonomy?.categoryName,
+          taxonomy?.availableTypes
+        ),
+      },
       { type: 'image_url', image_url: { url: imageData } },
     ]
 

--- a/services/property/src/adapters/berget-adapter.ts
+++ b/services/property/src/adapters/berget-adapter.ts
@@ -1,6 +1,11 @@
 import axios from 'axios'
+import { ZodError } from 'zod'
+import { logger } from '@onecore/utilities'
 import bergetConfig from '../config/berget'
-import type { AIComponentAnalysis } from '../types/component'
+import {
+  AIComponentAnalysisSchema,
+  type AIComponentAnalysis,
+} from '../types/component'
 import { resolveComponentAnalysisPrompt } from '../prompts/component-analysis'
 
 // AI-powered component image analysis. The system prompt is selected per
@@ -25,7 +30,7 @@ import { resolveComponentAnalysisPrompt } from '../prompts/component-analysis'
 export const analyzeComponentImage = async (
   base64Image: string,
   additionalImage?: string,
-  taxonomy?: { categoryName?: string; availableTypes?: string[] }
+  taxonomy?: { categoryName: string; availableTypes: string[] }
 ): Promise<AIComponentAnalysis> => {
   try {
     // Ensure primary image has data URI prefix
@@ -96,37 +101,61 @@ export const analyzeComponentImage = async (
       throw new Error('Could not parse JSON from AI response')
     }
 
-    const analysis = JSON.parse(jsonMatch[0]) as AIComponentAnalysis
+    const analysis = JSON.parse(jsonMatch[0]) as Record<string, unknown>
 
-    // Ensure all fields exist (default to null if missing)
-    return {
-      // Basic identification fields (three-level taxonomy)
+    // The AI output is untrusted: clamp near-miss numeric values rather than
+    // failing the whole analysis on them, then validate the final shape so an
+    // out-of-contract response fails here (with a curated error) instead of
+    // failing core's response parse downstream.
+    const roundedWarranty =
+      typeof analysis.warrantyMonths === 'number' &&
+      Number.isFinite(analysis.warrantyMonths)
+        ? Math.round(analysis.warrantyMonths)
+        : null
+    const warrantyMonths =
+      roundedWarranty !== null && roundedWarranty >= 0 ? roundedWarranty : null
+
+    const confidence =
+      typeof analysis.confidence === 'number' &&
+      Number.isFinite(analysis.confidence)
+        ? Math.min(1, Math.max(0, analysis.confidence))
+        : 0
+
+    return AIComponentAnalysisSchema.parse({
       componentCategory: analysis.componentCategory ?? null,
       componentType: analysis.componentType ?? null,
       componentSubtype: analysis.componentSubtype ?? null,
       manufacturer: analysis.manufacturer ?? null,
       model: analysis.model ?? null,
       serialNumber: analysis.serialNumber ?? null,
-
-      // Condition and age assessment
       estimatedAge: analysis.estimatedAge ?? null,
       condition: analysis.condition ?? null,
-
-      // Technical information from labels
       specifications: analysis.specifications ?? null,
       dimensions: analysis.dimensions ?? null,
-      warrantyMonths: analysis.warrantyMonths ?? null,
-
-      // Classification codes
+      warrantyMonths,
       ncsCode: analysis.ncsCode ?? null,
-
-      // Additional information
       additionalInformation: analysis.additionalInformation ?? null,
-
-      // Confidence score
-      confidence: analysis.confidence ?? 0,
-    }
+      confidence,
+    })
   } catch (error) {
+    // The curated rethrows below hide diagnostic detail from the API
+    // consumer, so record the raw error (zod issues, JSON syntax error,
+    // axios failure) here before mapping it
+    logger.error({ err: error }, 'berget-adapter.analyzeComponentImage')
+
+    if (error instanceof ZodError) {
+      // Don't leak raw zod issues to the API consumer
+      throw new Error('AI response did not match the expected format')
+    }
+
+    if (error instanceof SyntaxError) {
+      // The regex-extracted brace span wasn't valid JSON — same curated
+      // message as when no JSON is found at all
+      throw new Error(
+        'AI analysis failed: Could not parse JSON from AI response'
+      )
+    }
+
     // Handle specific error cases
     if (axios.isAxiosError(error)) {
       if (error.response?.status === 401) {

--- a/services/property/src/adapters/component-category-adapter.ts
+++ b/services/property/src/adapters/component-category-adapter.ts
@@ -1,5 +1,6 @@
 import { trimStrings } from '@src/utils/data-conversion'
 import { prisma } from './db'
+import { logger } from '@onecore/utilities'
 import type {
   CreateComponentCategory,
   UpdateComponentCategory,
@@ -34,14 +35,24 @@ export const getComponentCategories = async (
 }
 
 export const getComponentCategoryById = async (id: string) => {
-  const category = await prisma.componentCategories.findUnique({
-    where: { id },
-    include: {
-      componentTypes: true,
-    },
-  })
+  try {
+    const category = await prisma.componentCategories.findUnique({
+      where: { id },
+      include: {
+        // Deterministic order so consumers (e.g. the AI analysis prompt)
+        // produce reproducible output across environments
+        componentTypes: { orderBy: { typeName: 'asc' } },
+      },
+    })
 
-  return category ? trimStrings(category) : null
+    return category ? trimStrings(category) : null
+  } catch (err) {
+    logger.error(
+      { err, id },
+      'component-category-adapter.getComponentCategoryById'
+    )
+    throw err
+  }
 }
 
 export const createComponentCategory = async (

--- a/services/property/src/app.ts
+++ b/services/property/src/app.ts
@@ -44,6 +44,10 @@ app.on('error', (err) => {
 const koaBodyMiddleware = bodyParser({
   multipart: false,
   urlencoded: true,
+  // /components/analyze-image accepts up to two base64 images of 14M chars
+  // each (~28MB of JSON). Matches core's jsonLimit so bodies forwarded by the
+  // proxy aren't rejected here with 413 (koa-body's default is 1mb).
+  jsonLimit: '50mb',
 })
 
 app.use(async (ctx, next) => {

--- a/services/property/src/prompts/component-analysis/base.ts
+++ b/services/property/src/prompts/component-analysis/base.ts
@@ -1,0 +1,24 @@
+// Shared, category-agnostic instructions for component image analysis.
+// Used by every prompt: the resolver composes <domain block> + BASE_INSTRUCTIONS
+// + OUTPUT_FORMAT. Category files (e.g. ./vitvaror) only add domain framing and
+// a focus list on top of this base — keep anything generic (image handling,
+// conservative defaults) here so it is not duplicated per category.
+export const BASE_INSTRUCTIONS = `Analysera bilden/bilderna och extrahera relevant information.
+
+Du kan få EN eller TVÅ bilder:
+
+Om EN bild (typskylt):
+- Extrahera all teknisk data (modell, serienummer, specifikationer, dimensioner, garanti)
+- Sätt componentType till null om du inte kan identifiera produkttypen från texten
+
+Om EN bild (produktbild):
+- Identifiera componentCategory, componentType och componentSubtype visuellt
+- Bedöm skick (condition) och uppskatta ålder (estimatedAge)
+- Extrahera synlig data om tillgänglig
+
+Om TVÅ bilder:
+- Kombinera information från båda bilderna
+- Använd produktbilden för att identifiera componentType och bedöma skick
+- Använd typskylten för exakta tekniska data (modell, serienummer, specifikationer)
+
+Identifiera komponentens kategori, typ och eventuell undertyp så specifikt som bilden tillåter. Var konservativ när underlaget är osäkert och använd null för fält du inte kan fastställa.`

--- a/services/property/src/prompts/component-analysis/general.ts
+++ b/services/property/src/prompts/component-analysis/general.ts
@@ -1,0 +1,5 @@
+// General fallback domain framing, used when the selected component category
+// has no dedicated overlay. Deliberately category-agnostic: it only frames the
+// expert role broadly. The actual analysis instructions live in BASE_INSTRUCTIONS
+// (./base) and are shared with every category.
+export const generalPrompt = `Du är en expert på att identifiera och bedöma fastighetskomponenter, t.ex. vitvaror, VVS, ventilation, värmesystem, el, ytskikt och fasta inventarier (listan är inte uttömmande).`

--- a/services/property/src/prompts/component-analysis/index.test.ts
+++ b/services/property/src/prompts/component-analysis/index.test.ts
@@ -1,4 +1,4 @@
-import { resolveComponentAnalysisPrompt } from './index'
+import { resolveComponentAnalysisPrompt, hasDedicatedPrompt } from './index'
 import { BASE_INSTRUCTIONS } from './base'
 import { vitvarorPrompt } from './vitvaror'
 import { generalPrompt } from './general'
@@ -55,5 +55,19 @@ describe('resolveComponentAnalysisPrompt', () => {
     const prompt = resolveComponentAnalysisPrompt(undefined, ['Kylskåp'])
     expect(prompt).not.toContain('tillhör kategorin')
     expect(prompt).not.toContain('Välj componentType EXAKT')
+  })
+})
+
+describe('hasDedicatedPrompt', () => {
+  it('is true for categories with a dedicated overlay, case-insensitively', () => {
+    expect(hasDedicatedPrompt('Vitvaror')).toBe(true)
+    expect(hasDedicatedPrompt('  vitVAROR ')).toBe(true)
+  })
+
+  it('is false for categories without an overlay and for missing names', () => {
+    expect(hasDedicatedPrompt('VVS')).toBe(false)
+    expect(hasDedicatedPrompt(undefined)).toBe(false)
+    expect(hasDedicatedPrompt('')).toBe(false)
+    expect(hasDedicatedPrompt('   ')).toBe(false)
   })
 })

--- a/services/property/src/prompts/component-analysis/index.test.ts
+++ b/services/property/src/prompts/component-analysis/index.test.ts
@@ -1,0 +1,59 @@
+import { resolveComponentAnalysisPrompt } from './index'
+import { BASE_INSTRUCTIONS } from './base'
+import { vitvarorPrompt } from './vitvaror'
+import { generalPrompt } from './general'
+import { OUTPUT_FORMAT } from './output-format'
+
+describe('resolveComponentAnalysisPrompt', () => {
+  it('returns the vitvaror prompt for the Vitvaror category', () => {
+    const prompt = resolveComponentAnalysisPrompt('Vitvaror')
+    expect(prompt).toContain(vitvarorPrompt)
+    expect(prompt).not.toContain(generalPrompt)
+  })
+
+  it('matches the category name case-insensitively and trims whitespace', () => {
+    const prompt = resolveComponentAnalysisPrompt('  vitVAROR  ')
+    expect(prompt).toContain(vitvarorPrompt)
+  })
+
+  it('falls back to the general prompt for an unmatched category', () => {
+    const prompt = resolveComponentAnalysisPrompt('VVS')
+    expect(prompt).toContain(generalPrompt)
+    expect(prompt).not.toContain(vitvarorPrompt)
+  })
+
+  it('falls back to the general prompt when no category is provided', () => {
+    const prompt = resolveComponentAnalysisPrompt()
+    expect(prompt).toContain(generalPrompt)
+  })
+
+  it('always includes the shared base instructions and JSON output contract', () => {
+    for (const category of ['Vitvaror', 'VVS', undefined]) {
+      const prompt = resolveComponentAnalysisPrompt(category)
+      expect(prompt).toContain(BASE_INSTRUCTIONS)
+      expect(prompt).toContain(OUTPUT_FORMAT)
+    }
+  })
+
+  it('constrains componentType to the available types when provided', () => {
+    const prompt = resolveComponentAnalysisPrompt('Vitvaror', [
+      'Kylskåp',
+      'Diskmaskin',
+    ])
+    expect(prompt).toContain('Välj componentType EXAKT')
+    expect(prompt).toContain('- Kylskåp')
+    expect(prompt).toContain('- Diskmaskin')
+  })
+
+  it('pins the category but adds no type list when the category has no types', () => {
+    const prompt = resolveComponentAnalysisPrompt('Vitvaror', [])
+    expect(prompt).toContain('tillhör kategorin "Vitvaror"')
+    expect(prompt).not.toContain('Välj componentType EXAKT')
+  })
+
+  it('adds no taxonomy constraint when no category is provided', () => {
+    const prompt = resolveComponentAnalysisPrompt(undefined, ['Kylskåp'])
+    expect(prompt).not.toContain('tillhör kategorin')
+    expect(prompt).not.toContain('Välj componentType EXAKT')
+  })
+})

--- a/services/property/src/prompts/component-analysis/index.ts
+++ b/services/property/src/prompts/component-analysis/index.ts
@@ -13,6 +13,23 @@ const OVERLAYS: Record<string, string> = {
   vitvaror: vitvarorPrompt,
 }
 
+const resolveOverlay = (categoryName?: string): string | undefined => {
+  const key = categoryName?.trim().toLowerCase()
+  return key && Object.prototype.hasOwnProperty.call(OVERLAYS, key)
+    ? OVERLAYS[key]
+    : undefined
+}
+
+/**
+ * True when the category has a dedicated prompt overlay (i.e. does not fall
+ * back to the general prompt). Exposed so callers can log when a selected
+ * category resolves to the general prompt — e.g. after a category with a
+ * dedicated overlay is renamed in the component library admin UI, which
+ * silently stops the overlay from matching.
+ */
+export const hasDedicatedPrompt = (categoryName?: string): boolean =>
+  resolveOverlay(categoryName) !== undefined
+
 /**
  * Builds the optional taxonomy-constraint block. When the selected category is
  * known we pin componentCategory to it, and when its component types are known
@@ -54,8 +71,7 @@ export const resolveComponentAnalysisPrompt = (
   categoryName?: string,
   availableTypes?: string[]
 ): string => {
-  const key = categoryName?.trim().toLowerCase()
-  const domain = (key && OVERLAYS[key]) || generalPrompt
+  const domain = resolveOverlay(categoryName) ?? generalPrompt
   const constraint = buildTaxonomyConstraint(categoryName, availableTypes)
 
   return [domain, BASE_INSTRUCTIONS, constraint, OUTPUT_FORMAT]

--- a/services/property/src/prompts/component-analysis/index.ts
+++ b/services/property/src/prompts/component-analysis/index.ts
@@ -1,0 +1,64 @@
+import { BASE_INSTRUCTIONS } from './base'
+import { OUTPUT_FORMAT } from './output-format'
+import { vitvarorPrompt } from './vitvaror'
+import { generalPrompt } from './general'
+
+// Category-specific domain overlays, keyed by the normalised (trimmed,
+// lowercased) component_categories.categoryName from the component library.
+// Each overlay only frames the domain (expert role + focus list); the shared
+// analysis instructions and output contract are added by the resolver.
+// Add a new category by creating an overlay file and registering it here; any
+// category without an entry falls back to the general overlay.
+const OVERLAYS: Record<string, string> = {
+  vitvaror: vitvarorPrompt,
+}
+
+/**
+ * Builds the optional taxonomy-constraint block. When the selected category is
+ * known we pin componentCategory to it, and when its component types are known
+ * we force the model to classify componentType into one of the real type names
+ * (or null) instead of inventing free text.
+ */
+const buildTaxonomyConstraint = (
+  categoryName?: string,
+  availableTypes?: string[]
+): string => {
+  if (!categoryName) {
+    return ''
+  }
+
+  const pin = `Komponenten tillhör kategorin "${categoryName}". Sätt componentCategory till "${categoryName}".`
+
+  if (!availableTypes?.length) {
+    return pin
+  }
+
+  const list = availableTypes.map((type) => `- ${type}`).join('\n')
+  return `${pin}\nVälj componentType EXAKT från följande lista (kopiera stavningen) eller sätt componentType till null om ingen passar:\n${list}`
+}
+
+/**
+ * Resolves the system prompt for component image analysis.
+ *
+ * Composes the domain overlay for the given category (or the general fallback)
+ * with the shared base instructions, an optional taxonomy constraint, and the
+ * JSON output contract — so every prompt behaves consistently and returns the
+ * same AIComponentAnalysis shape.
+ *
+ * @param categoryName - Category name from the component library (optional)
+ * @param availableTypes - Component type names under the category (optional);
+ *   when provided, the model is constrained to pick componentType from them
+ * @returns Composed system prompt string
+ */
+export const resolveComponentAnalysisPrompt = (
+  categoryName?: string,
+  availableTypes?: string[]
+): string => {
+  const key = categoryName?.trim().toLowerCase()
+  const domain = (key && OVERLAYS[key]) || generalPrompt
+  const constraint = buildTaxonomyConstraint(categoryName, availableTypes)
+
+  return [domain, BASE_INSTRUCTIONS, constraint, OUTPUT_FORMAT]
+    .filter(Boolean)
+    .join('\n\n')
+}

--- a/services/property/src/prompts/component-analysis/output-format.ts
+++ b/services/property/src/prompts/component-analysis/output-format.ts
@@ -1,6 +1,6 @@
 // Shared JSON output contract for component image analysis.
 // This is the SINGLE source of the response format and must stay in sync with
-// AIComponentAnalysisSchema in ../../types/ai-analysis.ts. Category-specific
+// AIComponentAnalysisSchema in @onecore/types (libs/types/src/property/schema.ts). Category-specific
 // prompts only describe domain guidance; the resolver appends this block so the
 // 14-field contract is never duplicated (and never drifts) across prompt files.
 export const OUTPUT_FORMAT = `Svara ENDAST med JSON i följande format (inget annat text):

--- a/services/property/src/prompts/component-analysis/output-format.ts
+++ b/services/property/src/prompts/component-analysis/output-format.ts
@@ -1,0 +1,24 @@
+// Shared JSON output contract for component image analysis.
+// This is the SINGLE source of the response format and must stay in sync with
+// AIComponentAnalysisSchema in ../../types/ai-analysis.ts. Category-specific
+// prompts only describe domain guidance; the resolver appends this block so the
+// 14-field contract is never duplicated (and never drifts) across prompt files.
+export const OUTPUT_FORMAT = `Svara ENDAST med JSON i följande format (inget annat text):
+{
+  "componentCategory": "övergripande kategori (t.ex. 'Vitvaror', 'VVS', 'Ventilation', 'Ytskikt')",
+  "componentType": "typ av komponent (t.ex. 'Kylskåp', 'Radiator', 'Golv')",
+  "componentSubtype": "specifik variant om det går att avgöra (annars null)",
+  "manufacturer": "tillverkare/märke (om synligt, annars null)",
+  "model": "modellnamn/nummer (om synligt, annars null)",
+  "serialNumber": "serienummer (om synligt på bild, annars null)",
+  "estimatedAge": "uppskattad ålder som text (t.ex. '5-10 år', 'Ny', 'Okänd')",
+  "condition": "visuellt skick som text (t.ex. 'Utmärkt', 'Gott', 'Normalt', 'Slitet')",
+  "specifications": "tekniska specifikationer om synliga (annars null)",
+  "dimensions": "fysiska mått om synliga på etikett (t.ex. 'BxDxH: 60x60x85 cm', annars null)",
+  "warrantyMonths": "garantitid i månader om synlig (t.ex. från garantietikett, annars null)",
+  "ncsCode": "NCS-färgkod om synlig (format XXX eller XXX.XXX, annars null)",
+  "additionalInformation": "övrig relevant information synlig på produkten (annars null)",
+  "confidence": 0.85
+}
+
+VIKTIGT: Fyll ENDAST i fält där information är synlig eller kan extraheras från bilden. Använd null för fält där du inte är säker. Var konservativ med confidence-värdet (0.0-1.0).`

--- a/services/property/src/prompts/component-analysis/vitvaror.ts
+++ b/services/property/src/prompts/component-analysis/vitvaror.ts
@@ -1,0 +1,13 @@
+// Domain overlay for white goods / household appliances (vitvaror).
+// Only the domain framing and focus list — the resolver prepends this before
+// the shared BASE_INSTRUCTIONS and appends OUTPUT_FORMAT.
+export const vitvarorPrompt = `Du är en expert på svenska vitvaror och hushållsapparater.
+
+Fokusera på dessa typer av vitvaror:
+- Kylskåp, Kyl/Frys-kombinationer
+- Spisar, Ugnar, Häll
+- Diskmaskiner
+- Tvättmaskiner, Torktumlare, Torkskåp
+- Mikrovågsugnar
+- Fläktar, Köksfläktar
+- Värmepumpar`

--- a/services/property/src/routes/ai-analysis.ts
+++ b/services/property/src/routes/ai-analysis.ts
@@ -1,12 +1,10 @@
 import KoaRouter from '@koa/router'
 import { generateRouteMetadata, logger } from '@onecore/utilities'
 import { parseRequest } from '../middleware/parse-request'
-import {
-  AnalyzeComponentImageRequestSchema,
-  AIComponentAnalysisSchema,
-} from '../types/component'
+import { AnalyzeComponentImageRequestSchema } from '../types/component'
 import { analyzeComponentImage } from '../adapters/berget-adapter'
 import { getComponentCategoryById } from '../adapters/component-category-adapter'
+import { hasDedicatedPrompt } from '../prompts/component-analysis'
 
 /**
  * @swagger
@@ -135,18 +133,37 @@ export const routes = (router: KoaRouter) => {
           | { categoryName: string; availableTypes: string[] }
           | undefined
         if (categoryId) {
-          const category = await getComponentCategoryById(categoryId)
-          if (category) {
-            taxonomy = {
-              categoryName: category.categoryName,
-              availableTypes: category.componentTypes.map(
-                (type) => type.typeName
-              ),
+          try {
+            const category = await getComponentCategoryById(categoryId)
+            if (category) {
+              taxonomy = {
+                categoryName: category.categoryName,
+                availableTypes: category.componentTypes.map(
+                  (type) => type.typeName
+                ),
+              }
+              if (!hasDedicatedPrompt(category.categoryName)) {
+                // Normal for most categories — but if a category that HAS a
+                // dedicated overlay (e.g. "Vitvaror") is renamed in the
+                // component library, this is the only signal that its
+                // analyses silently degraded to the general prompt.
+                logger.info(
+                  { categoryId, categoryName: category.categoryName },
+                  'components.analyze-image: no dedicated prompt for category, using general prompt'
+                )
+              }
+            } else {
+              logger.warn(
+                { categoryId },
+                'components.analyze-image: unknown categoryId, using general prompt'
+              )
             }
-          } else {
+          } catch (err) {
+            // The taxonomy is an enhancement — a failed lookup must not abort
+            // the analysis (or leak the underlying error to the client).
             logger.warn(
-              { categoryId },
-              'components.analyze-image: unknown categoryId, using general prompt'
+              { err, categoryId },
+              'components.analyze-image: category lookup failed, using general prompt'
             )
           }
         }

--- a/services/property/src/routes/ai-analysis.ts
+++ b/services/property/src/routes/ai-analysis.ts
@@ -6,6 +6,7 @@ import {
   AIComponentAnalysisSchema,
 } from '../types/component'
 import { analyzeComponentImage } from '../adapters/berget-adapter'
+import { getComponentCategoryById } from '../adapters/component-category-adapter'
 
 /**
  * @swagger
@@ -41,6 +42,10 @@ export const routes = (router: KoaRouter) => {
    *               additionalImage:
    *                 type: string
    *                 description: Optional additional base64 encoded image (max 10MB) - combine typeplate + product photo for best results
+   *               categoryId:
+   *                 type: string
+   *                 format: uuid
+   *                 description: Optional component category id from the component library - the service uses it to select the analysis prompt and to constrain the classification to the component types under that category (falls back to a general prompt when omitted or unknown)
    *     responses:
    *       200:
    *         description: Component analysis successful
@@ -121,9 +126,43 @@ export const routes = (router: KoaRouter) => {
       const metadata = generateRouteMetadata(ctx)
 
       try {
-        const { image, additionalImage } = ctx.request.parsedBody
-        const analysis = await analyzeComponentImage(image, additionalImage)
+        const { image, additionalImage, categoryId } = ctx.request.parsedBody
 
+        // When a category is selected, look up its name (selects the prompt)
+        // and the component types under it (constrains the classification).
+        // An unknown id falls back to the general prompt rather than failing.
+        let taxonomy:
+          | { categoryName: string; availableTypes: string[] }
+          | undefined
+        if (categoryId) {
+          const category = await getComponentCategoryById(categoryId)
+          if (category) {
+            taxonomy = {
+              categoryName: category.categoryName,
+              availableTypes: category.componentTypes.map(
+                (type) => type.typeName
+              ),
+            }
+          } else {
+            logger.warn(
+              { categoryId },
+              'components.analyze-image: unknown categoryId, using general prompt'
+            )
+          }
+        }
+
+        const analysis = await analyzeComponentImage(
+          image,
+          additionalImage,
+          taxonomy
+        )
+
+        // TODO: type-id mapping (next step). The AI returns componentType as a
+        // name constrained to the category's types. Map it back to the matching
+        // category.componentTypes[].id and return a componentTypeId so Odoo can
+        // link directly to the type. Requires keeping the {id, typeName} pairs
+        // here (not just typeName) and adding componentTypeId to the response
+        // schema in both property and core.
         ctx.status = 200
         ctx.body = {
           content: analysis,

--- a/services/property/src/tests/ai-analysis.test.ts
+++ b/services/property/src/tests/ai-analysis.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest'
 import app from '../app'
 import * as bergetAdapter from '../adapters/berget-adapter'
 import * as componentCategoryAdapter from '../adapters/component-category-adapter'
+import { logger } from '@onecore/utilities'
 
 beforeEach(jest.restoreAllMocks)
 
@@ -44,6 +45,22 @@ describe('AI Analysis API', () => {
       })
     })
 
+    it('accepts image payloads larger than the 1mb koa-body default', async () => {
+      jest
+        .spyOn(bergetAdapter, 'analyzeComponentImage')
+        .mockResolvedValueOnce(mockAnalysisResult)
+
+      // ~2MB base64 image — rejected with 413 before jsonLimit was raised
+      const largeBase64Image = `data:image/jpeg;base64,${'A'.repeat(2_000_000)}`
+
+      const res = await request(app.callback())
+        .post('/components/analyze-image')
+        .send({ image: largeBase64Image })
+
+      expect(res.status).toBe(200)
+      expect(res.body.content.componentCategory).toBe('Vitvara')
+    })
+
     it('returns 200 with analysis when both images provided', async () => {
       const analyzeSpy = jest
         .spyOn(bergetAdapter, 'analyzeComponentImage')
@@ -65,6 +82,7 @@ describe('AI Analysis API', () => {
     })
 
     it('looks up the category and forwards its name and types to the analyzer', async () => {
+      const infoSpy = jest.spyOn(logger, 'info')
       const categoryId = '11111111-1111-1111-1111-111111111111'
       const date = new Date()
       jest
@@ -107,6 +125,39 @@ describe('AI Analysis API', () => {
         categoryName: 'Vitvaror',
         availableTypes: ['Kylskåp', 'Diskmaskin'],
       })
+      expect(infoSpy).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'components.analyze-image: no dedicated prompt for category, using general prompt'
+      )
+    })
+
+    it('logs when the selected category has no dedicated prompt', async () => {
+      const infoSpy = jest.spyOn(logger, 'info')
+      const categoryId = '44444444-4444-4444-4444-444444444444'
+      const date = new Date()
+      jest
+        .spyOn(componentCategoryAdapter, 'getComponentCategoryById')
+        .mockResolvedValueOnce({
+          id: categoryId,
+          categoryName: 'VVS',
+          description: '',
+          createdAt: date,
+          updatedAt: date,
+          componentTypes: [],
+        })
+      jest
+        .spyOn(bergetAdapter, 'analyzeComponentImage')
+        .mockResolvedValueOnce(mockAnalysisResult)
+
+      const res = await request(app.callback())
+        .post('/components/analyze-image')
+        .send({ image: validBase64Image, categoryId })
+
+      expect(res.status).toBe(200)
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ categoryName: 'VVS' }),
+        'components.analyze-image: no dedicated prompt for category, using general prompt'
+      )
     })
 
     it('falls back to the general prompt when categoryId is unknown', async () => {
@@ -130,6 +181,36 @@ describe('AI Analysis API', () => {
         undefined,
         undefined
       )
+    })
+
+    it('falls back to the general prompt when the category lookup fails', async () => {
+      jest
+        .spyOn(componentCategoryAdapter, 'getComponentCategoryById')
+        .mockRejectedValueOnce(new Error('db connection refused'))
+      const analyzeSpy = jest
+        .spyOn(bergetAdapter, 'analyzeComponentImage')
+        .mockResolvedValueOnce(mockAnalysisResult)
+
+      const res = await request(app.callback())
+        .post('/components/analyze-image')
+        .send({
+          image: validBase64Image,
+          categoryId: '33333333-3333-3333-3333-333333333333',
+        })
+
+      expect(res.status).toBe(200)
+      expect(res.body.content).toMatchObject({
+        componentCategory: 'Vitvara',
+        componentType: 'Kylskåp',
+        confidence: 0.85,
+      })
+      expect(analyzeSpy).toHaveBeenCalledWith(
+        validBase64Image,
+        undefined,
+        undefined
+      )
+      // The DB error must not leak to the client
+      expect(JSON.stringify(res.body)).not.toContain('db connection refused')
     })
 
     it('returns 400 when image is missing', async () => {

--- a/services/property/src/tests/ai-analysis.test.ts
+++ b/services/property/src/tests/ai-analysis.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest'
 import app from '../app'
 import * as bergetAdapter from '../adapters/berget-adapter'
+import * as componentCategoryAdapter from '../adapters/component-category-adapter'
 
 beforeEach(jest.restoreAllMocks)
 
@@ -58,7 +59,76 @@ describe('AI Analysis API', () => {
       expect(res.status).toBe(200)
       expect(analyzeSpy).toHaveBeenCalledWith(
         validBase64Image,
-        validBase64Image
+        validBase64Image,
+        undefined
+      )
+    })
+
+    it('looks up the category and forwards its name and types to the analyzer', async () => {
+      const categoryId = '11111111-1111-1111-1111-111111111111'
+      const date = new Date()
+      jest
+        .spyOn(componentCategoryAdapter, 'getComponentCategoryById')
+        .mockResolvedValueOnce({
+          id: categoryId,
+          categoryName: 'Vitvaror',
+          description: '',
+          createdAt: date,
+          updatedAt: date,
+          componentTypes: [
+            {
+              id: 't1',
+              typeName: 'Kylskåp',
+              categoryId,
+              description: null,
+              createdAt: date,
+              updatedAt: date,
+            },
+            {
+              id: 't2',
+              typeName: 'Diskmaskin',
+              categoryId,
+              description: null,
+              createdAt: date,
+              updatedAt: date,
+            },
+          ],
+        })
+      const analyzeSpy = jest
+        .spyOn(bergetAdapter, 'analyzeComponentImage')
+        .mockResolvedValueOnce(mockAnalysisResult)
+
+      const res = await request(app.callback())
+        .post('/components/analyze-image')
+        .send({ image: validBase64Image, categoryId })
+
+      expect(res.status).toBe(200)
+      expect(analyzeSpy).toHaveBeenCalledWith(validBase64Image, undefined, {
+        categoryName: 'Vitvaror',
+        availableTypes: ['Kylskåp', 'Diskmaskin'],
+      })
+    })
+
+    it('falls back to the general prompt when categoryId is unknown', async () => {
+      jest
+        .spyOn(componentCategoryAdapter, 'getComponentCategoryById')
+        .mockResolvedValueOnce(null)
+      const analyzeSpy = jest
+        .spyOn(bergetAdapter, 'analyzeComponentImage')
+        .mockResolvedValueOnce(mockAnalysisResult)
+
+      const res = await request(app.callback())
+        .post('/components/analyze-image')
+        .send({
+          image: validBase64Image,
+          categoryId: '22222222-2222-2222-2222-222222222222',
+        })
+
+      expect(res.status).toBe(200)
+      expect(analyzeSpy).toHaveBeenCalledWith(
+        validBase64Image,
+        undefined,
+        undefined
       )
     })
 

--- a/services/property/src/types/ai-analysis.ts
+++ b/services/property/src/types/ai-analysis.ts
@@ -14,6 +14,10 @@ export const AnalyzeComponentImageRequestSchema = z.object({
     .string()
     .max(14_000_000, 'Additional image too large (max 10MB)')
     .optional(),
+  // Component category id from the component library. The service looks up the
+  // category (selects the analysis prompt) and its component types (constrains
+  // the classification). Falls back to a general prompt when omitted.
+  categoryId: z.string().uuid().optional(),
 })
 
 // MVP: Core AI analysis fields focused on Swedish appliances (vitvaror)

--- a/services/property/src/types/ai-analysis.ts
+++ b/services/property/src/types/ai-analysis.ts
@@ -1,59 +1,17 @@
 import { z } from 'zod'
+import { property } from '@onecore/types'
 
-// ==================== AI COMPONENT ANALYSIS (Vitvaror) ====================
+// ==================== AI COMPONENT ANALYSIS ====================
 
-// MVP: Request schema with primary image and optional additional image
-// Base64 encoding adds ~33% overhead: 10MB file ≈ 13.3MB base64
-// Two images allow: typeplate + product photo for better accuracy
-export const AnalyzeComponentImageRequestSchema = z.object({
-  image: z
-    .string()
-    .min(1, 'Base64 image data is required')
-    .max(14_000_000, 'Image too large (max 10MB)'),
-  additionalImage: z
-    .string()
-    .max(14_000_000, 'Additional image too large (max 10MB)')
-    .optional(),
-  // Component category id from the component library. The service looks up the
-  // category (selects the analysis prompt) and its component types (constrains
-  // the classification). Falls back to a general prompt when omitted.
-  categoryId: z.string().uuid().optional(),
-})
+// Re-exported from @onecore/types (single source of truth shared with the
+// core proxy). Keep the local export names so the route, the berget adapter
+// and the swagger registration are unaffected.
+export const AnalyzeComponentImageRequestSchema =
+  property.AnalyzeComponentImageRequestSchema
+export const AIComponentAnalysisSchema = property.AIComponentAnalysisSchema
 
-// MVP: Core AI analysis fields focused on Swedish appliances (vitvaror)
-// All fields nullable except confidence (AI might not detect everything)
-export const AIComponentAnalysisSchema = z.object({
-  // Basic identification fields (three-level taxonomy)
-  componentCategory: z.string().nullable(), // Broad category: "Vitvara", "VVS", etc.
-  componentType: z.string().nullable(), // Appliance type: "Kylskåp", "Diskmaskin"
-  componentSubtype: z.string().nullable(), // Variant: "60cm integrerad", "Fristående 190L"
-  manufacturer: z.string().nullable(),
-  model: z.string().nullable(),
-  serialNumber: z.string().nullable(),
-
-  // Condition and age assessment
-  estimatedAge: z.string().nullable(),
-  condition: z.string().nullable(),
-
-  // Technical information from labels
-  specifications: z.string().nullable(),
-  dimensions: z.string().nullable(),
-  warrantyMonths: z.number().int().min(0).nullable(),
-
-  // Classification codes
-  ncsCode: z.string().nullable(),
-
-  // Additional information
-  additionalInformation: z.string().nullable(),
-
-  // Confidence score (always present)
-  confidence: z.number().min(0).max(1),
-})
-
-export type AnalyzeComponentImageRequest = z.infer<
-  typeof AnalyzeComponentImageRequestSchema
->
-export type AIComponentAnalysis = z.infer<typeof AIComponentAnalysisSchema>
+export type AnalyzeComponentImageRequest = property.AnalyzeComponentImageRequest
+export type AIComponentAnalysis = property.AIComponentAnalysis
 
 // ==================== AI SCANNER ANALYSIS ====================
 


### PR DESCRIPTION
## Summary

`POST /components/analyze-image` previously used a single hardcoded prompt for
white goods (vitvaror). It now selects the system prompt per component category
and constrains the AI's classification to the real component types in the
library, with a general fallback for categories without a dedicated prompt.

## What's in the change

- **New optional `categoryId` (uuid) on the request.** When provided, the
  property service looks up the category: its name selects the prompt overlay,
  and its component types are injected as the allowed `componentType` values
  (the model must copy one verbatim or return null). Unknown ids and failed
  lookups log and degrade to the general prompt rather than failing the
  analysis — the taxonomy is an enhancement, never a requirement.
- **Composable prompts** (`prompts/component-analysis/`): a category overlay
  (e.g. vitvaror) + shared base instructions + optional taxonomy constraint +
  a single JSON output contract. Adding a category is one overlay file plus a
  registry entry, and the response format can't drift between prompts.
- **AI output is validated at the source.** The Berget adapter clamps
  near-miss numeric values (confidence into 0–1, warrantyMonths rounded,
  negative/non-numeric → null) and validates the result against the response
  schema. Out-of-contract responses fail in the property service with a
  curated message; raw zod/JSON diagnostics are logged server-side and never
  reach the client.
- **Schemas live once in `@onecore/types`** (`libs/types/src/property`) and
  are re-exported under unchanged names in core and the property service.
  This fixes two user-facing bugs from the previous duplicated copies: core
  stripped `componentCategory` from responses (Zod removes unknown keys), and
  core rejected base64 images between 10MiB and the real 14M-char limit.
  Regression tests pin both sides of the size boundary.
- **Rename observability.** Categories can be renamed in the property-tree
  admin UI, which silently un-matches a name-keyed prompt overlay. The route
  logs when a selected category resolves to the general prompt so a downgrade
  is diagnosable.
- Deterministic `componentTypes` ordering in the category lookup, and core's
  component DELETE tests now mock their child-lookup adapters (they previously
  depended on whether a local property service was running).

## Notes for reviewers

- **Odoo is the consumer** of this endpoint. The request shape is backwards
  compatible (`categoryId` optional); responses now reliably include
  `componentCategory`.
- No generated files were hand-edited; core's generated api-types were
  regenerated from the property swagger.
- Known gap (pre-existing, not addressed here): the property service's own
  koa-body has no `jsonLimit` (default 1mb), so the 10MB image contract is not
  yet reachable end-to-end. Flagged separately.
- Possible future work: a `promptKey` column on `component_categories` would
  make overlays rename-proof, but needs a migration + admin UI changes.

## Testing

- New unit tests: prompt resolver (12), Berget adapter with mocked axios (8)
- Route tests: category forwarding, unknown-id and lookup-failure fallbacks,
  no error-text leakage, overlay-downgrade logging in both directions
- Core: drift-regression tests for the image-size boundary (11M chars → 200,
  14M+1 → 400)
- `pnpm run typecheck` clean across all 18 packages; full affected suites green
