### PR TITLE
Exclude Avtalsmall templates from lease search

### DIFF
--- a/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
@@ -94,6 +94,11 @@ export class LeaseSearchQueryBuilder {
       .innerJoin('cmobj', 'cmobj.keycmobj', 'hykop.keycmobj')
       .where('hyobj.deletemark', 0)
       .whereNot('hyobj.hyobjben', 'like', '%M%')
+      // keyhyobt = 1 is "Avtalsmall" — an agreement template, not a real contract.
+      // Template rows have all dates NULL, so calculateStatus classifies them as
+      // "Gällande" and they leak into search results. Xpand's own UI hides them and
+      // rental-object-adapter already excludes them via a keyhyobt whitelist.
+      .whereNot('hyobj.keyhyobt', '1')
 
     this.joinedTables.add('hyobj')
     this.joinedTables.add('hyhav')

--- a/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/xpand/lease-search-adapter.ts
@@ -45,6 +45,14 @@ const OBJECT_TYPE_MAP: Record<string, string> = {
 const normalizeObjectType = (type: string): string =>
   OBJECT_TYPE_MAP[type.toLowerCase()] ?? type
 
+/**
+ * Xpand hyobj.keyhyobt code for "Avtalsmall" (agreement template).
+ * Template rows are not real contracts — they have all dates NULL, so
+ * calculateStatus would classify them as "Gällande" and they'd leak into
+ * search results. Xpand's own UI hides them; excluded here from all searches.
+ */
+const XPAND_HYOBT_AVTALSMALL = '1'
+
 export interface LeaseSearchOptions {
   forExport?: boolean
   /**
@@ -94,11 +102,7 @@ export class LeaseSearchQueryBuilder {
       .innerJoin('cmobj', 'cmobj.keycmobj', 'hykop.keycmobj')
       .where('hyobj.deletemark', 0)
       .whereNot('hyobj.hyobjben', 'like', '%M%')
-      // keyhyobt = 1 is "Avtalsmall" — an agreement template, not a real contract.
-      // Template rows have all dates NULL, so calculateStatus classifies them as
-      // "Gällande" and they leak into search results. Xpand's own UI hides them and
-      // rental-object-adapter already excludes them via a keyhyobt whitelist.
-      .whereNot('hyobj.keyhyobt', '1')
+      .whereNot('hyobj.keyhyobt', XPAND_HYOBT_AVTALSMALL)
 
     this.joinedTables.add('hyobj')
     this.joinedTables.add('hyhav')

--- a/services/leasing/src/services/lease-service/helpers/transformFromXPandDb.ts
+++ b/services/leasing/src/services/lease-service/helpers/transformFromXPandDb.ts
@@ -5,6 +5,11 @@ const calculateStatus = (
   lastDebitDateString: string,
   startDateString: string
 ): LeaseStatus => {
+  // A row with no start date and no last-debit date is not a real, active lease
+  // (e.g. an Xpand "Avtalsmall" template). Without this guard it falls through to
+  // Current below.
+  if (!startDateString && !lastDebitDateString) return LeaseStatus.Ended
+
   const leaseStartDate = new Date(startDateString)
   const leaseLastDebitDate = new Date(lastDebitDateString)
   const today = new Date()

--- a/services/leasing/src/services/lease-service/tests/helpers/transformFromXPandDb.test.ts
+++ b/services/leasing/src/services/lease-service/tests/helpers/transformFromXPandDb.test.ts
@@ -112,6 +112,26 @@ describe(transformFromXPandDb.toLease, () => {
 
     expect(lease.status).toBe(LeaseStatus.AboutToEnd)
   })
+  it('should set status to Ended for a row with no start date and no lastDebitDate (e.g. an Avtalsmall template)', () => {
+    const dbRow = {
+      leaseId: '209-028-02-0301',
+      leaseType: 'Bostadskontrakt               ',
+      noticeGivenBy: null,
+      contractDate: null,
+      lastDebitDate: null,
+      approvalDate: null,
+      noticeDate: null,
+      fromDate: null,
+      toDate: null,
+      noticeTimeTenant: null,
+      preferredMoveOutDate: null,
+      terminationDate: null,
+    }
+
+    const lease = transformFromXPandDb.toLease(dbRow, undefined, undefined)
+
+    expect(lease.status).toBe(LeaseStatus.Ended)
+  })
   it('should set status to Ended for a lease with a lastDebit date in the past', () => {
     const pastDate = new Date()
     pastDate.setMonth(new Date().getMonth() - 1)


### PR DESCRIPTION
Problem
Vacant objects showed as Gällande in the leasespage/lease search (/leases). Reported for 209-028-02-0301 (vacant since 2026-04-09).

Cause
Lease status is calculated from hyobj.fdate + hyobj.sistadeb. Each object also has a keyhyobt = 1 ("Avtalsmall") template row in Xpand with all dates NULL, and with no dates, calculateStatus falls through to Current. The real contracts were all ended and hidden by the default filter, leaving only the template > "1 av 1 resultat", Gällande. Lease search didn't filter out templates, though rental-object-adapter already does (via keyhyobt).

Fix

lease-search-adapter.ts: exclude keyhyobt = 1 (Avtalsmall) in buildBaseQuery().
transformFromXPandDb.ts: defensive guard - calculateStatus returns Ended when both dates are missing.
Regression test for the all-NULL row.
Verified: 31,989 Avtalsmall rows in prod (all NULL fdate), ~19,800 currently leaking into search; no real contract type has a NULL fdate/startDate. 