### PR TITLE
MIM-1567: Show skyddad identitet status on kundkortet + listor

### DIFF
--- a/apps/property-tree/src/entities/tenant/hooks/useTenantSearch.ts
+++ b/apps/property-tree/src/entities/tenant/hooks/useTenantSearch.ts
@@ -7,6 +7,7 @@ import type { ContactSearchResult } from '@/services/api/core/tenantService'
 export interface TenantSearchResult {
   fullName: string
   contactCode: string
+  protectedIdentity?: boolean
 }
 
 export const useTenantSearch = () => {
@@ -27,6 +28,7 @@ export const useTenantSearch = () => {
       return contactsSearchQuery.data.map((contact: ContactSearchResult) => ({
         fullName: contact.fullName,
         contactCode: contact.contactCode,
+        protectedIdentity: contact.protectedIdentity,
       }))
     }
 

--- a/apps/property-tree/src/entities/tenant/index.ts
+++ b/apps/property-tree/src/entities/tenant/index.ts
@@ -3,6 +3,8 @@ export { ProtectedIdentityBadge } from './ui/ProtectedIdentityBadge'
 export { TenantCard } from './ui/TenantCard'
 export { TenantContactActions } from './ui/TenantContactActions'
 export { TenantLeaseCard } from './ui/TenantLeaseCard'
+export { TenantName } from './ui/TenantName'
+export { TenantNameLink } from './ui/TenantNameLink'
 export { TenantPersonalInfo } from './ui/TenantPersonalInfo'
 
 // Formatting utilities

--- a/apps/property-tree/src/entities/tenant/index.ts
+++ b/apps/property-tree/src/entities/tenant/index.ts
@@ -1,4 +1,5 @@
 // UI Components
+export { ProtectedIdentityBadge } from './ui/ProtectedIdentityBadge'
 export { TenantCard } from './ui/TenantCard'
 export { TenantContactActions } from './ui/TenantContactActions'
 export { TenantLeaseCard } from './ui/TenantLeaseCard'

--- a/apps/property-tree/src/entities/tenant/lib/formatting.ts
+++ b/apps/property-tree/src/entities/tenant/lib/formatting.ts
@@ -11,7 +11,11 @@ export function formatTenantName(tenant: {
   firstName?: string | null
   lastName?: string | null
   fullName?: string | null
+  protectedIdentity?: boolean
 }) {
+  if (tenant.protectedIdentity) {
+    return 'Skyddad identitet'
+  }
   return tenant.firstName && tenant.lastName
     ? `${tenant.firstName} ${tenant.lastName}`
     : tenant.fullName || '-'

--- a/apps/property-tree/src/entities/tenant/ui/ProtectedIdentityBadge.tsx
+++ b/apps/property-tree/src/entities/tenant/ui/ProtectedIdentityBadge.tsx
@@ -1,0 +1,45 @@
+import { ShieldAlert } from 'lucide-react'
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/shared/ui/Tooltip'
+
+type Size = 'sm' | 'md'
+
+interface ProtectedIdentityBadgeProps {
+  size?: Size
+}
+
+const SIZE_CLASSES: Record<Size, { wrapper: string; icon: string }> = {
+  sm: { wrapper: 'w-5 h-5', icon: 'h-3 w-3' },
+  md: { wrapper: 'w-8 h-8', icon: 'h-4 w-4' },
+}
+
+export function ProtectedIdentityBadge({
+  size = 'md',
+}: ProtectedIdentityBadgeProps) {
+  const { wrapper, icon } = SIZE_CLASSES[size]
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className={`flex items-center justify-center ${wrapper} bg-red-100 rounded-full border border-red-200 cursor-help shrink-0`}
+            aria-label="Skyddad identitet"
+          >
+            <ShieldAlert className={`${icon} text-red-600`} />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>
+            Skyddad identitet. Hantera kunduppgifter med särskild varsamhet.
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/apps/property-tree/src/entities/tenant/ui/TenantLeaseCard.tsx
+++ b/apps/property-tree/src/entities/tenant/ui/TenantLeaseCard.tsx
@@ -1,7 +1,11 @@
 import { Link } from 'react-router-dom'
 import { User, Users } from 'lucide-react'
 
-import { TenantContactActions, TenantPersonalInfo } from '@/entities/tenant'
+import {
+  ProtectedIdentityBadge,
+  TenantContactActions,
+  TenantPersonalInfo,
+} from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core/leaseService'
 
@@ -28,9 +32,10 @@ export function TenantLeaseCard({
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
-        <div className="flex items-center">
+        <div className="flex items-center gap-2">
           <Users className="h-5 w-5 mr-2 text-slate-500" />
           <h4 className="font-medium">Kontraktsinnehavare</h4>
+          {tenant.protectedIdentity && <ProtectedIdentityBadge size="sm" />}
         </div>
         <Button variant="outline" asChild className="shrink-0">
           <Link to={paths.tenant(tenant.contactCode)} rel="noopener noreferrer">

--- a/apps/property-tree/src/entities/tenant/ui/TenantName.tsx
+++ b/apps/property-tree/src/entities/tenant/ui/TenantName.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react'
+
+interface TenantNameProps {
+  protectedIdentity?: boolean
+  fullName?: string | null
+  fallback?: string
+  /**
+   * Overrides the rendered name when protectedIdentity is false. Use when
+   * the name needs to be assembled from multiple fields (e.g. firstName +
+   * lastName in the TenantPage header).
+   */
+  children?: ReactNode
+}
+
+/**
+ * Renders a contact/tenant name. When protectedIdentity is true the name is
+ * replaced by an italic "Skyddad identitet" placeholder — keep callers from
+ * having to repeat this conditional in every list cell.
+ */
+export function TenantName({
+  protectedIdentity,
+  fullName,
+  fallback = '-',
+  children,
+}: TenantNameProps) {
+  if (protectedIdentity) {
+    return (
+      <span className="italic text-muted-foreground">Skyddad identitet</span>
+    )
+  }
+  if (children !== undefined) {
+    return <>{children}</>
+  }
+  return <>{fullName || fallback}</>
+}

--- a/apps/property-tree/src/entities/tenant/ui/TenantNameLink.tsx
+++ b/apps/property-tree/src/entities/tenant/ui/TenantNameLink.tsx
@@ -1,0 +1,57 @@
+import { Link } from 'react-router-dom'
+
+import { cn } from '@/shared/lib/utils'
+import { paths } from '@/shared/routes'
+
+import { ProtectedIdentityBadge } from './ProtectedIdentityBadge'
+import { TenantName } from './TenantName'
+
+interface TenantNameLinkProps {
+  contactCode: string
+  fullName?: string | null
+  protectedIdentity?: boolean
+  fallback?: string
+  className?: string
+  badgeSize?: 'sm' | 'md'
+}
+
+/**
+ * Renders a tenant name as a link to the kundkort (when the contact code
+ * starts with P/F) plus the skyddad-identitet badge inline. Replaces the
+ * link/span branching and badge wiring that was duplicated across the lease
+ * list tabs and the lease/contract search results.
+ */
+export function TenantNameLink({
+  contactCode,
+  fullName,
+  protectedIdentity,
+  fallback,
+  className,
+  badgeSize = 'sm',
+}: TenantNameLinkProps) {
+  const isValidContact =
+    contactCode.startsWith('P') || contactCode.startsWith('F')
+  const nameNode = (
+    <TenantName
+      fullName={fullName}
+      protectedIdentity={protectedIdentity}
+      fallback={fallback}
+    />
+  )
+
+  return (
+    <span className={cn('inline-flex items-center gap-2', className)}>
+      {isValidContact ? (
+        <Link
+          to={paths.tenant(contactCode)}
+          className="font-medium text-primary hover:underline"
+        >
+          {nameNode}
+        </Link>
+      ) : (
+        <span className="font-medium">{nameNode}</span>
+      )}
+      {protectedIdentity && <ProtectedIdentityBadge size={badgeSize} />}
+    </span>
+  )
+}

--- a/apps/property-tree/src/features/economy/components/TenantSearchSection.tsx
+++ b/apps/property-tree/src/features/economy/components/TenantSearchSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Search, X } from 'lucide-react'
 
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 import {
   TenantSearchResult,
   useTenantSearch,
@@ -100,7 +101,12 @@ export function TenantSearchSection({
                   onClick={() => handleSelectCustomer(tenant)}
                   className="w-full px-3 py-2 text-left hover:bg-accent hover:text-accent-foreground transition-colors"
                 >
-                  <div className="font-medium">{tenant.fullName}</div>
+                  <div className="font-medium inline-flex items-center gap-2">
+                    {tenant.fullName}
+                    {tenant.protectedIdentity && (
+                      <ProtectedIdentityBadge size="sm" />
+                    )}
+                  </div>
                   <div className="text-sm opacity-70">
                     {tenant.contactCode} • {tenant.fullName}
                   </div>

--- a/apps/property-tree/src/features/economy/components/TenantSearchSection.tsx
+++ b/apps/property-tree/src/features/economy/components/TenantSearchSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Search, X } from 'lucide-react'
 
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { ProtectedIdentityBadge, TenantName } from '@/entities/tenant'
 import {
   TenantSearchResult,
   useTenantSearch,
@@ -102,7 +102,10 @@ export function TenantSearchSection({
                   className="w-full px-3 py-2 text-left hover:bg-accent hover:text-accent-foreground transition-colors"
                 >
                   <div className="font-medium inline-flex items-center gap-2">
-                    {tenant.fullName}
+                    <TenantName
+                      fullName={tenant.fullName}
+                      protectedIdentity={tenant.protectedIdentity}
+                    />
                     {tenant.protectedIdentity && (
                       <ProtectedIdentityBadge size="sm" />
                     )}

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
@@ -203,8 +203,14 @@ export function CreateInspectionDialog({
                       <span className="flex items-center gap-2">
                         <span>
                           Kontrakt {option.lease.leaseNumber} –{' '}
-                          {option.lease.tenants?.[0]?.fullName ??
-                            'Okänd hyresgäst'}
+                          {option.lease.tenants?.[0]?.protectedIdentity ? (
+                            <span className="italic text-muted-foreground">
+                              Skyddad identitet
+                            </span>
+                          ) : (
+                            (option.lease.tenants?.[0]?.fullName ??
+                            'Okänd hyresgäst')
+                          )}
                         </span>
                         {option.lease.tenants?.[0]?.protectedIdentity && (
                           <ProtectedIdentityBadge size="sm" />

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { LeaseStatusBadge } from '@/entities/lease'
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
@@ -205,6 +206,9 @@ export function CreateInspectionDialog({
                           {option.lease.tenants?.[0]?.fullName ??
                             'Okänd hyresgäst'}
                         </span>
+                        {option.lease.tenants?.[0]?.protectedIdentity && (
+                          <ProtectedIdentityBadge size="sm" />
+                        )}
                         <LeaseStatusBadge status={option.lease.status} />
                       </span>
                     ) : (

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { LeaseStatusBadge } from '@/entities/lease'
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { ProtectedIdentityBadge, TenantName } from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
@@ -197,31 +197,31 @@ export function CreateInspectionDialog({
                 <SelectValue placeholder="Välj hyreskontrakt" />
               </SelectTrigger>
               <SelectContent>
-                {leaseOptions.map((option) => (
-                  <SelectItem key={option.value} value={option.value}>
-                    {option.lease ? (
-                      <span className="flex items-center gap-2">
-                        <span>
-                          Kontrakt {option.lease.leaseNumber} –{' '}
-                          {option.lease.tenants?.[0]?.protectedIdentity ? (
-                            <span className="italic text-muted-foreground">
-                              Skyddad identitet
-                            </span>
-                          ) : (
-                            (option.lease.tenants?.[0]?.fullName ??
-                            'Okänd hyresgäst')
+                {leaseOptions.map((option) => {
+                  const tenant = option.lease?.tenants?.[0]
+                  return (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.lease ? (
+                        <span className="flex items-center gap-2">
+                          <span>
+                            Kontrakt {option.lease.leaseNumber} –{' '}
+                            <TenantName
+                              fullName={tenant?.fullName}
+                              protectedIdentity={tenant?.protectedIdentity}
+                              fallback="Okänd hyresgäst"
+                            />
+                          </span>
+                          {tenant?.protectedIdentity && (
+                            <ProtectedIdentityBadge size="sm" />
                           )}
+                          <LeaseStatusBadge status={option.lease.status} />
                         </span>
-                        {option.lease.tenants?.[0]?.protectedIdentity && (
-                          <ProtectedIdentityBadge size="sm" />
-                        )}
-                        <LeaseStatusBadge status={option.lease.status} />
-                      </span>
-                    ) : (
-                      'Inget kontrakt'
-                    )}
-                  </SelectItem>
-                ))}
+                      ) : (
+                        'Inget kontrakt'
+                      )}
+                    </SelectItem>
+                  )
+                })}
               </SelectContent>
             </Select>
           </div>

--- a/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
@@ -1,11 +1,8 @@
-import { Link } from 'react-router-dom'
-
 import { formatDate, LeaseStatusBadge } from '@/entities/lease'
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { TenantNameLink } from '@/entities/tenant'
 
 import type { LeaseSearchResult } from '@/services/api/core/leaseSearchService'
 
-import { paths } from '@/shared/routes'
 import { ObjectTypeBadge } from '@/shared/ui/StatusBadges'
 
 export const leaseColumns = [
@@ -40,17 +37,11 @@ export const leaseColumns = [
         <div className="space-y-1">
           {lease.contacts.map((contact) => (
             <div key={contact.contactCode}>
-              <div className="flex items-center gap-2">
-                <Link
-                  to={paths.tenant(contact.contactCode)}
-                  className="font-medium text-primary hover:underline"
-                >
-                  {contact.name}
-                </Link>
-                {contact.protectedIdentity && (
-                  <ProtectedIdentityBadge size="sm" />
-                )}
-              </div>
+              <TenantNameLink
+                contactCode={contact.contactCode}
+                fullName={contact.name}
+                protectedIdentity={contact.protectedIdentity}
+              />
               <div className="text-sm text-muted-foreground">
                 {contact.contactCode}
               </div>

--- a/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 
 import { formatDate, LeaseStatusBadge } from '@/entities/lease'
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 
 import type { LeaseSearchResult } from '@/services/api/core/leaseSearchService'
 
@@ -39,12 +40,17 @@ export const leaseColumns = [
         <div className="space-y-1">
           {lease.contacts.map((contact) => (
             <div key={contact.contactCode}>
-              <Link
-                to={paths.tenant(contact.contactCode)}
-                className="font-medium text-primary hover:underline"
-              >
-                {contact.name}
-              </Link>
+              <div className="flex items-center gap-2">
+                <Link
+                  to={paths.tenant(contact.contactCode)}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {contact.name}
+                </Link>
+                {contact.protectedIdentity && (
+                  <ProtectedIdentityBadge size="sm" />
+                )}
+              </div>
               <div className="text-sm text-muted-foreground">
                 {contact.contactCode}
               </div>

--- a/apps/property-tree/src/features/leases/ui/LeaseSearchTable.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeaseSearchTable.tsx
@@ -1,11 +1,8 @@
-import { Link } from 'react-router-dom'
-
 import { formatDate, LeaseStatusBadge } from '@/entities/lease'
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { TenantNameLink } from '@/entities/tenant'
 
 import type { LeaseSearchResult } from '@/services/api/core/leaseSearchService'
 
-import { paths } from '@/shared/routes'
 import { ObjectTypeBadge } from '@/shared/ui/StatusBadges'
 
 export function LeaseMobileCard(lease: LeaseSearchResult) {
@@ -25,17 +22,11 @@ export function LeaseMobileCard(lease: LeaseSearchResult) {
           lease.contacts.map((contact) => (
             <div key={contact.contactCode} className="flex justify-between">
               <span className="text-muted-foreground">Hyresgäst:</span>
-              <span className="flex items-center gap-2">
-                <Link
-                  to={paths.tenant(contact.contactCode)}
-                  className="font-medium text-primary hover:underline"
-                >
-                  {contact.name}
-                </Link>
-                {contact.protectedIdentity && (
-                  <ProtectedIdentityBadge size="sm" />
-                )}
-              </span>
+              <TenantNameLink
+                contactCode={contact.contactCode}
+                fullName={contact.name}
+                protectedIdentity={contact.protectedIdentity}
+              />
             </div>
           ))
         ) : (

--- a/apps/property-tree/src/features/leases/ui/LeaseSearchTable.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeaseSearchTable.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 
 import { formatDate, LeaseStatusBadge } from '@/entities/lease'
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 
 import type { LeaseSearchResult } from '@/services/api/core/leaseSearchService'
 
@@ -24,12 +25,17 @@ export function LeaseMobileCard(lease: LeaseSearchResult) {
           lease.contacts.map((contact) => (
             <div key={contact.contactCode} className="flex justify-between">
               <span className="text-muted-foreground">Hyresgäst:</span>
-              <Link
-                to={paths.tenant(contact.contactCode)}
-                className="font-medium text-primary hover:underline"
-              >
-                {contact.name}
-              </Link>
+              <span className="flex items-center gap-2">
+                <Link
+                  to={paths.tenant(contact.contactCode)}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {contact.name}
+                </Link>
+                {contact.protectedIdentity && (
+                  <ProtectedIdentityBadge size="sm" />
+                )}
+              </span>
             </div>
           ))
         ) : (

--- a/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
@@ -4,6 +4,7 @@ import { Loader2 } from 'lucide-react'
 
 import { formatDate, LeaseMobileCard, LeaseStatusBadge } from '@/entities/lease'
 import { useLeasesByRentalProperty } from '@/entities/lease/hooks/useLeasesByRentalProperty'
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core/leaseService'
 
@@ -53,16 +54,21 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
 
           return (
             <div key={tenant.contactCode}>
-              {isValidContact ? (
-                <Link
-                  to={paths.tenant(tenant.contactCode)}
-                  className="font-medium text-primary hover:underline"
-                >
-                  {tenant.fullName}
-                </Link>
-              ) : (
-                <span className="font-medium">{tenant.fullName}</span>
-              )}
+              <div className="flex items-center gap-2">
+                {isValidContact ? (
+                  <Link
+                    to={paths.tenant(tenant.contactCode)}
+                    className="font-medium text-primary hover:underline"
+                  >
+                    {tenant.fullName}
+                  </Link>
+                ) : (
+                  <span className="font-medium">{tenant.fullName}</span>
+                )}
+                {tenant.protectedIdentity && (
+                  <ProtectedIdentityBadge size="sm" />
+                )}
+              </div>
               <div className="text-sm text-muted-foreground">
                 {tenant.contactCode}
               </div>
@@ -157,16 +163,21 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
                   {index > 0 && <div className="border-t pt-2" />}
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Hyresgäst:</span>
-                    {isValidContact ? (
-                      <Link
-                        to={paths.tenant(tenant.contactCode)}
-                        className="font-medium text-primary hover:underline"
-                      >
-                        {tenant.fullName}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{tenant.fullName}</span>
-                    )}
+                    <span className="flex items-center gap-2">
+                      {isValidContact ? (
+                        <Link
+                          to={paths.tenant(tenant.contactCode)}
+                          className="font-medium text-primary hover:underline"
+                        >
+                          {tenant.fullName}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{tenant.fullName}</span>
+                      )}
+                      {tenant.protectedIdentity && (
+                        <ProtectedIdentityBadge size="sm" />
+                      )}
+                    </span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Kundnummer:</span>

--- a/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
@@ -1,14 +1,12 @@
 import type { ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 import { Loader2 } from 'lucide-react'
 
 import { formatDate, LeaseMobileCard, LeaseStatusBadge } from '@/entities/lease'
 import { useLeasesByRentalProperty } from '@/entities/lease/hooks/useLeasesByRentalProperty'
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { TenantNameLink } from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core/leaseService'
 
-import { paths } from '@/shared/routes'
 import { TabLayout } from '@/shared/ui/layout/TabLayout'
 import { ResponsiveTable } from '@/shared/ui/ResponsiveTable'
 
@@ -47,42 +45,18 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
 
     return (
       <div className="space-y-1">
-        {lease.tenants.map((tenant) => {
-          const isValidContact =
-            tenant.contactCode.startsWith('P') ||
-            tenant.contactCode.startsWith('F')
-
-          const nameDisplay = tenant.protectedIdentity ? (
-            <span className="italic text-muted-foreground">
-              Skyddad identitet
-            </span>
-          ) : (
-            tenant.fullName
-          )
-
-          return (
-            <div key={tenant.contactCode}>
-              <div className="flex items-center gap-2">
-                {isValidContact ? (
-                  <Link
-                    to={paths.tenant(tenant.contactCode)}
-                    className="font-medium text-primary hover:underline"
-                  >
-                    {nameDisplay}
-                  </Link>
-                ) : (
-                  <span className="font-medium">{nameDisplay}</span>
-                )}
-                {tenant.protectedIdentity && (
-                  <ProtectedIdentityBadge size="sm" />
-                )}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                {tenant.contactCode}
-              </div>
+        {lease.tenants.map((tenant) => (
+          <div key={tenant.contactCode}>
+            <TenantNameLink
+              contactCode={tenant.contactCode}
+              fullName={tenant.fullName}
+              protectedIdentity={tenant.protectedIdentity}
+            />
+            <div className="text-sm text-muted-foreground">
+              {tenant.contactCode}
             </div>
-          )
-        })}
+          </div>
+        ))}
       </div>
     )
   }
@@ -161,38 +135,18 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
         <div className="space-y-2 text-sm">
           {hasTenants ? (
             lease.tenants?.map((tenant, index) => {
-              const isValidContact =
-                tenant.contactCode.startsWith('P') ||
-                tenant.contactCode.startsWith('F')
               const phone = tenant.phoneNumbers?.find((p) => p.isMainNumber)
-              const nameDisplay = tenant.protectedIdentity ? (
-                <span className="italic text-muted-foreground">
-                  Skyddad identitet
-                </span>
-              ) : (
-                tenant.fullName
-              )
 
               return (
                 <div key={tenant.contactCode} className="space-y-1">
                   {index > 0 && <div className="border-t pt-2" />}
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Hyresgäst:</span>
-                    <span className="flex items-center gap-2">
-                      {isValidContact ? (
-                        <Link
-                          to={paths.tenant(tenant.contactCode)}
-                          className="font-medium text-primary hover:underline"
-                        >
-                          {nameDisplay}
-                        </Link>
-                      ) : (
-                        <span className="font-medium">{nameDisplay}</span>
-                      )}
-                      {tenant.protectedIdentity && (
-                        <ProtectedIdentityBadge size="sm" />
-                      )}
-                    </span>
+                    <TenantNameLink
+                      contactCode={tenant.contactCode}
+                      fullName={tenant.fullName}
+                      protectedIdentity={tenant.protectedIdentity}
+                    />
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Kundnummer:</span>

--- a/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeasesTabContent.tsx
@@ -52,6 +52,14 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
             tenant.contactCode.startsWith('P') ||
             tenant.contactCode.startsWith('F')
 
+          const nameDisplay = tenant.protectedIdentity ? (
+            <span className="italic text-muted-foreground">
+              Skyddad identitet
+            </span>
+          ) : (
+            tenant.fullName
+          )
+
           return (
             <div key={tenant.contactCode}>
               <div className="flex items-center gap-2">
@@ -60,10 +68,10 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
                     to={paths.tenant(tenant.contactCode)}
                     className="font-medium text-primary hover:underline"
                   >
-                    {tenant.fullName}
+                    {nameDisplay}
                   </Link>
                 ) : (
-                  <span className="font-medium">{tenant.fullName}</span>
+                  <span className="font-medium">{nameDisplay}</span>
                 )}
                 {tenant.protectedIdentity && (
                   <ProtectedIdentityBadge size="sm" />
@@ -157,6 +165,13 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
                 tenant.contactCode.startsWith('P') ||
                 tenant.contactCode.startsWith('F')
               const phone = tenant.phoneNumbers?.find((p) => p.isMainNumber)
+              const nameDisplay = tenant.protectedIdentity ? (
+                <span className="italic text-muted-foreground">
+                  Skyddad identitet
+                </span>
+              ) : (
+                tenant.fullName
+              )
 
               return (
                 <div key={tenant.contactCode} className="space-y-1">
@@ -169,10 +184,10 @@ export function LeasesTabContent({ rentalPropertyId }: LeasesTabContentProps) {
                           to={paths.tenant(tenant.contactCode)}
                           className="font-medium text-primary hover:underline"
                         >
-                          {tenant.fullName}
+                          {nameDisplay}
                         </Link>
                       ) : (
-                        <span className="font-medium">{tenant.fullName}</span>
+                        <span className="font-medium">{nameDisplay}</span>
                       )}
                       {tenant.protectedIdentity && (
                         <ProtectedIdentityBadge size="sm" />

--- a/apps/property-tree/src/features/search/ui/CommandPalette.tsx
+++ b/apps/property-tree/src/features/search/ui/CommandPalette.tsx
@@ -14,6 +14,8 @@ import {
   Wrench,
 } from 'lucide-react'
 
+import { ProtectedIdentityBadge } from '@/entities/tenant'
+
 import { debounce } from '@/shared/lib/debounce'
 import { paths } from '@/shared/routes'
 
@@ -68,6 +70,9 @@ function getResultProps(item: CombinedSearchResult) {
         icon,
         label: item.contactCode,
         subtitle: item.fullName,
+        trailing: item.protectedIdentity ? (
+          <ProtectedIdentityBadge size="sm" />
+        ) : undefined,
         path: paths.tenant(item.contactCode),
         state: {},
       }
@@ -235,6 +240,9 @@ export function CommandPalette() {
                         label={props.label}
                         prefix={props.prefix}
                         subtitle={props.subtitle}
+                        trailing={
+                          'trailing' in props ? props.trailing : undefined
+                        }
                         isSelected={selectedIndex === index}
                         onClick={() => handleSelect(props.path, props.state)}
                       />

--- a/apps/property-tree/src/features/search/ui/SearchResultItem.tsx
+++ b/apps/property-tree/src/features/search/ui/SearchResultItem.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from 'react'
+
 import { motion } from 'framer-motion'
 import { ArrowRight, type LucideIcon } from 'lucide-react'
 
@@ -6,6 +8,7 @@ interface SearchResultItemProps {
   label: string
   prefix?: string
   subtitle?: string | null
+  trailing?: ReactNode
   isSelected: boolean
   onClick: () => void
 }
@@ -15,6 +18,7 @@ export function SearchResultItem({
   label,
   prefix,
   subtitle,
+  trailing,
   isSelected,
   onClick,
 }: SearchResultItemProps) {
@@ -35,6 +39,7 @@ export function SearchResultItem({
       </div>
       {subtitle && <span className="text-xs text-gray-400">{subtitle}</span>}
       <span className="flex-1 text-left">{label}</span>
+      {trailing}
       <ArrowRight className="h-4 w-4 opacity-50" />
     </motion.button>
   )

--- a/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
+++ b/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
@@ -136,6 +136,13 @@ export function TenantLeasesTabContent({
               const isValidContact =
                 tenant.contactCode.startsWith('P') ||
                 tenant.contactCode.startsWith('F')
+              const nameDisplay = tenant.protectedIdentity ? (
+                <span className="italic text-muted-foreground">
+                  Skyddad identitet
+                </span>
+              ) : (
+                tenant.fullName
+              )
               return (
                 <div key={tenant.contactCode}>
                   <div className="flex items-center gap-2">
@@ -144,10 +151,10 @@ export function TenantLeasesTabContent({
                         to={paths.tenant(tenant.contactCode)}
                         className="font-medium text-primary hover:underline"
                       >
-                        {tenant.fullName}
+                        {nameDisplay}
                       </Link>
                     ) : (
-                      <span className="font-medium">{tenant.fullName}</span>
+                      <span className="font-medium">{nameDisplay}</span>
                     )}
                     {tenant.protectedIdentity && (
                       <ProtectedIdentityBadge size="sm" />
@@ -251,6 +258,13 @@ export function TenantLeasesTabContent({
               const isValidContact =
                 tenant.contactCode.startsWith('P') ||
                 tenant.contactCode.startsWith('F')
+              const nameDisplay = tenant.protectedIdentity ? (
+                <span className="italic text-muted-foreground">
+                  Skyddad identitet
+                </span>
+              ) : (
+                tenant.fullName
+              )
               return (
                 <div key={tenant.contactCode} className="space-y-1">
                   {index > 0 && <div className="border-t pt-2" />}
@@ -262,10 +276,10 @@ export function TenantLeasesTabContent({
                           to={paths.tenant(tenant.contactCode)}
                           className="font-medium text-primary hover:underline"
                         >
-                          {tenant.fullName}
+                          {nameDisplay}
                         </Link>
                       ) : (
-                        <span className="font-medium">{tenant.fullName}</span>
+                        <span className="font-medium">{nameDisplay}</span>
                       )}
                       {tenant.protectedIdentity && (
                         <ProtectedIdentityBadge size="sm" />

--- a/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
+++ b/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
@@ -12,6 +12,7 @@ import {
   LeaseStatusBadge,
   sortLeasesByStatus,
 } from '@/entities/lease'
+import { ProtectedIdentityBadge } from '@/entities/tenant'
 
 import { Lease } from '@/services/api/core/leaseService'
 
@@ -137,16 +138,21 @@ export function TenantLeasesTabContent({
                 tenant.contactCode.startsWith('F')
               return (
                 <div key={tenant.contactCode}>
-                  {isValidContact ? (
-                    <Link
-                      to={paths.tenant(tenant.contactCode)}
-                      className="font-medium text-primary hover:underline"
-                    >
-                      {tenant.fullName}
-                    </Link>
-                  ) : (
-                    <span className="font-medium">{tenant.fullName}</span>
-                  )}
+                  <div className="flex items-center gap-2">
+                    {isValidContact ? (
+                      <Link
+                        to={paths.tenant(tenant.contactCode)}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {tenant.fullName}
+                      </Link>
+                    ) : (
+                      <span className="font-medium">{tenant.fullName}</span>
+                    )}
+                    {tenant.protectedIdentity && (
+                      <ProtectedIdentityBadge size="sm" />
+                    )}
+                  </div>
                   <div className="text-sm text-muted-foreground">
                     {tenant.contactCode}
                   </div>
@@ -250,16 +256,21 @@ export function TenantLeasesTabContent({
                   {index > 0 && <div className="border-t pt-2" />}
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Hyresgäst:</span>
-                    {isValidContact ? (
-                      <Link
-                        to={paths.tenant(tenant.contactCode)}
-                        className="font-medium text-primary hover:underline"
-                      >
-                        {tenant.fullName}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{tenant.fullName}</span>
-                    )}
+                    <span className="flex items-center gap-2">
+                      {isValidContact ? (
+                        <Link
+                          to={paths.tenant(tenant.contactCode)}
+                          className="font-medium text-primary hover:underline"
+                        >
+                          {tenant.fullName}
+                        </Link>
+                      ) : (
+                        <span className="font-medium">{tenant.fullName}</span>
+                      )}
+                      {tenant.protectedIdentity && (
+                        <ProtectedIdentityBadge size="sm" />
+                      )}
+                    </span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Kundnummer:</span>

--- a/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
+++ b/apps/property-tree/src/features/tenants/ui/TenantLeasesTabContent.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react'
-import { Link } from 'react-router-dom'
 import type { RentalPropertyInfo } from '@onecore/types'
 import { InfoIcon } from 'lucide-react'
 
@@ -12,11 +11,10 @@ import {
   LeaseStatusBadge,
   sortLeasesByStatus,
 } from '@/entities/lease'
-import { ProtectedIdentityBadge } from '@/entities/tenant'
+import { TenantNameLink } from '@/entities/tenant'
 
 import { Lease } from '@/services/api/core/leaseService'
 
-import { paths } from '@/shared/routes'
 import { Button } from '@/shared/ui/Button'
 import { TabLayout } from '@/shared/ui/layout/TabLayout'
 import { ResponsiveTable } from '@/shared/ui/ResponsiveTable'
@@ -132,40 +130,18 @@ export function TenantLeasesTabContent({
         }
         return (
           <div className="space-y-1">
-            {lease.tenants.map((tenant) => {
-              const isValidContact =
-                tenant.contactCode.startsWith('P') ||
-                tenant.contactCode.startsWith('F')
-              const nameDisplay = tenant.protectedIdentity ? (
-                <span className="italic text-muted-foreground">
-                  Skyddad identitet
-                </span>
-              ) : (
-                tenant.fullName
-              )
-              return (
-                <div key={tenant.contactCode}>
-                  <div className="flex items-center gap-2">
-                    {isValidContact ? (
-                      <Link
-                        to={paths.tenant(tenant.contactCode)}
-                        className="font-medium text-primary hover:underline"
-                      >
-                        {nameDisplay}
-                      </Link>
-                    ) : (
-                      <span className="font-medium">{nameDisplay}</span>
-                    )}
-                    {tenant.protectedIdentity && (
-                      <ProtectedIdentityBadge size="sm" />
-                    )}
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {tenant.contactCode}
-                  </div>
+            {lease.tenants.map((tenant) => (
+              <div key={tenant.contactCode}>
+                <TenantNameLink
+                  contactCode={tenant.contactCode}
+                  fullName={tenant.fullName}
+                  protectedIdentity={tenant.protectedIdentity}
+                />
+                <div className="text-sm text-muted-foreground">
+                  {tenant.contactCode}
                 </div>
-              )
-            })}
+              </div>
+            ))}
           </div>
         )
       },
@@ -254,45 +230,23 @@ export function TenantLeasesTabContent({
         {/* Tenant Info Section */}
         {lease.tenants && lease.tenants.length > 0 && (
           <div className="space-y-2 text-sm">
-            {lease.tenants.map((tenant, index) => {
-              const isValidContact =
-                tenant.contactCode.startsWith('P') ||
-                tenant.contactCode.startsWith('F')
-              const nameDisplay = tenant.protectedIdentity ? (
-                <span className="italic text-muted-foreground">
-                  Skyddad identitet
-                </span>
-              ) : (
-                tenant.fullName
-              )
-              return (
-                <div key={tenant.contactCode} className="space-y-1">
-                  {index > 0 && <div className="border-t pt-2" />}
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Hyresgäst:</span>
-                    <span className="flex items-center gap-2">
-                      {isValidContact ? (
-                        <Link
-                          to={paths.tenant(tenant.contactCode)}
-                          className="font-medium text-primary hover:underline"
-                        >
-                          {nameDisplay}
-                        </Link>
-                      ) : (
-                        <span className="font-medium">{nameDisplay}</span>
-                      )}
-                      {tenant.protectedIdentity && (
-                        <ProtectedIdentityBadge size="sm" />
-                      )}
-                    </span>
-                  </div>
-                  <div className="flex justify-between">
-                    <span className="text-muted-foreground">Kundnummer:</span>
-                    <span>{tenant.contactCode}</span>
-                  </div>
+            {lease.tenants.map((tenant, index) => (
+              <div key={tenant.contactCode} className="space-y-1">
+                {index > 0 && <div className="border-t pt-2" />}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Hyresgäst:</span>
+                  <TenantNameLink
+                    contactCode={tenant.contactCode}
+                    fullName={tenant.fullName}
+                    protectedIdentity={tenant.protectedIdentity}
+                  />
                 </div>
-              )
-            })}
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Kundnummer:</span>
+                  <span>{tenant.contactCode}</span>
+                </div>
+              </div>
+            ))}
           </div>
         )}
 

--- a/apps/property-tree/src/pages/TenantPage.tsx
+++ b/apps/property-tree/src/pages/TenantPage.tsx
@@ -10,6 +10,7 @@ import { useRentalProperties } from '@/entities/rental-property'
 import {
   ProtectedIdentityBadge,
   TenantCard,
+  TenantName,
   useTenant,
 } from '@/entities/tenant'
 
@@ -36,15 +37,9 @@ function TenantHeader({ tenant }: { tenant: Tenant }) {
     <TooltipProvider>
       <div className="flex items-center gap-3 mb-6">
         <h1 className="text-3xl font-bold">
-          {tenant.protectedIdentity ? (
-            <span className="italic text-muted-foreground">
-              Skyddad identitet
-            </span>
-          ) : (
-            <>
-              {tenant.firstName} {tenant.lastName}
-            </>
-          )}
+          <TenantName protectedIdentity={tenant.protectedIdentity}>
+            {tenant.firstName} {tenant.lastName}
+          </TenantName>
         </h1>
         {tenant.protectedIdentity && <ProtectedIdentityBadge />}
         {tenant.specialAttention && (

--- a/apps/property-tree/src/pages/TenantPage.tsx
+++ b/apps/property-tree/src/pages/TenantPage.tsx
@@ -36,7 +36,15 @@ function TenantHeader({ tenant }: { tenant: Tenant }) {
     <TooltipProvider>
       <div className="flex items-center gap-3 mb-6">
         <h1 className="text-3xl font-bold">
-          {tenant.firstName} {tenant.lastName}
+          {tenant.protectedIdentity ? (
+            <span className="italic text-muted-foreground">
+              Skyddad identitet
+            </span>
+          ) : (
+            <>
+              {tenant.firstName} {tenant.lastName}
+            </>
+          )}
         </h1>
         {tenant.protectedIdentity && <ProtectedIdentityBadge />}
         {tenant.specialAttention && (

--- a/apps/property-tree/src/pages/TenantPage.tsx
+++ b/apps/property-tree/src/pages/TenantPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import type { RentalPropertyInfo } from '@onecore/types'
-import { AlertTriangle } from 'lucide-react'
+import { AlertTriangle, ShieldAlert } from 'lucide-react'
 
 import { TenantTabs } from '@/widgets/tenant-tabs'
 
@@ -26,7 +26,7 @@ import {
   TooltipTrigger,
 } from '@/shared/ui/Tooltip'
 
-// Helper component: Tenant header with name and special attention badge
+// Helper component: Tenant header with name and status badges
 function TenantHeader({ tenant }: { tenant: Tenant }) {
   return (
     <TooltipProvider>
@@ -34,6 +34,20 @@ function TenantHeader({ tenant }: { tenant: Tenant }) {
         <h1 className="text-3xl font-bold">
           {tenant.firstName} {tenant.lastName}
         </h1>
+        {tenant.protectedIdentity && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div className="flex items-center justify-center w-8 h-8 bg-red-100 rounded-full border border-red-200 cursor-help">
+                <ShieldAlert className="h-4 w-4 text-red-600" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                Skyddad identitet. Hantera kunduppgifter med särskild varsamhet.
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        )}
         {tenant.specialAttention && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/property-tree/src/pages/TenantPage.tsx
+++ b/apps/property-tree/src/pages/TenantPage.tsx
@@ -1,13 +1,17 @@
 import { useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import type { RentalPropertyInfo } from '@onecore/types'
-import { AlertTriangle, ShieldAlert } from 'lucide-react'
+import { AlertTriangle } from 'lucide-react'
 
 import { TenantTabs } from '@/widgets/tenant-tabs'
 
 import { useLeasesByContactCode } from '@/entities/lease'
 import { useRentalProperties } from '@/entities/rental-property'
-import { TenantCard, useTenant } from '@/entities/tenant'
+import {
+  ProtectedIdentityBadge,
+  TenantCard,
+  useTenant,
+} from '@/entities/tenant'
 
 import type { Lease } from '@/services/api/core/leaseService'
 import type { Tenant } from '@/services/types'
@@ -34,20 +38,7 @@ function TenantHeader({ tenant }: { tenant: Tenant }) {
         <h1 className="text-3xl font-bold">
           {tenant.firstName} {tenant.lastName}
         </h1>
-        {tenant.protectedIdentity && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center justify-center w-8 h-8 bg-red-100 rounded-full border border-red-200 cursor-help">
-                <ShieldAlert className="h-4 w-4 text-red-600" />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>
-                Skyddad identitet. Hantera kunduppgifter med särskild varsamhet.
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        )}
+        {tenant.protectedIdentity && <ProtectedIdentityBadge />}
         {tenant.specialAttention && (
           <Tooltip>
             <TooltipTrigger asChild>

--- a/apps/property-tree/src/pages/TenantsPage.tsx
+++ b/apps/property-tree/src/pages/TenantsPage.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ChevronDown } from 'lucide-react'
 
-import { ProtectedIdentityBadge, useTenantSearch } from '@/entities/tenant'
+import {
+  ProtectedIdentityBadge,
+  TenantName,
+  useTenantSearch,
+} from '@/entities/tenant'
 
 import { paths } from '@/shared/routes'
 import { Badge } from '@/shared/ui/Badge'
@@ -100,7 +104,10 @@ export function TenantsPage() {
                     label: 'Namn',
                     render: (contact) => (
                       <span className="font-medium inline-flex items-center gap-2">
-                        {contact.fullName}
+                        <TenantName
+                          fullName={contact.fullName}
+                          protectedIdentity={contact.protectedIdentity}
+                        />
                         {contact.protectedIdentity && (
                           <ProtectedIdentityBadge size="sm" />
                         )}
@@ -133,7 +140,10 @@ export function TenantsPage() {
                     <div className="flex justify-between items-start">
                       <div>
                         <div className="font-medium inline-flex items-center gap-2">
-                          {contact.fullName}
+                          <TenantName
+                            fullName={contact.fullName}
+                            protectedIdentity={contact.protectedIdentity}
+                          />
                           {contact.protectedIdentity && (
                             <ProtectedIdentityBadge size="sm" />
                           )}

--- a/apps/property-tree/src/pages/TenantsPage.tsx
+++ b/apps/property-tree/src/pages/TenantsPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ChevronDown } from 'lucide-react'
 
-import { useTenantSearch } from '@/entities/tenant'
+import { ProtectedIdentityBadge, useTenantSearch } from '@/entities/tenant'
 
 import { paths } from '@/shared/routes'
 import { Badge } from '@/shared/ui/Badge'
@@ -99,7 +99,12 @@ export function TenantsPage() {
                     key: 'name',
                     label: 'Namn',
                     render: (contact) => (
-                      <span className="font-medium">{contact.fullName}</span>
+                      <span className="font-medium inline-flex items-center gap-2">
+                        {contact.fullName}
+                        {contact.protectedIdentity && (
+                          <ProtectedIdentityBadge size="sm" />
+                        )}
+                      </span>
                     ),
                   },
                   {
@@ -127,7 +132,12 @@ export function TenantsPage() {
                   <div className="space-y-2 w-full">
                     <div className="flex justify-between items-start">
                       <div>
-                        <div className="font-medium">{contact.fullName}</div>
+                        <div className="font-medium inline-flex items-center gap-2">
+                          {contact.fullName}
+                          {contact.protectedIdentity && (
+                            <ProtectedIdentityBadge size="sm" />
+                          )}
+                        </div>
                         <div className="text-sm text-muted-foreground">
                           {contact.contactCode}
                         </div>

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -9878,6 +9878,7 @@ export interface components {
             }[];
           emailAddress?: string | null;
           isTenant: boolean;
+          protectedIdentity?: boolean;
           specialAttention?: boolean;
           parkingSpaceWaitingList?: {
             /** Format: date-time */
@@ -9958,6 +9959,7 @@ export interface components {
         }[];
       emailAddress?: string | null;
       isTenant: boolean;
+      protectedIdentity?: boolean;
       specialAttention?: boolean;
     };
     ListingTextContent: {
@@ -12421,6 +12423,7 @@ export interface components {
               }[];
             emailAddress?: string | null;
             isTenant: boolean;
+            protectedIdentity?: boolean;
             specialAttention?: boolean;
             parkingSpaceWaitingList?: {
               /** Format: date-time */
@@ -12695,6 +12698,7 @@ export interface components {
               }[];
             emailAddress?: string | null;
             isTenant: boolean;
+            protectedIdentity?: boolean;
             specialAttention?: boolean;
             parkingSpaceWaitingList?: {
               /** Format: date-time */
@@ -13079,6 +13083,7 @@ export interface components {
               }[];
             emailAddress?: string | null;
             isTenant: boolean;
+            protectedIdentity?: boolean;
             specialAttention?: boolean;
             parkingSpaceWaitingList?: {
               /** Format: date-time */

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -9902,6 +9902,7 @@ export interface components {
           contactCode: string;
           email: string | null;
           phone: string | null;
+          protectedIdentity?: boolean;
         })[];
       address: string | null;
       /** Format: date-time */
@@ -9924,6 +9925,7 @@ export interface components {
       contactCode: string;
       email: string | null;
       phone: string | null;
+      protectedIdentity?: boolean;
     };
     PaginationMeta: {
       totalRecords: number;

--- a/apps/property-tree/src/services/api/core/tenantService.ts
+++ b/apps/property-tree/src/services/api/core/tenantService.ts
@@ -5,6 +5,7 @@ import { GET, POST } from './baseApi'
 export interface ContactSearchResult {
   fullName: string
   contactCode: string
+  protectedIdentity?: boolean
 }
 
 async function getByContactCode(contactCode: string): Promise<Tenant> {

--- a/apps/property-tree/src/services/types.ts
+++ b/apps/property-tree/src/services/types.ts
@@ -265,6 +265,7 @@ export interface Tenant {
   emailAddress: string
   isTenant: boolean
   parkingSpaceWaitingList: WaitingListResponse
+  protectedIdentity?: boolean
   specialAttention: boolean
   isAboutToLeave: boolean
   currentHousingContract: ContractType

--- a/core/src/adapters/leasing-adapter/index.ts
+++ b/core/src/adapters/leasing-adapter/index.ts
@@ -205,7 +205,13 @@ const getContactsDataBySearchQuery = async (
 ): Promise<
   AdapterResult<
     Array<
-      Pick<Contact, 'fullName' | 'contactCode' | 'nationalRegistrationNumber'>
+      Pick<
+        Contact,
+        | 'fullName'
+        | 'contactCode'
+        | 'nationalRegistrationNumber'
+        | 'protectedIdentity'
+      >
     >,
     unknown
   >

--- a/core/src/services/lease-service/schemas/lease.ts
+++ b/core/src/services/lease-service/schemas/lease.ts
@@ -44,6 +44,7 @@ export const Contact = z.object({
     .optional(),
   emailAddress: z.string().nullable().optional(),
   isTenant: z.boolean(),
+  protectedIdentity: z.boolean().optional(),
   specialAttention: z.boolean().optional(),
 })
 
@@ -154,6 +155,7 @@ export const Lease = z.object({
           .optional(),
         emailAddress: z.string().nullable().optional(),
         isTenant: z.boolean(),
+        protectedIdentity: z.boolean().optional(),
         specialAttention: z.boolean().optional(),
         // --- tenant-only additions (not part of Contact) ---
         parkingSpaceWaitingList: z

--- a/libs/types/src/leasing/v1/lease-search.ts
+++ b/libs/types/src/leasing/v1/lease-search.ts
@@ -9,6 +9,7 @@ export const ContactInfoSchema = z.object({
   contactCode: z.string(),
   email: z.string().nullable(),
   phone: z.string().nullable(),
+  protectedIdentity: z.boolean().optional(),
 })
 
 export type ContactInfo = z.infer<typeof ContactInfoSchema>

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -45,6 +45,7 @@ interface Contact {
   parkingSpaceWaitingList?: WaitingList
   housingWaitingList?: WaitingList
   storageWaitingList?: WaitingList
+  protectedIdentity?: boolean //cmctc.lagsokt — set when contact has skyddad identitet
   specialAttention?: boolean
 }
 

--- a/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
@@ -464,6 +464,7 @@ export class LeaseSearchQueryBuilder {
         SELECT
           cmctc.cmctcben as name,
           cmctc.cmctckod as contactCode,
+          cmctc.lagsokt as lagsokt,
           cmeml.cmemlben as email,
           cmtel.cmtelben as phone
         FROM hyavk
@@ -653,6 +654,7 @@ export const parseContactsJson = (
       contactCode: c.contactCode ? String(c.contactCode).trim() : '',
       email: c.email ? String(c.email).trim() : null,
       phone: c.phone ? String(c.phone).trim() : null,
+      protectedIdentity: c.lagsokt != null,
     }))
   } catch (e) {
     logger.warn(e, 'parseContactsJson: failed to parse contacts JSON')

--- a/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -125,6 +125,7 @@ const transformFromDbContact = (
     parkingSpaceWaitingList: getParkingSpaceWaitingList(rows),
     housingWaitingList: getHousingWaitingList(rows),
     storageWaitingList: getStorageWaitingList(rows),
+    protectedIdentity,
     specialAttention: !!row.specialAttention,
   }
 

--- a/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -488,6 +488,7 @@ const getContactsDataBySearchQuery = async (
       contactCode: string
       fullName: string
       nationalRegistrationNumber: string
+      protectedIdentity: boolean
     }>,
     'internal-error'
   >
@@ -500,7 +501,11 @@ const getContactsDataBySearchQuery = async (
       // Email search only
       const rows = await xpandDb
         .from('cmctc')
-        .select('cmctc.cmctckod as contactCode', 'cmctc.cmctcben as fullName')
+        .select(
+          'cmctc.cmctckod as contactCode',
+          'cmctc.cmctcben as fullName',
+          'cmctc.lagsokt as lagsokt'
+        )
         .where(
           'cmctc.keycmobj',
           'in',
@@ -514,7 +519,7 @@ const getContactsDataBySearchQuery = async (
 
       return {
         ok: true,
-        data: rows,
+        data: rows.map(withProtectedIdentity),
       }
     }
 
@@ -524,7 +529,8 @@ const getContactsDataBySearchQuery = async (
         .select(
           'cmctc.cmctckod as contactCode',
           'cmctc.cmctcben as fullName',
-          'cmctc.persorgnr as nationalRegistrationNumber'
+          'cmctc.persorgnr as nationalRegistrationNumber',
+          'cmctc.lagsokt as lagsokt'
         )
         .where(
           'cmctc.keycmobj',
@@ -540,7 +546,7 @@ const getContactsDataBySearchQuery = async (
 
       return {
         ok: true,
-        data: rows,
+        data: rows.map(withProtectedIdentity),
       }
     }
 
@@ -554,7 +560,11 @@ const getContactsDataBySearchQuery = async (
 
     const rows = await xpandDb
       .from('cmctc')
-      .select('cmctc.cmctckod as contactCode', 'cmctc.cmctcben as fullName')
+      .select(
+        'cmctc.cmctckod as contactCode',
+        'cmctc.cmctcben as fullName',
+        'cmctc.lagsokt as lagsokt'
+      )
       .where('cmctc.deletemark', '=', '0')
       .where((builder) => {
         builder.where('cmctc.cmctckod', 'like', `${q}%`)
@@ -568,7 +578,7 @@ const getContactsDataBySearchQuery = async (
 
     return {
       ok: true,
-      data: rows,
+      data: rows.map(withProtectedIdentity),
     }
   } catch (err) {
     logger.error({ err }, 'tenant-lease-adapter.getContactsDataBySearchQuery')
@@ -577,6 +587,15 @@ const getContactsDataBySearchQuery = async (
       err: 'internal-error',
     }
   }
+}
+
+// Derives the protectedIdentity boolean from the raw cmctc.lagsokt column
+// (`!== null` matches the semantics used elsewhere in this adapter — see line 94).
+// Typed loosely because knex returns rows as `unknown` — the calling site's
+// declared Promise<AdapterResult<…>> enforces the shape we actually return.
+const withProtectedIdentity = (row: any) => {
+  const { lagsokt, ...rest } = row
+  return { ...rest, protectedIdentity: lagsokt !== null }
 }
 
 /**
@@ -588,14 +607,24 @@ const getContactsDataBySearchQuery = async (
 const searchContactsPaginated = async (
   q: string,
   ctx: Context
-): Promise<PaginatedResponse<{ contactCode: string; fullName: string }>> => {
+): Promise<
+  PaginatedResponse<{
+    contactCode: string
+    fullName: string
+    protectedIdentity: boolean
+  }>
+> => {
   const isEmailSearch = q.includes('@')
   const isPhoneNumberSearch = /^[0+][\d\-+]*$/.test(q)
 
   if (isEmailSearch) {
     const query = xpandDb
       .from('cmctc')
-      .select('cmctc.cmctckod as contactCode', 'cmctc.cmctcben as fullName')
+      .select(
+        'cmctc.cmctckod as contactCode',
+        'cmctc.cmctcben as fullName',
+        'cmctc.lagsokt as lagsokt'
+      )
       .where(
         'cmctc.keycmobj',
         'in',
@@ -605,13 +634,18 @@ const searchContactsPaginated = async (
           .where('cmemlben', 'like', `${q}%`)
       )
 
-    return paginateKnex(query, ctx)
+    const page = await paginateKnex(query, ctx)
+    return { ...page, content: page.content.map(withProtectedIdentity) }
   }
 
   if (isPhoneNumberSearch) {
     const query = xpandDb
       .from('cmctc')
-      .select('cmctc.cmctckod as contactCode', 'cmctc.cmctcben as fullName')
+      .select(
+        'cmctc.cmctckod as contactCode',
+        'cmctc.cmctcben as fullName',
+        'cmctc.lagsokt as lagsokt'
+      )
       .where(
         'cmctc.keycmobj',
         'in',
@@ -623,7 +657,8 @@ const searchContactsPaginated = async (
       .where('cmctc.deletemark', '=', '0')
       .orderBy('cmctc.cmctcben', 'asc')
 
-    return paginateKnex(query, ctx)
+    const page = await paginateKnex(query, ctx)
+    return { ...page, content: page.content.map(withProtectedIdentity) }
   }
 
   // Split into terms - all must match name (AND), or match contactCode/persorgnr
@@ -634,7 +669,11 @@ const searchContactsPaginated = async (
 
   const query = xpandDb
     .from('cmctc')
-    .select('cmctc.cmctckod as contactCode', 'cmctc.cmctcben as fullName')
+    .select(
+      'cmctc.cmctckod as contactCode',
+      'cmctc.cmctcben as fullName',
+      'cmctc.lagsokt as lagsokt'
+    )
     .where('cmctc.deletemark', '=', '0')
     .where((builder) => {
       builder.where('cmctc.cmctckod', 'like', `${q}%`)
@@ -648,7 +687,8 @@ const searchContactsPaginated = async (
     })
     .orderBy('cmctc.cmctcben', 'asc')
 
-  return paginateKnex(query, ctx)
+  const page = await paginateKnex(query, ctx)
+  return { ...page, content: page.content.map(withProtectedIdentity) }
 }
 
 /**

--- a/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/tenant-lease-adapter.ts
@@ -1089,6 +1089,7 @@ const getContacts = async (contactCodes: string[]) => {
             : row.emailAddress
           : 'redacted',
       isTenant: false,
+      protectedIdentity,
       specialAttention: !!row.specialAttention,
     }
   })

--- a/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
+++ b/services/leasing/src/services/lease-service/tests/adapters/xpand/tenant-lease-adapter.test.ts
@@ -82,6 +82,7 @@ describe(tenantLeaseAdapter.getContactByContactCode, () => {
             isMainNumber: true,
           },
         ],
+        protectedIdentity: false,
         specialAttention: false,
         emailAddress: 'redacted',
         isTenant: false,
@@ -448,6 +449,74 @@ describe('transformFromDbContact', () => {
     expect(contact.fullName).toBeUndefined()
     expect(contact.nationalRegistrationNumber).toBeUndefined()
     expect(contact.birthDate).toBeUndefined()
+  })
+
+  it('should expose protectedIdentity=true when the Xpand row is flagged', () => {
+    const rows = [
+      {
+        contactCode: 'P123456',
+        contactKey: '_ADBAEC',
+        firstName: 'Test',
+        lastName: 'Testman',
+        fullName: 'Test Testman',
+        nationalRegistrationNumber: '121212121212',
+        birthDate: '1212-12-12',
+        street: 'Gatvägen 12',
+        postalCode: '12345',
+        city: 'Test City',
+        emailAddress: 'noreply@mimer.nu',
+        protectedIdentity: true,
+      },
+    ]
+    const phoneNumbers: {
+      phoneNumber: string
+      type: string
+      isMainNumber: number
+    }[] = []
+    const leaseIds: string[] = []
+
+    const contact: Contact = tenantLeaseAdapter.transformFromDbContact(
+      rows,
+      phoneNumbers,
+      leaseIds,
+      false
+    )
+
+    expect(contact.protectedIdentity).toBe(true)
+  })
+
+  it('should expose protectedIdentity=false when the Xpand row is not flagged', () => {
+    const rows = [
+      {
+        contactCode: 'P123456',
+        contactKey: '_ADBAEC',
+        firstName: 'Test',
+        lastName: 'Testman',
+        fullName: 'Test Testman',
+        nationalRegistrationNumber: '121212121212',
+        birthDate: '1212-12-12',
+        street: 'Gatvägen 12',
+        postalCode: '12345',
+        city: 'Test City',
+        emailAddress: 'noreply@mimer.nu',
+        protectedIdentity: null,
+      },
+    ]
+    const phoneNumbers: {
+      phoneNumber: string
+      type: string
+      isMainNumber: number
+    }[] = []
+    const leaseIds: string[] = []
+
+    const contact: Contact = tenantLeaseAdapter.transformFromDbContact(
+      rows,
+      phoneNumbers,
+      leaseIds,
+      false
+    )
+
+    expect(contact.protectedIdentity).toBe(false)
   })
 
   it('should handle special attention correctly', () => {

--- a/services/leasing/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/services/leasing/src/services/lease-service/tests/routes/contacts.test.ts
@@ -48,6 +48,7 @@ describe('GET /contacts/search', () => {
             contactCode: 'foo',
             fullName: 'Foo Bar',
             nationalRegistrationNumber: '123456789',
+            protectedIdentity: false,
           },
         ],
       })


### PR DESCRIPTION
Adds "Skyddad identitet" badge to tenant card and in lists where a person is flagged as skyddad identitet.
Refactored the link to tenant card so less code is repeated. Right now the name in the list will be replaced with "Skyddad identitet" if the flag is true.. 