### PR TITLE
MIM-1877 Include subgroup members when resolving Keycloak role users

### DIFF
--- a/core/src/services/auth-service/keycloak-admin-adapter.ts
+++ b/core/src/services/auth-service/keycloak-admin-adapter.ts
@@ -148,24 +148,29 @@ async function expandGroupTree(
   token: string
 ): Promise<string[]> {
   const visited = new Set<string>()
-  const queue: string[] = []
+  let frontier: string[] = []
 
   for (const id of rootGroupIds) {
     if (!visited.has(id)) {
       visited.add(id)
-      queue.push(id)
+      frontier.push(id)
     }
   }
 
-  while (queue.length > 0) {
-    const id = queue.shift() as string
-    const children = await fetchAllChildren(id, token)
-    for (const child of children) {
-      if (!visited.has(child.id)) {
-        visited.add(child.id)
-        queue.push(child.id)
+  while (frontier.length > 0) {
+    const childrenPerGroup = await Promise.all(
+      frontier.map((id) => fetchAllChildren(id, token))
+    )
+    const nextFrontier: string[] = []
+    for (const children of childrenPerGroup) {
+      for (const child of children) {
+        if (!visited.has(child.id)) {
+          visited.add(child.id)
+          nextFrontier.push(child.id)
+        }
       }
     }
+    frontier = nextFrontier
   }
 
   return Array.from(visited)

--- a/core/src/services/auth-service/keycloak-admin-adapter.ts
+++ b/core/src/services/auth-service/keycloak-admin-adapter.ts
@@ -105,6 +105,72 @@ async function fetchGroupMembers(groupId: string, token: string) {
   )
 }
 
+// Keycloak's role-mapping is set on a single group, but users in its subgroups
+// inherit the role too. `/groups/{id}/members` returns only direct members and
+// has no flag to descend, so we walk the hierarchy via `/groups/{id}/children`
+// and collect every descendant group id ourselves.
+async function fetchGroupChildren(
+  groupId: string,
+  token: string,
+  first: number
+) {
+  const { url, realm } = config.auth.keycloak
+  return loggedAxios.get(
+    `${url}/admin/realms/${realm}/groups/${encodeURIComponent(groupId)}/children`,
+    {
+      params: { first, max: GROUP_CHILDREN_PAGE_SIZE },
+      headers: { Authorization: `Bearer ${token}` },
+      validateStatus: (status) => status >= 200 && status < 300,
+    }
+  )
+}
+
+const GROUP_CHILDREN_PAGE_SIZE = 100
+
+async function fetchAllChildren(
+  groupId: string,
+  token: string
+): Promise<{ id: string }[]> {
+  const children: { id: string }[] = []
+  let first = 0
+  while (true) {
+    const res = await fetchGroupChildren(groupId, token, first)
+    const page: { id: string }[] = Array.isArray(res.data) ? res.data : []
+    children.push(...page)
+    if (page.length < GROUP_CHILDREN_PAGE_SIZE) break
+    first += GROUP_CHILDREN_PAGE_SIZE
+  }
+  return children
+}
+
+async function expandGroupTree(
+  rootGroupIds: string[],
+  token: string
+): Promise<string[]> {
+  const visited = new Set<string>()
+  const queue: string[] = []
+
+  for (const id of rootGroupIds) {
+    if (!visited.has(id)) {
+      visited.add(id)
+      queue.push(id)
+    }
+  }
+
+  while (queue.length > 0) {
+    const id = queue.shift() as string
+    const children = await fetchAllChildren(id, token)
+    for (const child of children) {
+      if (!visited.has(child.id)) {
+        visited.add(child.id)
+        queue.push(child.id)
+      }
+    }
+  }
+
+  return Array.from(visited)
+}
+
 async function fetchUsersByRoleViaGroups(roleName: string, token: string) {
   const groupsRes = await fetchGroupsByRole(roleName, token)
   const groups: { id: string }[] = Array.isArray(groupsRes.data)
@@ -113,8 +179,13 @@ async function fetchUsersByRoleViaGroups(roleName: string, token: string) {
 
   if (groups.length === 0) return []
 
+  const allGroupIds = await expandGroupTree(
+    groups.map((g) => g.id),
+    token
+  )
+
   const memberResults = await Promise.all(
-    groups.map((group) => fetchGroupMembers(group.id, token))
+    allGroupIds.map((id) => fetchGroupMembers(id, token))
   )
 
   const seen = new Set<string>()

--- a/core/src/services/auth-service/tests/keycloak-admin-adapter.test.ts
+++ b/core/src/services/auth-service/tests/keycloak-admin-adapter.test.ts
@@ -9,6 +9,8 @@ const rolesUrl = (role: string) =>
   `${url}/admin/realms/${realm}/roles/${encodeURIComponent(role)}/groups`
 const membersUrl = (groupId: string) =>
   `${url}/admin/realms/${realm}/groups/${encodeURIComponent(groupId)}/members`
+const childrenUrl = (groupId: string) =>
+  `${url}/admin/realms/${realm}/groups/${encodeURIComponent(groupId)}/children`
 
 const mockServer = setupServer()
 
@@ -76,6 +78,9 @@ describe('keycloak-admin-adapter', () => {
         http.get(rolesUrl('admin'), () =>
           HttpResponse.json([{ id: 'g1' }], { status: 200 })
         ),
+        http.get(childrenUrl('g1'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
         http.get(membersUrl('g1'), () =>
           HttpResponse.json([user], { status: 200 })
         )
@@ -95,6 +100,12 @@ describe('keycloak-admin-adapter', () => {
         http.get(rolesUrl('admin'), () =>
           HttpResponse.json([{ id: 'g1' }, { id: 'g2' }], { status: 200 })
         ),
+        http.get(childrenUrl('g1'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(childrenUrl('g2'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
         http.get(membersUrl('g1'), () =>
           HttpResponse.json([alice, bob], { status: 200 })
         ),
@@ -106,6 +117,148 @@ describe('keycloak-admin-adapter', () => {
       const result = await getUsersByRole('admin')
 
       expect(result).toEqual({ ok: true, data: [alice, bob] })
+    })
+
+    it('includes members of subgroups of role-mapped groups', async () => {
+      const alice = { id: 'u1', username: 'alice' }
+      const bob = { id: 'u2', username: 'bob' }
+      const carol = { id: 'u3', username: 'carol' }
+
+      mockServer.use(
+        tokenHandler(),
+        http.get(rolesUrl('admin'), () =>
+          HttpResponse.json([{ id: 'parent' }], { status: 200 })
+        ),
+        http.get(childrenUrl('parent'), () =>
+          HttpResponse.json([{ id: 'sub-a' }, { id: 'sub-b' }], { status: 200 })
+        ),
+        http.get(childrenUrl('sub-a'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(childrenUrl('sub-b'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(membersUrl('parent'), () =>
+          HttpResponse.json([alice], { status: 200 })
+        ),
+        http.get(membersUrl('sub-a'), () =>
+          HttpResponse.json([bob], { status: 200 })
+        ),
+        http.get(membersUrl('sub-b'), () =>
+          HttpResponse.json([carol], { status: 200 })
+        )
+      )
+
+      const result = await getUsersByRole('admin')
+
+      if (!result.ok) throw new Error('expected ok')
+      expect(result.data).toEqual(expect.arrayContaining([alice, bob, carol]))
+      expect(result.data).toHaveLength(3)
+    })
+
+    it('descends recursively into nested subgroups', async () => {
+      const alice = { id: 'u1', username: 'alice' }
+      const grandchildMember = { id: 'u2', username: 'deep' }
+
+      mockServer.use(
+        tokenHandler(),
+        http.get(rolesUrl('admin'), () =>
+          HttpResponse.json([{ id: 'parent' }], { status: 200 })
+        ),
+        http.get(childrenUrl('parent'), () =>
+          HttpResponse.json([{ id: 'child' }], { status: 200 })
+        ),
+        http.get(childrenUrl('child'), () =>
+          HttpResponse.json([{ id: 'grandchild' }], { status: 200 })
+        ),
+        http.get(childrenUrl('grandchild'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(membersUrl('parent'), () =>
+          HttpResponse.json([alice], { status: 200 })
+        ),
+        http.get(membersUrl('child'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(membersUrl('grandchild'), () =>
+          HttpResponse.json([grandchildMember], { status: 200 })
+        )
+      )
+
+      const result = await getUsersByRole('admin')
+
+      if (!result.ok) throw new Error('expected ok')
+      expect(result.data).toEqual(
+        expect.arrayContaining([alice, grandchildMember])
+      )
+      expect(result.data).toHaveLength(2)
+    })
+
+    it('deduplicates a user present in both parent and subgroup', async () => {
+      const alice = { id: 'u1', username: 'alice' }
+
+      mockServer.use(
+        tokenHandler(),
+        http.get(rolesUrl('admin'), () =>
+          HttpResponse.json([{ id: 'parent' }], { status: 200 })
+        ),
+        http.get(childrenUrl('parent'), () =>
+          HttpResponse.json([{ id: 'child' }], { status: 200 })
+        ),
+        http.get(childrenUrl('child'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(membersUrl('parent'), () =>
+          HttpResponse.json([alice], { status: 200 })
+        ),
+        http.get(membersUrl('child'), () =>
+          HttpResponse.json([alice], { status: 200 })
+        )
+      )
+
+      const result = await getUsersByRole('admin')
+
+      expect(result).toEqual({ ok: true, data: [alice] })
+    })
+
+    it('pages through /children when a group has more than 100 subgroups', async () => {
+      const member = { id: 'sub-member', username: 'sub-member' }
+      const pageOne = Array.from({ length: 100 }, (_, i) => ({
+        id: `sub-${i}`,
+      }))
+      const pageTwo = [{ id: 'sub-100' }]
+
+      mockServer.use(
+        tokenHandler(),
+        http.get(rolesUrl('admin'), () =>
+          HttpResponse.json([{ id: 'parent' }], { status: 200 })
+        ),
+        http.get(childrenUrl('parent'), ({ request }) => {
+          const u = new URL(request.url)
+          const first = Number(u.searchParams.get('first') ?? '0')
+          if (first === 0) return HttpResponse.json(pageOne, { status: 200 })
+          if (first === 100) return HttpResponse.json(pageTwo, { status: 200 })
+          return HttpResponse.json([], { status: 200 })
+        }),
+        // Every subgroup reports no further children
+        http.get(/\/groups\/[^/]+\/children$/, () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        http.get(membersUrl('parent'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
+        // sub-100 has the only member; every other subgroup is empty
+        http.get(membersUrl('sub-100'), () =>
+          HttpResponse.json([member], { status: 200 })
+        ),
+        http.get(/\/groups\/[^/]+\/members$/, () =>
+          HttpResponse.json([], { status: 200 })
+        )
+      )
+
+      const result = await getUsersByRole('admin')
+
+      expect(result).toEqual({ ok: true, data: [member] })
     })
 
     it('returns empty array when role has no groups', async () => {
@@ -134,6 +287,9 @@ describe('keycloak-admin-adapter', () => {
           }
           return HttpResponse.json([{ id: 'g1' }], { status: 200 })
         }),
+        http.get(childrenUrl('g1'), () =>
+          HttpResponse.json([], { status: 200 })
+        ),
         http.get(membersUrl('g1'), () =>
           HttpResponse.json([user], { status: 200 })
         )


### PR DESCRIPTION
## Summary
- Property-managers in Keycloak subgroups were missing from the property-areas page because the adapter only fetched direct members of the role-mapped group.
- `/groups/{id}/members` returns only direct members and has no flag to descend; `/roles/{role}/groups` only lists groups the role is directly mapped to.
- Fix: walk the group hierarchy via `/groups/{id}/children` (paginated, BFS, de-duped) starting from the role-mapped groups, then fetch members for every descendant.

## Test plan
- [x] New unit tests in `keycloak-admin-adapter.test.ts` cover: subgroup inclusion, nested (grandchild) descent, parent+subgroup user de-duplication, and `/children` pagination >100.
- [x] Existing 188 property-base-service tests still pass.
- [x] `core` typecheck clean.
- [ ] Verify in staging: place a user in a subgroup of `Förvaltningsområden` and confirm they appear on the property-areas page.
