### PR TITLE
fix: sort property manager filter list 

### DIFF
--- a/apps/property-tree/src/entities/lease/hooks/useLeaseFilters.ts
+++ b/apps/property-tree/src/entities/lease/hooks/useLeaseFilters.ts
@@ -186,6 +186,7 @@ export function useLeaseFilters() {
           value: u.id,
           description: u.attributes?.employeeId?.[0],
         }))
+        .sort((a, b) => a.label.localeCompare(b.label, 'sv'))
     },
     []
   )


### PR DESCRIPTION
Now it sorts alphabetically.. :) 