### PR TITLE
AVTAL-115: followup

### DIFF
--- a/apps/property-tree/src/features/tenants/lib/invoiceDeferral.ts
+++ b/apps/property-tree/src/features/tenants/lib/invoiceDeferral.ts
@@ -27,3 +27,7 @@ export function canGrantInvoiceDeferral(invoice: Invoice): boolean {
     !invoice.credit
   )
 }
+
+export function hasInvoiceDeferral(invoice: Invoice): boolean {
+  return !!invoice.deferral
+}

--- a/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
+++ b/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
@@ -351,21 +351,21 @@ export const InvoicesTable = (props: Props) => {
     return (
       <>
         {invoice.description && (
-          <div className="mb-3 text-sm bg-background/50 rounded p-2">
+          <div className="text-sm bg-background/50 rounded p-2">
             <span className="font-medium">Text:</span> {invoice.description}
             {invoice.expectedLoss && <div>Befarad kundförlust</div>}
-          </div>
-        )}
-        {invoice.credit && (
-          <div className="mb-3 text-sm bg-background/50 rounded p-2">
-            <span className="font-medium">Krediterar faktura:</span>{' '}
-            {invoice.credit.originalInvoiceId}
           </div>
         )}
         {invoice.deferral?.madeBy && (
           <div className="mb-3 text-sm bg-background/50 rounded p-2">
             <span className="font-medium">Anstånd beviljat av:</span>{' '}
             {invoice.deferral.madeBy}
+          </div>
+        )}
+        {invoice.credit && (
+          <div className="mb-3 text-sm bg-background/50 rounded p-2">
+            <span className="font-medium">Krediterar faktura:</span>{' '}
+            {invoice.credit.originalInvoiceId}
           </div>
         )}
         {invoice.invoiceFileUrl && (

--- a/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
+++ b/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
@@ -66,8 +66,6 @@ export const InvoicesTable = (props: Props) => {
     return format(dateObj, 'yyyy-MM-dd')
   }
 
-  const hasDeferral = hasInvoiceDeferral
-
   const getStatusBadge = (invoice: Invoice) => {
     return match(invoice)
       .with({ credit: { originalInvoiceId: P.string } }, () => (
@@ -91,7 +89,7 @@ export const InvoicesTable = (props: Props) => {
   }
 
   const getDeferralBadge = (invoice: Invoice) => {
-    if (!hasDeferral(invoice)) {
+    if (!hasInvoiceDeferral(invoice)) {
       return null
     }
 
@@ -161,7 +159,7 @@ export const InvoicesTable = (props: Props) => {
 
     const dateLabel = formatDate(invoice.expirationDate)
 
-    if (!hasDeferral(invoice)) {
+    if (!hasInvoiceDeferral(invoice)) {
       return <span>{dateLabel}</span>
     }
 
@@ -483,7 +481,7 @@ export const InvoicesTable = (props: Props) => {
             <span className="text-muted-foreground">Inkasso:</span>
             <span>{invoice.sentToDebtCollection ? 'Ja' : 'Nej'}</span>
           </div>
-          {hasDeferral(invoice) && (
+          {hasInvoiceDeferral(invoice) && (
             <div className="flex justify-between items-center">
               <span className="text-muted-foreground">Anstånd:</span>
               {getDeferralBadge(invoice)}

--- a/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
+++ b/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
@@ -12,6 +12,7 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/shared/ui/Tooltip'
 
 import { useInvoicePaymentEvents } from '../hooks/useInvoicePaymentEvents'
+import { hasInvoiceDeferral } from '../lib/invoiceDeferral'
 import { InvoiceDeferralAction } from './InvoiceDeferralAction'
 
 const currencyFormatter = new Intl.NumberFormat('sv-SE', {
@@ -65,9 +66,7 @@ export const InvoicesTable = (props: Props) => {
     return format(dateObj, 'yyyy-MM-dd')
   }
 
-  // Xledger updates dueDate on deferral and adds "Anstånd till YYYY-MM-DD" to text.
-  // defermentDate is parsed from that text — it won't be later than expirationDate.
-  const hasDeferral = (invoice: Invoice): boolean => !!invoice.defermentDate
+  const hasDeferral = hasInvoiceDeferral
 
   const getStatusBadge = (invoice: Invoice) => {
     return match(invoice)
@@ -96,7 +95,20 @@ export const InvoicesTable = (props: Props) => {
       return null
     }
 
-    return <Badge variant="destructive">Anstånd</Badge>
+    const badge = <Badge variant="destructive">Anstånd</Badge>
+
+    if (invoice.deferral?.madeBy) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="cursor-help">{badge}</span>
+          </TooltipTrigger>
+          <TooltipContent>Beviljat av {invoice.deferral.madeBy}</TooltipContent>
+        </Tooltip>
+      )
+    }
+
+    return badge
   }
 
   const getInvoiceType = (invoice: Invoice): string => {
@@ -348,6 +360,12 @@ export const InvoicesTable = (props: Props) => {
           <div className="mb-3 text-sm bg-background/50 rounded p-2">
             <span className="font-medium">Krediterar faktura:</span>{' '}
             {invoice.credit.originalInvoiceId}
+          </div>
+        )}
+        {invoice.deferral?.madeBy && (
+          <div className="mb-3 text-sm bg-background/50 rounded p-2">
+            <span className="font-medium">Anstånd beviljat av:</span>{' '}
+            {invoice.deferral.madeBy}
           </div>
         )}
         {invoice.invoiceFileUrl && (

--- a/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
+++ b/apps/property-tree/src/features/tenants/ui/InvoicesTable.tsx
@@ -65,31 +65,9 @@ export const InvoicesTable = (props: Props) => {
     return format(dateObj, 'yyyy-MM-dd')
   }
 
-  const formatSource = (source: Invoice['source']) => {
-    return match(source)
-      .with('next', () => 'XLedger')
-      .with('legacy', () => 'Xpand')
-      .exhaustive()
-  }
-
-  // Get the effective expiration date (deferment date if applicable, otherwise original)
-  const getEffectiveExpirationDate = (
-    invoice: Invoice
-  ): { date: Date | null; isDeferment: boolean; originalDate: Date | null } => {
-    const originalDate = invoice.expirationDate
-      ? new Date(invoice.expirationDate)
-      : null
-
-    const defermentDate = invoice.defermentDate
-      ? new Date(invoice.defermentDate)
-      : null
-
-    if (defermentDate && originalDate && defermentDate > originalDate) {
-      return { date: defermentDate, isDeferment: true, originalDate }
-    }
-
-    return { date: originalDate, isDeferment: false, originalDate: null }
-  }
+  // Xledger updates dueDate on deferral and adds "Anstånd till YYYY-MM-DD" to text.
+  // defermentDate is parsed from that text — it won't be later than expirationDate.
+  const hasDeferral = (invoice: Invoice): boolean => !!invoice.defermentDate
 
   const getStatusBadge = (invoice: Invoice) => {
     return match(invoice)
@@ -111,6 +89,14 @@ export const InvoicesTable = (props: Props) => {
       .otherwise((v) => (
         <Badge variant="secondary">Okänd betalstatus: {v.paymentStatus}</Badge>
       ))
+  }
+
+  const getDeferralBadge = (invoice: Invoice) => {
+    if (!hasDeferral(invoice)) {
+      return null
+    }
+
+    return <Badge variant="destructive">Anstånd</Badge>
   }
 
   const getInvoiceType = (invoice: Invoice): string => {
@@ -159,25 +145,22 @@ export const InvoicesTable = (props: Props) => {
 
   // Component to render expiration date with deferment indicator
   const ExpirationDateCell = ({ invoice }: { invoice: Invoice }) => {
-    const { date, isDeferment, originalDate } =
-      getEffectiveExpirationDate(invoice)
+    if (!invoice.expirationDate) return <span>-</span>
 
-    if (!date) return <span>-</span>
+    const dateLabel = formatDate(invoice.expirationDate)
 
-    if (isDeferment && originalDate) {
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="cursor-help">{formatDate(date)}*</span>
-          </TooltipTrigger>
-          <TooltipContent>
-            Ursprungligt förfallodatum: {formatDate(originalDate)}
-          </TooltipContent>
-        </Tooltip>
-      )
+    if (!hasDeferral(invoice)) {
+      return <span>{dateLabel}</span>
     }
 
-    return <span>{formatDate(date)}</span>
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="cursor-help">{dateLabel}*</span>
+        </TooltipTrigger>
+        <TooltipContent>Förfallodatum efter anstånd</TooltipContent>
+      </Tooltip>
+    )
   }
 
   // Component to display payment events table
@@ -338,11 +321,9 @@ export const InvoicesTable = (props: Props) => {
       className: 'p-3 text-sm',
     },
     {
-      key: 'source',
-      label: 'Källa',
-      render: (invoice) => (
-        <span className="text-sm">{formatSource(invoice.source)}</span>
-      ),
+      key: 'deferral',
+      label: 'Anstånd',
+      render: (invoice) => getDeferralBadge(invoice),
       className: 'p-3 text-sm',
     },
     {
@@ -484,10 +465,12 @@ export const InvoicesTable = (props: Props) => {
             <span className="text-muted-foreground">Inkasso:</span>
             <span>{invoice.sentToDebtCollection ? 'Ja' : 'Nej'}</span>
           </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Källa:</span>
-            <span>{formatSource(invoice.source)}</span>
-          </div>
+          {hasDeferral(invoice) && (
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground">Anstånd:</span>
+              {getDeferralBadge(invoice)}
+            </div>
+          )}
         </div>
       </>
     )

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -10054,7 +10054,7 @@ export interface paths {
   "/v1/contacts/batch": {
     /**
      * Batch lookup of contacts by contact code
-     * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, or `includeAddress` to include those joins. Missing contact codes are simply absent from the response.
+     * @description Lean by default — returns base contact fields with empty phone/email/address arrays. Set `includePhone`, `includeEmail`, `includeAddress`, or `includeRelations` to include those joins. Missing contact codes are simply absent from the response.
      */
     get: {
       parameters: {
@@ -10067,6 +10067,8 @@ export interface paths {
           includeEmail?: boolean;
           /** @description Include addresses in the response. */
           includeAddress?: boolean;
+          /** @description Include related contacts (guardians/wards) in the response. */
+          includeRelations?: boolean;
         };
       };
       responses: {
@@ -13879,6 +13881,12 @@ export interface components {
           region: string | null;
           country: string | null;
         })[];
+      relatedContacts?: ({
+          contactCode: string;
+          /** @enum {string} */
+          role: "trustee" | "administrator" | "ward";
+          fullName: string;
+        })[];
       /** @enum {string} */
       type: "individual";
       personal: {
@@ -13916,6 +13924,12 @@ export interface components {
           city: string | null;
           region: string | null;
           country: string | null;
+        })[];
+      relatedContacts?: ({
+          contactCode: string;
+          /** @enum {string} */
+          role: "trustee" | "administrator" | "ward";
+          fullName: string;
         })[];
       /** @enum {string} */
       type: "organisation";

--- a/libs/types/src/schemas/v1/invoice.ts
+++ b/libs/types/src/schemas/v1/invoice.ts
@@ -22,6 +22,12 @@ export const InvoiceRowSchema = z.object({
   vat: z.number(),
 })
 
+export const InvoiceDeferralSchema = z.object({
+  endDate: z.coerce.date(),
+  reason: z.string(),
+  madeBy: z.string(),
+})
+
 export const InvoicePaymentEventSchema = z.object({
   type: z.string(),
   invoiceId: z.string(),
@@ -46,7 +52,7 @@ export const InvoiceSchema = z.object({
   toDate: z.coerce.date(),
   invoiceDate: z.coerce.date(),
   expirationDate: z.coerce.date().optional(),
-  defermentDate: z.coerce.date().optional(),
+  deferral: InvoiceDeferralSchema.optional(),
   debitStatus: z.number(),
   paymentStatus: PaymentStatusSchema,
   transactionType: InvoiceTransactionTypeSchema,

--- a/services/economy/src/common/adapters/tenfast/schemas.ts
+++ b/services/economy/src/common/adapters/tenfast/schemas.ts
@@ -134,6 +134,13 @@ export function isVisibleTenfastInvoice(invoice: {
   return !EXCLUDED_TENFAST_INVOICE_STATES.includes(invoice.state)
 }
 
+export const TenfastGracePeriodSchema = z.object({
+  endDate: z.string(),
+  reason: z.string(),
+  madeBy: z.string(),
+  madeByEmail: z.string(),
+})
+
 export const TenfastInvoiceSchema = z.object({
   interval: z.object({
     from: z.string(),
@@ -204,6 +211,7 @@ export const TenfastInvoiceSchema = z.object({
   ocrNumber: z.string(),
   late: z.boolean(),
   state: TenfastInvoiceStateSchema,
+  gracePeriod: TenfastGracePeriodSchema.nullish(),
 })
 
 export const TenfastRentalPropertySearchResponseSchema = z.object({

--- a/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
+++ b/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
@@ -409,10 +409,15 @@ const fetchTenfastInvoiceByOcr = async (
     )
 
     if (result.status === 404) {
+      logger.info({ ocr }, 'deferral: Tenfast OCR lookup returned 404')
       return { ok: false, err: 'not-found' }
     }
 
     if (result.status !== 200) {
+      logger.info(
+        { ocr, status: result.status, data: result.data },
+        'deferral: Tenfast OCR lookup returned unexpected status'
+      )
       return { ok: false, err: 'unknown' }
     }
 
@@ -539,6 +544,10 @@ export const setGracePeriod = async (params: {
   try {
     const result = await fetchTenfastInvoiceByOcr(params.invoiceOcr)
     if (!result.ok) {
+      logger.info(
+        { invoiceOcr: params.invoiceOcr, err: result.err },
+        'deferral: Tenfast grace period aborted — OCR lookup failed'
+      )
       return result
     }
 
@@ -558,12 +567,21 @@ export const setGracePeriod = async (params: {
       return { ok: true, data: null }
     }
     if (res.status === 404) {
+      logger.error(
+        { invoiceOcr: params.invoiceOcr, tenfastInvoiceId: result.data._id },
+        'deferral: Tenfast grace-period endpoint returned 404'
+      )
       return { ok: false, err: 'not-found' }
     }
 
     logger.error(
-      { status: res.status, data: res.data, ocr: params.invoiceOcr },
-      'tenfast-adapter.setGracePeriod: unexpected status'
+      {
+        status: res.status,
+        data: res.data,
+        ocr: params.invoiceOcr,
+        tenfastInvoiceId: result.data._id,
+      },
+      'deferral: Tenfast grace-period endpoint returned unexpected status'
     )
     return { ok: false, err: 'unknown' }
   } catch (err: any) {

--- a/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
+++ b/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
@@ -21,6 +21,7 @@ import {
   TenfastAutogiroConsent,
   isVisibleTenfastInvoice,
 } from './schemas'
+import { TenfastDeferralSource } from '../../invoice-deferral'
 import {
   Contact,
   Invoice,
@@ -148,10 +149,15 @@ const dateToDateString = (date: Date): string => {
   return date.toISOString().split('T')[0]
 }
 
+export type ParsedTenfastInvoice = {
+  invoice: Invoice
+  tenfastDeferral?: TenfastDeferralSource
+}
+
 export const getInvoicesForTenant = async (
   tenantId: string,
   from?: Date
-): Promise<AdapterResult<Invoice[], string>> => {
+): Promise<AdapterResult<ParsedTenfastInvoice[], string>> => {
   try {
     const result = await makeTenfastRequest(
       `/v1/hyresvard/hyresgaster/${tenantId}/hyror?populate=avtal`,
@@ -193,7 +199,7 @@ export const getInvoicesForTenant = async (
 export const getInvoicesByContactCode = async (
   contactCode: string,
   filters?: { from?: Date }
-): Promise<Invoice[]> => {
+): Promise<ParsedTenfastInvoice[]> => {
   const tenantResult = await getTenantByContactCode(contactCode)
   if (!tenantResult.ok) {
     throw tenantResult.err
@@ -428,7 +434,7 @@ const fetchTenfastInvoiceByOcr = async (
 
 export const getInvoiceByOcr = async (
   ocr: string
-): Promise<AdapterResult<Invoice, string>> => {
+): Promise<AdapterResult<ParsedTenfastInvoice, string>> => {
   const result = await fetchTenfastInvoiceByOcr(ocr)
   if (!result.ok) {
     if (result.err === 'not-found') {
@@ -476,33 +482,51 @@ export const getInvoiceArticle = async (
   }
 }
 
-const transformToInvoice = (tenfastInvoice: TenfastInvoice): Invoice => {
+const toTenfastDeferralSource = (
+  gracePeriod: TenfastInvoice['gracePeriod']
+): TenfastDeferralSource | undefined => {
+  if (!gracePeriod) {
+    return undefined
+  }
+
+  return {
+    reason: gracePeriod.reason,
+    madeBy: gracePeriod.madeByEmail,
+  }
+}
+
+const transformToInvoice = (
+  tenfastInvoice: TenfastInvoice
+): ParsedTenfastInvoice => {
   const remainingAmount = tenfastInvoice.amount - tenfastInvoice.amountPaid
 
   return {
-    amount: tenfastInvoice.amount,
-    debitStatus: 0, //
-    fromDate: new Date(tenfastInvoice.interval.from),
-    toDate: new Date(tenfastInvoice.interval.to),
-    invoiceDate: tenfastInvoice.activatedAt
-      ? new Date(tenfastInvoice.activatedAt)
-      : new Date(tenfastInvoice.expectedInvoiceDate),
-    expirationDate: new Date(tenfastInvoice.due),
-    paidAmount: tenfastInvoice.amountPaid,
-    remainingAmount,
-    invoiceId: tenfastInvoice.ocrNumber,
-    leaseIds: tenfastInvoice.avtal.map((a) => a.externalId),
-    paymentStatus:
-      remainingAmount <= 0 ? PaymentStatus.Paid : PaymentStatus.Unpaid,
-    type: 'Regular',
-    reference: tenfastInvoice.ocrNumber,
-    source: 'next', // ??
-    invoiceRows: tenfastInvoice.hyror.map(transformToInvoiceRow),
-    transactionType: InvoiceTransactionType.Rent,
-    // TODO this is only (?) used for uniquely identifying invoices with the same invoice number in mina sidor.
-    // We should maybe add a unique id property to the Invoice type instead
-    transactionTypeName: 'some random string',
-    credit: null,
+    invoice: {
+      amount: tenfastInvoice.amount,
+      debitStatus: 0, //
+      fromDate: new Date(tenfastInvoice.interval.from),
+      toDate: new Date(tenfastInvoice.interval.to),
+      invoiceDate: tenfastInvoice.activatedAt
+        ? new Date(tenfastInvoice.activatedAt)
+        : new Date(tenfastInvoice.expectedInvoiceDate),
+      expirationDate: new Date(tenfastInvoice.due),
+      paidAmount: tenfastInvoice.amountPaid,
+      remainingAmount,
+      invoiceId: tenfastInvoice.ocrNumber,
+      leaseIds: tenfastInvoice.avtal.map((a) => a.externalId),
+      paymentStatus:
+        remainingAmount <= 0 ? PaymentStatus.Paid : PaymentStatus.Unpaid,
+      type: 'Regular',
+      reference: tenfastInvoice.ocrNumber,
+      source: 'next', // ??
+      invoiceRows: tenfastInvoice.hyror.map(transformToInvoiceRow),
+      transactionType: InvoiceTransactionType.Rent,
+      // TODO this is only (?) used for uniquely identifying invoices with the same invoice number in mina sidor.
+      // We should maybe add a unique id property to the Invoice type instead
+      transactionTypeName: 'some random string',
+      credit: null,
+    },
+    tenfastDeferral: toTenfastDeferralSource(tenfastInvoice.gracePeriod),
   }
 }
 

--- a/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
+++ b/services/economy/src/common/adapters/tenfast/tenfast-adapter.ts
@@ -581,7 +581,7 @@ export const setGracePeriod = async (params: {
         ocr: params.invoiceOcr,
         tenfastInvoiceId: result.data._id,
       },
-      'deferral: Tenfast grace-period endpoint returned unexpected status'
+      'tenfast-adapter.setGracePeriod: unexpected status'
     )
     return { ok: false, err: 'unknown' }
   } catch (err: any) {

--- a/services/economy/src/common/invoice-deferral.ts
+++ b/services/economy/src/common/invoice-deferral.ts
@@ -1,4 +1,5 @@
 import { Invoice } from '@onecore/types'
+import { logger } from '@onecore/utilities'
 
 export type TenfastDeferralSource = {
   reason: string
@@ -10,6 +11,12 @@ export function buildInvoiceDeferral(sources: {
   tenfastDeferral?: TenfastDeferralSource
 }): NonNullable<Invoice['deferral']> | undefined {
   if (!sources.defermentEndDate) {
+    if (sources.tenfastDeferral) {
+      logger.warn(
+        { tenfastDeferral: sources.tenfastDeferral },
+        'deferral: no public deferral — Tenfast grace period present but missing Xledger deferment end date'
+      )
+    }
     return undefined
   }
 

--- a/services/economy/src/common/invoice-deferral.ts
+++ b/services/economy/src/common/invoice-deferral.ts
@@ -1,0 +1,32 @@
+import { Invoice } from '@onecore/types'
+
+export type TenfastDeferralSource = {
+  reason: string
+  madeBy: string
+}
+
+export function buildInvoiceDeferral(sources: {
+  defermentEndDate?: Date
+  tenfastDeferral?: TenfastDeferralSource
+}): NonNullable<Invoice['deferral']> | undefined {
+  if (!sources.defermentEndDate) {
+    return undefined
+  }
+
+  return {
+    endDate: sources.defermentEndDate,
+    reason: sources.tenfastDeferral?.reason ?? '',
+    madeBy: sources.tenfastDeferral?.madeBy ?? '',
+  }
+}
+
+export function withInvoiceDeferral(
+  invoice: Invoice,
+  sources: {
+    defermentEndDate?: Date
+    tenfastDeferral?: TenfastDeferralSource
+  }
+): Invoice {
+  const deferral = buildInvoiceDeferral(sources)
+  return deferral ? { ...invoice, deferral } : invoice
+}

--- a/services/economy/src/services/common/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/common/adapters/xledger-adapter.ts
@@ -165,7 +165,7 @@ const dateToXledgerDateString = (date: Date): string => {
 }
 
 // Extract deferment date from description like "Anstånd till 2025-12-31"
-const getDefermentDate = (
+export const getDefermentDate = (
   description: string | undefined
 ): Date | undefined => {
   if (!description) return undefined
@@ -174,6 +174,11 @@ const getDefermentDate = (
     return new Date(match[1])
   }
   return undefined
+}
+
+export type ParsedXledgerInvoice = {
+  invoice: Invoice
+  defermentEndDate?: Date
 }
 
 /*
@@ -193,7 +198,7 @@ function getInvoiceCredit(invoiceNode: any): Invoice['credit'] {
     .otherwise(() => null)
 }
 
-const transformToInvoice = (invoiceData: any): Invoice => {
+const transformToInvoice = (invoiceData: any): ParsedXledgerInvoice => {
   const InvoiceTypeMap: Record<number, Invoice['type']> = {
     600: 'Other',
     797: 'Regular',
@@ -226,6 +231,8 @@ const transformToInvoice = (invoiceData: any): Invoice => {
     }
   }
 
+  const defermentEndDate = getDefermentDate(invoiceData.node.text)
+
   const invoice: Omit<Invoice, 'paymentStatus'> = {
     invoiceId: invoiceData.node.invoiceNumber,
     leaseIds: [],
@@ -235,7 +242,6 @@ const transformToInvoice = (invoiceData: any): Invoice => {
     fromDate: dateFromString(invoiceData.node.period.fromDate),
     toDate: dateFromString(invoiceData.node.period.toDate),
     expirationDate: dateFromString(invoiceData.node.dueDate),
-    defermentDate: getDefermentDate(invoiceData.node.text),
     debitStatus: 0,
     transactionType: InvoiceTransactionType.Rent,
     transactionTypeName: randomUUID(),
@@ -256,9 +262,12 @@ const transformToInvoice = (invoiceData: any): Invoice => {
 
   // TODO? handle overpaid invoices (negative remainingAmount)?
   // TODO? DO we want a unique status for invoices paid after due date?
-  function getPaymentStatus(invoice: Omit<Invoice, 'paymentStatus'>) {
+  function getPaymentStatus(
+    invoice: Omit<Invoice, 'paymentStatus'>,
+    defermentEndDate?: Date
+  ) {
     const now = new Date()
-    const overdueDate = invoice.defermentDate ?? invoice.expirationDate
+    const overdueDate = defermentEndDate ?? invoice.expirationDate
 
     //Can remainingAmount be negative? otherwise skip check
     if (!invoice.remainingAmount || invoice.remainingAmount <= 0)
@@ -269,7 +278,15 @@ const transformToInvoice = (invoiceData: any): Invoice => {
     return PaymentStatus.Unpaid
   }
 
-  return { ...invoice, paymentStatus: getPaymentStatus(invoice) }
+  const invoiceWithPaymentStatus = {
+    ...invoice,
+    paymentStatus: getPaymentStatus(invoice, defermentEndDate),
+  }
+
+  return {
+    invoice: invoiceWithPaymentStatus,
+    ...(defermentEndDate && { defermentEndDate }),
+  }
 }
 
 export interface XledgerCustomer {
@@ -905,7 +922,7 @@ function mapToPaymentSyncEvent(event: any): InvoicePaymentEvent | null {
 export const getInvoicesByContactCode = async (
   contactCode: string,
   filters?: { from?: Date }
-): Promise<Invoice[] | null> => {
+): Promise<ParsedXledgerInvoice[] | null> => {
   const xledgerId = await getCustomerDbId(contactCode)
 
   if (!xledgerId) {
@@ -971,7 +988,11 @@ export const getInvoices = async (from?: Date, to?: Date) => {
   }
 
   const result = await makeXledgerRequest(query)
-  return result.data?.arTransactions?.edges.map(transformToInvoice) ?? []
+  return (
+    result.data?.arTransactions?.edges.map(
+      (e: any) => transformToInvoice(e).invoice
+    ) ?? []
+  )
 }
 
 export const getAllInvoicesWithMatchIds = async ({
@@ -1033,8 +1054,9 @@ export const getAllInvoicesWithMatchIds = async ({
 
   const invoicesWithMatchIds: Invoice[] = result.data.arTransactions.edges.map(
     (e: any): Invoice => {
+      const { invoice } = transformToInvoice(e)
       return {
-        ...transformToInvoice(e),
+        ...invoice,
         matchId: e.node.matchId,
       }
     }
@@ -1050,7 +1072,9 @@ export const getAllInvoicesWithMatchIds = async ({
   return { content: invoicesWithMatchIds, pageInfo }
 }
 
-export async function getInvoiceByInvoiceNumber(invoiceNumber: string) {
+export async function getInvoiceByInvoiceNumber(
+  invoiceNumber: string
+): Promise<ParsedXledgerInvoice | null> {
   const q = {
     query: gql`
       query ($invoiceNumber: String!) {
@@ -1079,9 +1103,9 @@ export async function getInvoiceByInvoiceNumber(invoiceNumber: string) {
       return null
     }
 
-    const [invoice] =
+    const [parsed] =
       result.data?.arTransactions.edges.map(transformToInvoice) ?? []
-    return invoice
+    return parsed ?? null
   } catch (err) {
     logger.error(err, 'Error getting invoice from Xledger')
     throw err
@@ -1483,7 +1507,7 @@ export const updateInvoiceDeferralDate = async (
   invoiceNumber: string,
   newDueDate: Date
 ): Promise<void> => {
-  const [dbId, invoice] = await Promise.all([
+  const [dbId, parsed] = await Promise.all([
     getArTransactionDbId(invoiceNumber),
     getInvoiceByInvoiceNumber(invoiceNumber),
   ])
@@ -1495,7 +1519,7 @@ export const updateInvoiceDeferralDate = async (
   }
 
   const dueDateString = dateToGraphQlDateString(newDueDate)
-  const text = buildDeferralText(invoice?.description, dueDateString)
+  const text = buildDeferralText(parsed?.invoice.description, dueDateString)
 
   const mutation = {
     query: gql`

--- a/services/economy/src/services/debt-collection-service/service.ts
+++ b/services/economy/src/services/debt-collection-service/service.ts
@@ -161,7 +161,7 @@ const getTenfastInvoices = async (ocrs: string[]): Promise<Invoice[]> => {
       throw new Error(invoiceResult.err)
     }
 
-    invoices.push(invoiceResult.data)
+    invoices.push(invoiceResult.data.invoice)
   }
 
   return invoices

--- a/services/economy/src/services/invoice-service/index.ts
+++ b/services/economy/src/services/invoice-service/index.ts
@@ -20,12 +20,10 @@ import {
   getLeaseDetails,
   stralforsPostChannelLookup,
   getAutogiroConsent,
+  getPublicInvoiceByOcr,
 } from './service'
 import * as invoiceService from './service'
-import {
-  getInvoiceByOcr,
-  getInvoicePdf,
-} from '../../common/adapters/tenfast/tenfast-adapter'
+import { getInvoicePdf } from '../../common/adapters/tenfast/tenfast-adapter'
 
 export const routes = (router: KoaRouter) => {
   router.get('(.*)/invoices/bycontactcode/:contactCode', async (ctx) => {
@@ -79,7 +77,7 @@ export const routes = (router: KoaRouter) => {
 
   router.get('(.*)/invoices/by-ocr/:ocr', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const result = await getInvoiceByOcr(ctx.params.ocr)
+    const result = await getPublicInvoiceByOcr(ctx.params.ocr)
 
     if (!result.ok) {
       ctx.status = result.err.includes('not found') ? 404 : 500

--- a/services/economy/src/services/invoice-service/service.ts
+++ b/services/economy/src/services/invoice-service/service.ts
@@ -57,6 +57,8 @@ import {
   getRentalIdFromLeaseId,
 } from '../common/helpers'
 import { TenfastRentArticle } from '@src/common/adapters/tenfast/schemas'
+import { AdapterResult } from '@src/common/types'
+import { withInvoiceDeferral } from '@src/common/invoice-deferral'
 import {
   getInvoiceArticle,
   getInvoiceByOcr,
@@ -910,50 +912,64 @@ export const getInvoicesByContactCode = async (
     from: filters?.from,
   })
 
-  const xledgerInvoiceIds = xledgerInvoices.map((invoice) => invoice.invoiceId)
+  const xledgerInvoiceIds = xledgerInvoices.map(
+    (parsed) => parsed.invoice.invoiceId
+  )
 
-  const regularInvoices: Invoice[] = []
-  const losses: Invoice[] = []
+  const regularInvoices: typeof xledgerInvoices = []
+  const losses: typeof xledgerInvoices = []
 
-  xledgerInvoices.forEach((i) => {
+  xledgerInvoices.forEach((parsed) => {
     // A loss is recorded as a transaction on account 1529
-    if (i.accountCode === '1529') {
-      losses.push(i)
+    if (parsed.invoice.accountCode === '1529') {
+      losses.push(parsed)
     } else {
-      regularInvoices.push(i)
+      regularInvoices.push(parsed)
     }
   })
 
   // An invoice is marked as an expected loss if there is a recorded loss with the same invoice number
-  regularInvoices.forEach((i) => {
-    const lossForInvoice = losses.find((l) => l.invoiceId === i.invoiceId)
+  regularInvoices.forEach((parsed) => {
+    const lossForInvoice = losses.find(
+      (loss) => loss.invoice.invoiceId === parsed.invoice.invoiceId
+    )
     if (lossForInvoice) {
-      i.expectedLoss = true
+      parsed.invoice.expectedLoss = true
     }
   })
 
   // If invoice exists in tenfast, use period (fromDate, toDate) from tenfast invoice
   // Otherwise use period from xledger invoice
   return regularInvoices
-    .map((invoice) => {
+    .map((parsed) => {
       const tenfastInvoice = tenfastInvoices.find(
-        (v) => v.invoiceId === invoice.invoiceId
+        (invoice) => invoice.invoice.invoiceId === parsed.invoice.invoiceId
       )
 
-      if (tenfastInvoice?.fromDate && tenfastInvoice.toDate) {
-        return {
-          ...invoice,
-          fromDate: tenfastInvoice.fromDate,
-          toDate: tenfastInvoice.toDate,
-        }
-      } else {
-        return invoice
+      const invoice = {
+        ...parsed.invoice,
+        ...(tenfastInvoice?.invoice.fromDate &&
+          tenfastInvoice.invoice.toDate && {
+            fromDate: tenfastInvoice.invoice.fromDate,
+            toDate: tenfastInvoice.invoice.toDate,
+          }),
       }
+
+      return withInvoiceDeferral(invoice, {
+        defermentEndDate: parsed.defermentEndDate,
+        tenfastDeferral: tenfastInvoice?.tenfastDeferral,
+      })
     })
     .concat(
-      tenfastInvoices.filter(
-        (invoice) => !xledgerInvoiceIds.includes(invoice.invoiceId)
-      )
+      tenfastInvoices
+        .filter(
+          (parsed) => !xledgerInvoiceIds.includes(parsed.invoice.invoiceId)
+        )
+        .map((parsed) =>
+          withInvoiceDeferral(parsed.invoice, {
+            tenfastDeferral: parsed.tenfastDeferral,
+          })
+        )
     )
 }
 
@@ -975,7 +991,7 @@ const checkInvoiceDeferralEligibility = async (
     return { ok: false, err: 'invoice-not-found' }
   }
 
-  if (!isInvoiceEligibleForDeferral(xledgerInvoice)) {
+  if (!isInvoiceEligibleForDeferral(xledgerInvoice.invoice)) {
     return { ok: false, err: 'invoice-not-eligible' }
   }
 
@@ -1020,27 +1036,55 @@ export const deferInvoice = async (params: {
   return { ok: true }
 }
 
+export const getPublicInvoiceByOcr = async (
+  ocr: string
+): Promise<AdapterResult<Invoice, string>> => {
+  const tenfastResult = await getInvoiceByOcr(ocr)
+  if (!tenfastResult.ok) {
+    return tenfastResult
+  }
+
+  const xledgerResult = await getInvoiceByInvoiceNumber(
+    tenfastResult.data.invoice.invoiceId
+  )
+
+  return {
+    ok: true,
+    data: withInvoiceDeferral(tenfastResult.data.invoice, {
+      defermentEndDate: xledgerResult?.defermentEndDate,
+      tenfastDeferral: tenfastResult.data.tenfastDeferral,
+    }),
+  }
+}
+
 export const getInvoiceDetails = async (
   invoiceNumber: string
 ): Promise<Invoice | null> => {
-  const result = await getInvoiceByInvoiceNumber(invoiceNumber)
-  if (!result) {
+  const parsed = await getInvoiceByInvoiceNumber(invoiceNumber)
+  if (!parsed) {
     return null
   }
 
-  const tenfastInvoiceResult = await getInvoiceByOcr(result.invoiceId)
+  let invoice = parsed.invoice
+  const tenfastInvoiceResult = await getInvoiceByOcr(invoice.invoiceId)
 
   if (!tenfastInvoiceResult.ok) {
     throw new Error(tenfastInvoiceResult.err)
   }
 
   if (tenfastInvoiceResult.data) {
-    result.invoiceRows = await enrichInvoiceRowsWithText(
-      tenfastInvoiceResult.data.invoiceRows
-    )
+    invoice = {
+      ...invoice,
+      invoiceRows: await enrichInvoiceRowsWithText(
+        tenfastInvoiceResult.data.invoice.invoiceRows
+      ),
+    }
   }
 
-  return result
+  return withInvoiceDeferral(invoice, {
+    defermentEndDate: parsed.defermentEndDate,
+    tenfastDeferral: tenfastInvoiceResult.data?.tenfastDeferral,
+  })
 }
 
 export const getInvoiceDetailsForContactCode = async (
@@ -1060,7 +1104,13 @@ export const getInvoiceDetailsForContactCode = async (
     return []
   }
 
-  return enrichInvoices(tenfastInvoicesResult.data)
+  return enrichInvoices(
+    tenfastInvoicesResult.data.map((parsed) =>
+      withInvoiceDeferral(parsed.invoice, {
+        tenfastDeferral: parsed.tenfastDeferral,
+      })
+    )
+  )
 }
 
 const enrichInvoices = async (invoices: Invoice[]): Promise<Invoice[]> => {

--- a/services/economy/src/services/invoice-service/service.ts
+++ b/services/economy/src/services/invoice-service/service.ts
@@ -988,10 +988,23 @@ const checkInvoiceDeferralEligibility = async (
 > => {
   const xledgerInvoice = await getInvoiceByInvoiceNumber(invoiceOcr)
   if (!xledgerInvoice) {
+    logger.warn(
+      { invoiceOcr },
+      'deferral: eligibility failed — invoice not found in Xledger'
+    )
     return { ok: false, err: 'invoice-not-found' }
   }
 
   if (!isInvoiceEligibleForDeferral(xledgerInvoice.invoice)) {
+    logger.warn(
+      {
+        invoiceOcr,
+        source: xledgerInvoice.invoice.source,
+        paymentStatus: xledgerInvoice.invoice.paymentStatus,
+        credit: xledgerInvoice.invoice.credit,
+      },
+      'deferral: eligibility failed — invoice not eligible'
+    )
     return { ok: false, err: 'invoice-not-eligible' }
   }
 
@@ -1017,6 +1030,10 @@ export const deferInvoice = async (params: {
   })
 
   if (!tenfastResult.ok) {
+    logger.error(
+      { invoiceOcr: params.invoiceOcr, err: tenfastResult.err },
+      'deferral: Tenfast grace period failed — skipping Xledger update'
+    )
     if (tenfastResult.err === 'not-found') {
       return { ok: false, err: 'invoice-not-found' }
     }
@@ -1028,7 +1045,7 @@ export const deferInvoice = async (params: {
   } catch (error) {
     logger.error(
       { error, invoiceOcr: params.invoiceOcr },
-      'deferInvoice: Xledger update failed after Tenfast grace period was set'
+      'deferral: Xledger update failed after Tenfast grace period was set'
     )
     return { ok: false, err: 'xledger-failed' }
   }
@@ -1062,6 +1079,11 @@ export const getInvoiceDetails = async (
 ): Promise<Invoice | null> => {
   const parsed = await getInvoiceByInvoiceNumber(invoiceNumber)
   if (!parsed) {
+    logger.warn(
+      { invoiceNumber },
+      'deferral: getInvoiceDetails — invoice not found in Xledger'
+    )
+
     return null
   }
 

--- a/services/economy/test/common/adapters/tenfast-adapter.test.ts
+++ b/services/economy/test/common/adapters/tenfast-adapter.test.ts
@@ -111,7 +111,7 @@ describe('Tenfast Adapter', () => {
 
       assert(result.ok)
       expect(result.data).toHaveLength(1)
-      expect(result.data[0]).toMatchObject({
+      expect(result.data[0].invoice).toMatchObject({
         amount: 1000,
         debitStatus: 0,
         fromDate: new Date('2024-01-01'),
@@ -126,8 +126,8 @@ describe('Tenfast Adapter', () => {
         reference: '55123456',
         source: 'next',
       })
-      expect(result.data[0].invoiceRows).toHaveLength(1)
-      expect(result.data[0].invoiceRows[0]).toMatchObject({
+      expect(result.data[0].invoice.invoiceRows).toHaveLength(1)
+      expect(result.data[0].invoice.invoiceRows[0]).toMatchObject({
         amount: 1000,
         rentArticle: 'HYRAB',
         fromDate: '2024-01-01',
@@ -135,6 +135,32 @@ describe('Tenfast Adapter', () => {
         vat: 0,
         printGroup: 'Hyra bostad',
       })
+    })
+
+    it('maps tenfast deferral source when grace period is present on invoice', async () => {
+      const mockInvoices = [
+        TenfastInvoiceFactory.build({
+          gracePeriod: {
+            endDate: '2026-06-30',
+            reason: 'Betalningsplan',
+            madeBy: 'user-123',
+            madeByEmail: 'admin@mimer.nu',
+          },
+        }),
+      ]
+      mockAxios.request.mockResolvedValue({
+        status: 200,
+        data: mockInvoices,
+      })
+
+      const result = await getInvoicesForTenant('tenant-123')
+
+      assert(result.ok)
+      expect(result.data[0].tenfastDeferral).toEqual({
+        reason: 'Betalningsplan',
+        madeBy: 'admin@mimer.nu',
+      })
+      expect(result.data[0].invoice.deferral).toBeUndefined()
     })
 
     it('should transform paid invoices correctly', async () => {
@@ -153,8 +179,8 @@ describe('Tenfast Adapter', () => {
       const result = await getInvoicesForTenant('tenant-123')
 
       assert(result.ok)
-      expect(result.data[0].paymentStatus).toBe(PaymentStatus.Paid)
-      expect(result.data[0].remainingAmount).toBe(0)
+      expect(result.data[0].invoice.paymentStatus).toBe(PaymentStatus.Paid)
+      expect(result.data[0].invoice.remainingAmount).toBe(0)
     })
 
     it('parses draft invoices but excludes them from results', async () => {
@@ -180,7 +206,7 @@ describe('Tenfast Adapter', () => {
 
       assert(result.ok)
       expect(result.data).toHaveLength(1)
-      expect(result.data[0].invoiceId).toBe('55123456')
+      expect(result.data[0].invoice.invoiceId).toBe('55123456')
     })
   })
 
@@ -197,7 +223,7 @@ describe('Tenfast Adapter', () => {
       const result = await getInvoiceByOcr(ocr)
 
       assert(result.ok)
-      expect(result.data).toMatchObject({
+      expect(result.data.invoice).toMatchObject({
         amount: 1000,
         paidAmount: 500,
         remainingAmount: 500,

--- a/services/economy/test/common/invoice-deferral.test.ts
+++ b/services/economy/test/common/invoice-deferral.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildInvoiceDeferral,
+  withInvoiceDeferral,
+} from '@src/common/invoice-deferral'
+import * as factory from '@test/factories'
+
+describe('invoice-deferral', () => {
+  it('builds deferral from xledger end date with empty tenfast metadata', () => {
+    expect(
+      buildInvoiceDeferral({ defermentEndDate: new Date('2026-06-30') })
+    ).toEqual({
+      endDate: new Date('2026-06-30'),
+      reason: '',
+      madeBy: '',
+    })
+  })
+
+  it('uses xledger end date and tenfast metadata when both exist', () => {
+    expect(
+      buildInvoiceDeferral({
+        defermentEndDate: new Date('2026-07-15'),
+        tenfastDeferral: {
+          reason: 'Betalningsplan',
+          madeBy: 'admin@mimer.nu',
+        },
+      })
+    ).toEqual({
+      endDate: new Date('2026-07-15'),
+      reason: 'Betalningsplan',
+      madeBy: 'admin@mimer.nu',
+    })
+  })
+
+  it('returns undefined when only tenfast has grace period metadata', () => {
+    expect(
+      buildInvoiceDeferral({
+        tenfastDeferral: {
+          reason: 'Betalningsplan',
+          madeBy: 'admin@mimer.nu',
+        },
+      })
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when no deferral sources exist', () => {
+    expect(buildInvoiceDeferral({})).toBeUndefined()
+  })
+
+  it('attaches deferral to invoice only when xledger has deferment end date', () => {
+    const invoice = factory.invoice.build({ invoiceId: '55123456' })
+
+    expect(
+      withInvoiceDeferral(invoice, {
+        defermentEndDate: new Date('2026-07-15'),
+        tenfastDeferral: {
+          reason: 'Betalningsplan',
+          madeBy: 'admin@mimer.nu',
+        },
+      })
+    ).toEqual({
+      ...invoice,
+      deferral: {
+        endDate: new Date('2026-07-15'),
+        reason: 'Betalningsplan',
+        madeBy: 'admin@mimer.nu',
+      },
+    })
+  })
+})

--- a/services/economy/test/services/common/adapters/xledger-adapter.test.ts
+++ b/services/economy/test/services/common/adapters/xledger-adapter.test.ts
@@ -89,7 +89,9 @@ describe(adapter.getInvoicesByContactCode, () => {
 
     const result = await adapter.getInvoicesByContactCode('P12345')
     expect(result).toHaveLength(1)
-    expect(() => schemas.v1.InvoiceSchema.array().parse(result)).not.toThrow()
+    expect(() =>
+      schemas.v1.InvoiceSchema.array().parse(result?.map((parsed) => parsed.invoice))
+    ).not.toThrow()
   })
 
   it('marks invoice as credit when payment reference is set', async () => {
@@ -135,7 +137,11 @@ describe(adapter.getInvoicesByContactCode, () => {
 
     const result = await adapter.getInvoicesByContactCode('P12345')
     expect(result).toEqual([
-      expect.objectContaining({ credit: { originalInvoiceId: '123456' } }),
+      expect.objectContaining({
+        invoice: expect.objectContaining({
+          credit: { originalInvoiceId: '123456' },
+        }),
+      }),
     ])
   })
 
@@ -181,7 +187,11 @@ describe(adapter.getInvoicesByContactCode, () => {
 
     const result = await adapter.getInvoicesByContactCode('P12345')
     expect(result).toEqual([
-      expect.objectContaining({ credit: { originalInvoiceId: '12345' } }),
+      expect.objectContaining({
+        invoice: expect.objectContaining({
+          credit: { originalInvoiceId: '12345' },
+        }),
+      }),
     ])
   })
 })

--- a/services/economy/test/services/debt-collection-service/__mocks__/tenfast-adapter.ts
+++ b/services/economy/test/services/debt-collection-service/__mocks__/tenfast-adapter.ts
@@ -136,7 +136,10 @@ export const setupDefaultMocks = () => {
     ok: true,
     data: createMockContact(),
   })
-  getInvoiceByOcr.mockResolvedValue({ ok: true, data: createMockRentInvoice() })
+  getInvoiceByOcr.mockResolvedValue({
+    ok: true,
+    data: { invoice: createMockRentInvoice() },
+  })
   getLease.mockResolvedValue({ ok: true, data: createMockLease() })
   getRentalProperty.mockResolvedValue({
     ok: true,

--- a/services/economy/test/services/debt-collection-service/service.test.ts
+++ b/services/economy/test/services/debt-collection-service/service.test.ts
@@ -195,7 +195,7 @@ describe('Debt Collection Service', () => {
 
       getInvoiceByOcr.mockResolvedValueOnce({
         ok: true,
-        data: createMockRentInvoice({ invoiceRows: mockRows }),
+        data: { invoice: createMockRentInvoice({ invoiceRows: mockRows }) },
       })
 
       const csvWithPayment = createRentInvoiceCsv([

--- a/services/economy/test/services/invoice-service/index.test.ts
+++ b/services/economy/test/services/invoice-service/index.test.ts
@@ -10,6 +10,10 @@ import { routes } from '@src/services/invoice-service'
 
 import * as factory from '@test/factories'
 import { schemas } from '@onecore/types'
+import { Invoice } from '@onecore/types'
+
+const parsedXledger = (invoice: Invoice) => ({ invoice })
+const parsedTenfast = (invoice: Invoice) => ({ invoice })
 
 const app = new Koa()
 const router = new KoaRouter()
@@ -32,17 +36,17 @@ describe('Invoice Service', () => {
       jest
         .spyOn(xledgerAdapter, 'getInvoicesByContactCode')
         .mockResolvedValueOnce([
-          factory.invoice.build({ invoiceId: '123' }),
-          factory.invoice.build({ invoiceId: '456' }),
-          factory.invoice.build({ invoiceId: '789' }),
+          parsedXledger(factory.invoice.build({ invoiceId: '123' })),
+          parsedXledger(factory.invoice.build({ invoiceId: '456' })),
+          parsedXledger(factory.invoice.build({ invoiceId: '789' })),
         ])
 
       jest
         .spyOn(tenfastAdapter, 'getInvoicesByContactCode')
         .mockResolvedValueOnce([
-          factory.invoice.build({ invoiceId: '123' }),
-          factory.invoice.build({ invoiceId: '456' }),
-          factory.invoice.build({ invoiceId: '789' }),
+          parsedTenfast(factory.invoice.build({ invoiceId: '123' })),
+          parsedTenfast(factory.invoice.build({ invoiceId: '456' })),
+          parsedTenfast(factory.invoice.build({ invoiceId: '789' })),
         ])
 
       const res = await request(app.callback()).get(
@@ -64,11 +68,11 @@ describe('Invoice Service', () => {
 
       jest
         .spyOn(xledgerAdapter, 'getInvoicesByContactCode')
-        .mockResolvedValueOnce([invoice_1])
+        .mockResolvedValueOnce([parsedXledger(invoice_1)])
 
       jest
         .spyOn(tenfastAdapter, 'getInvoicesByContactCode')
-        .mockResolvedValueOnce([invoice_2])
+        .mockResolvedValueOnce([parsedTenfast(invoice_2)])
 
       const res = await request(app.callback()).get(
         `/invoices/bycontactcode/P123456`
@@ -117,11 +121,11 @@ describe('Invoice Service', () => {
 
       jest
         .spyOn(xledgerAdapter, 'getInvoicesByContactCode')
-        .mockResolvedValueOnce([xledgerInvoice])
+        .mockResolvedValueOnce([parsedXledger(xledgerInvoice)])
 
       jest
         .spyOn(tenfastAdapter, 'getInvoicesByContactCode')
-        .mockResolvedValueOnce([tenfastInvoice])
+        .mockResolvedValueOnce([parsedTenfast(tenfastInvoice)])
 
       const res = await request(app.callback()).get(
         `/invoices/bycontactcode/P123456`
@@ -151,7 +155,7 @@ describe('Invoice Service', () => {
 
       jest
         .spyOn(xledgerAdapter, 'getInvoicesByContactCode')
-        .mockResolvedValueOnce([xledgerInvoice])
+        .mockResolvedValueOnce([parsedXledger(xledgerInvoice)])
 
       const res = await request(app.callback()).get(
         `/invoices/bycontactcode/P123456`
@@ -182,10 +186,15 @@ describe('Invoice Service', () => {
     it('responds with invoice', async () => {
       jest
         .spyOn(xledgerAdapter, 'getInvoiceByInvoiceNumber')
-        .mockResolvedValueOnce(factory.invoice.build())
+        .mockResolvedValueOnce(
+          parsedXledger(factory.invoice.build({ invoiceId: 'test-invoice-id' }))
+        )
       jest
         .spyOn(tenfastAdapter, 'getInvoiceByOcr')
-        .mockResolvedValueOnce({ ok: true, data: factory.invoice.build() })
+        .mockResolvedValueOnce({
+          ok: true,
+          data: parsedTenfast(factory.invoice.build({ invoiceId: 'test-invoice-id' })),
+        })
 
       const res = await request(app.callback()).get(`/invoices/12345`)
 

--- a/services/economy/test/services/invoice-service/service.test.ts
+++ b/services/economy/test/services/invoice-service/service.test.ts
@@ -1,6 +1,7 @@
 import {
   processInvoiceRows,
   getInvoiceDetails,
+  getPublicInvoiceByOcr,
   getBatchContactsCsv,
   getBatchLedgerRowsCsv,
   getAutogiroConsent,
@@ -174,30 +175,34 @@ describe('Rental Invoice Service', () => {
 
   describe('getInvoiceDetails', () => {
     const mockXledgerInvoice = {
-      invoiceId: 'test-invoice-id',
-      invoiceNumber: '55123456',
-      customerCode: 'P999999',
-      amount: 1000,
-      invoiceRows: [],
+      invoice: {
+        invoiceId: 'test-invoice-id',
+        invoiceNumber: '55123456',
+        customerCode: 'P999999',
+        amount: 1000,
+        invoiceRows: [],
+      },
     }
 
     const mockTenfastInvoiceResult = {
       ok: true,
       data: {
-        invoiceRows: [
-          {
-            rentArticle: 'HYRAB',
-            amount: 999.57,
-            vat: 0,
-            invoiceRowText: null,
-          },
-          {
-            rentArticle: 'PARK',
-            amount: 50,
-            vat: 0,
-            invoiceRowText: null,
-          },
-        ],
+        invoice: {
+          invoiceRows: [
+            {
+              rentArticle: 'HYRAB',
+              amount: 999.57,
+              vat: 0,
+              invoiceRowText: null,
+            },
+            {
+              rentArticle: 'PARK',
+              amount: 50,
+              vat: 0,
+              invoiceRowText: null,
+            },
+          ],
+        },
       },
     }
 
@@ -233,7 +238,7 @@ describe('Rental Invoice Service', () => {
       expect(getInvoiceArticle).toHaveBeenCalledWith('PARK')
 
       expect(result).toEqual({
-        ...mockXledgerInvoice,
+        ...mockXledgerInvoice.invoice,
         invoiceRows: [
           {
             rentArticle: 'HYRAB',
@@ -286,27 +291,29 @@ describe('Rental Invoice Service', () => {
       expect(getInvoiceByInvoiceNumber).toHaveBeenCalledWith('55123456')
       expect(getInvoiceByOcr).toHaveBeenCalledWith('test-invoice-id')
       expect(getInvoiceArticle).not.toHaveBeenCalled()
-      expect(result).toEqual(mockXledgerInvoice)
+      expect(result).toEqual(mockXledgerInvoice.invoice)
     })
 
     it('should handle invoice rows without rent articles', async () => {
       const mockTenfastResultWithoutArticles = {
         ok: true,
         data: {
-          invoiceRows: [
-            {
-              rentArticle: null,
-              amount: 50,
-              vat: 0,
-              invoiceRowText: null,
-            },
-            {
-              rentArticle: 'HYRAB',
-              amount: 999.57,
-              vat: 0,
-              invoiceRowText: null,
-            },
-          ],
+          invoice: {
+            invoiceRows: [
+              {
+                rentArticle: null,
+                amount: 50,
+                vat: 0,
+                invoiceRowText: null,
+              },
+              {
+                rentArticle: 'HYRAB',
+                amount: 999.57,
+                vat: 0,
+                invoiceRowText: null,
+              },
+            ],
+          },
         },
       }
 
@@ -323,7 +330,7 @@ describe('Rental Invoice Service', () => {
       expect(mockGetInvoiceArticle).toHaveBeenCalledWith('HYRAB')
 
       expect(result).toEqual({
-        ...mockXledgerInvoice,
+        ...mockXledgerInvoice.invoice,
         invoiceRows: [
           {
             rentArticle: null,
@@ -353,7 +360,7 @@ describe('Rental Invoice Service', () => {
       expect(getInvoiceArticle).toHaveBeenCalledTimes(2)
 
       expect(result).toEqual({
-        ...mockXledgerInvoice,
+        ...mockXledgerInvoice.invoice,
         invoiceRows: [
           {
             rentArticle: 'HYRAB',
@@ -375,20 +382,22 @@ describe('Rental Invoice Service', () => {
       const mockTenfastResultWithDuplicates = {
         ok: true,
         data: {
-          invoiceRows: [
-            {
-              rentArticle: 'HYRAB',
-              amount: 500,
-              vat: 0,
-              invoiceRowText: null,
-            },
-            {
-              rentArticle: 'HYRAB',
-              amount: 499.57,
-              vat: 0,
-              invoiceRowText: null,
-            },
-          ],
+          invoice: {
+            invoiceRows: [
+              {
+                rentArticle: 'HYRAB',
+                amount: 500,
+                vat: 0,
+                invoiceRowText: null,
+              },
+              {
+                rentArticle: 'HYRAB',
+                amount: 499.57,
+                vat: 0,
+                invoiceRowText: null,
+              },
+            ],
+          },
         },
       }
 
@@ -405,7 +414,7 @@ describe('Rental Invoice Service', () => {
       expect(mockGetInvoiceArticle).toHaveBeenCalledWith('HYRAB')
 
       expect(result).toEqual({
-        ...mockXledgerInvoice,
+        ...mockXledgerInvoice.invoice,
         invoiceRows: [
           {
             rentArticle: 'HYRAB',
@@ -420,6 +429,71 @@ describe('Rental Invoice Service', () => {
             invoiceRowText: 'Hyra bostad',
           },
         ],
+      })
+    })
+  })
+
+  describe('getPublicInvoiceByOcr', () => {
+    beforeEach(() => {
+      mockGetInvoiceByInvoiceNumber.mockReset()
+      mockGetInvoiceByOcr.mockReset()
+    })
+
+    it('returns a public invoice with deferral when xledger has deferment', async () => {
+      mockGetInvoiceByOcr.mockResolvedValue({
+        ok: true,
+        data: {
+          invoice: { invoiceId: '55123456', invoiceRows: [] },
+          tenfastDeferral: {
+            reason: 'Betalningsplan',
+            madeBy: 'admin@mimer.nu',
+          },
+        },
+      })
+      mockGetInvoiceByInvoiceNumber.mockResolvedValue({
+        invoice: { invoiceId: '55123456', invoiceRows: [] },
+        defermentEndDate: new Date('2026-07-15'),
+      })
+
+      const result = await getPublicInvoiceByOcr('55123456')
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          invoiceId: '55123456',
+          invoiceRows: [],
+          deferral: {
+            endDate: new Date('2026-07-15'),
+            reason: 'Betalningsplan',
+            madeBy: 'admin@mimer.nu',
+          },
+        },
+      })
+    })
+
+    it('returns invoice without deferral when xledger has no deferment', async () => {
+      mockGetInvoiceByOcr.mockResolvedValue({
+        ok: true,
+        data: {
+          invoice: { invoiceId: '55123456', invoiceRows: [] },
+          tenfastDeferral: {
+            reason: 'Betalningsplan',
+            madeBy: 'admin@mimer.nu',
+          },
+        },
+      })
+      mockGetInvoiceByInvoiceNumber.mockResolvedValue({
+        invoice: { invoiceId: '55123456', invoiceRows: [] },
+      })
+
+      const result = await getPublicInvoiceByOcr('55123456')
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          invoiceId: '55123456',
+          invoiceRows: [],
+        },
       })
     })
   })


### PR DESCRIPTION
- Add deferral property to Onecore invoice.
  Deferral data on invoice comes from both tenfast and xledger. Each of them can't by itself return the full object so instead we merge it in the service, using data from both sources. This means tenfast and xledger can't return full Invoice type any longer. So I introduced new partial types for them.
- Show Anstånd in invoice table col if deferral
- Show who made deferral on invoice details