### PR TITLE
Feature/mim 1824 mojlighet att soka pa namnreferens for strofaktura

### DIFF
--- a/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
+++ b/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
@@ -8,7 +8,7 @@ import {
 import { useMutation } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { sv } from 'date-fns/locale'
-import { CalendarIcon } from 'lucide-react'
+import { CalendarIcon, Check, ChevronsUpDown } from 'lucide-react'
 
 import { useLeasesByContactCode } from '@/entities/lease'
 import { useRentalProperties } from '@/entities/rental-property'
@@ -23,15 +23,16 @@ import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/Button'
 import { Calendar } from '@/shared/ui/Calendar'
 import { Card } from '@/shared/ui/Card'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/shared/ui/Command'
 import { Label } from '@/shared/ui/Label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/Popover'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/shared/ui/Select'
 import { Separator } from '@/shared/ui/Separator'
 
 import { getArticleById } from '@/data/articles/miscellaneousInvoiceArticles'
@@ -83,6 +84,7 @@ export function MiscellaneousInvoiceForm() {
   const { data: projects, isLoading: isLoadingProjects } = useXledgerProjects()
 
   const [reference, setReference] = useState<XledgerContact | null>(null)
+  const [referenceOpen, setReferenceOpen] = useState(false)
 
   useEffect(() => {
     if (userState.tag === 'success' && contacts) {
@@ -126,13 +128,6 @@ export function MiscellaneousInvoiceForm() {
   const [comment, setComment] = useState('')
   const [administrativeCosts, setAdministrativeCosts] = useState(false)
   const [attachedFile, setAttachedFile] = useState<File | null>(null)
-
-  const handleSelectContact = (dbId: string) => {
-    const selectedContact = contacts?.find((c) => c.dbId === dbId)
-    if (selectedContact) {
-      setReference(selectedContact)
-    }
-  }
 
   const handleSelectTenant = (tenant: TenantSearchResult | null) => {
     setSelectedTenant(tenant)
@@ -306,23 +301,60 @@ export function MiscellaneousInvoiceForm() {
               {isLoadingContacts ? (
                 <div>Laddar kontakter...</div>
               ) : (
-                <Select
-                  value={reference?.dbId}
-                  onValueChange={(dbId) => handleSelectContact(dbId)}
-                >
-                  <SelectTrigger id="contact">
-                    <SelectValue placeholder="Välj referens" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {contacts
-                      ?.sort((a, b) => a.fullName.localeCompare(b.fullName))
-                      .map((contact) => (
-                        <SelectItem key={contact.dbId} value={contact.dbId}>
-                          {contact.fullName}
-                        </SelectItem>
-                      ))}
-                  </SelectContent>
-                </Select>
+                <Popover open={referenceOpen} onOpenChange={setReferenceOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="contact"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={referenceOpen}
+                      className={cn(
+                        'w-full justify-between font-normal',
+                        !reference && 'text-muted-foreground'
+                      )}
+                    >
+                      {reference?.fullName ?? 'Välj referens'}
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[--radix-popover-trigger-width] p-0"
+                    align="start"
+                  >
+                    <Command>
+                      <CommandInput placeholder="Sök referens..." />
+                      <CommandList>
+                        <CommandEmpty>Inga resultat</CommandEmpty>
+                        <CommandGroup>
+                          {[...(contacts ?? [])]
+                            .sort((a, b) =>
+                              a.fullName.localeCompare(b.fullName)
+                            )
+                            .map((contact) => (
+                              <CommandItem
+                                key={contact.dbId}
+                                value={contact.fullName}
+                                onSelect={() => {
+                                  setReference(contact)
+                                  setReferenceOpen(false)
+                                }}
+                              >
+                                <Check
+                                  className={cn(
+                                    'mr-2 h-4 w-4',
+                                    reference?.dbId === contact.dbId
+                                      ? 'opacity-100'
+                                      : 'opacity-0'
+                                  )}
+                                />
+                                {contact.fullName}
+                              </CommandItem>
+                            ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
               )}
               {errors.reference && (
                 <span className={cn('text-destructive')}>

--- a/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
+++ b/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
@@ -8,7 +8,7 @@ import {
 import { useMutation } from '@tanstack/react-query'
 import { format } from 'date-fns'
 import { sv } from 'date-fns/locale'
-import { CalendarIcon, Check, ChevronsUpDown } from 'lucide-react'
+import { CalendarIcon } from 'lucide-react'
 
 import { useLeasesByContactCode } from '@/entities/lease'
 import { useRentalProperties } from '@/entities/rental-property'
@@ -23,16 +23,9 @@ import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/Button'
 import { Calendar } from '@/shared/ui/Calendar'
 import { Card } from '@/shared/ui/Card'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/shared/ui/Command'
 import { Label } from '@/shared/ui/Label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/Popover'
+import { SearchableSelect } from '@/shared/ui/SearchableSelect'
 import { Separator } from '@/shared/ui/Separator'
 
 import { getArticleById } from '@/data/articles/miscellaneousInvoiceArticles'
@@ -84,7 +77,6 @@ export function MiscellaneousInvoiceForm() {
   const { data: projects, isLoading: isLoadingProjects } = useXledgerProjects()
 
   const [reference, setReference] = useState<XledgerContact | null>(null)
-  const [referenceOpen, setReferenceOpen] = useState(false)
 
   useEffect(() => {
     if (userState.tag === 'success' && contacts) {
@@ -301,60 +293,18 @@ export function MiscellaneousInvoiceForm() {
               {isLoadingContacts ? (
                 <div>Laddar kontakter...</div>
               ) : (
-                <Popover open={referenceOpen} onOpenChange={setReferenceOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      id="contact"
-                      variant="outline"
-                      role="combobox"
-                      aria-expanded={referenceOpen}
-                      className={cn(
-                        'w-full justify-between font-normal',
-                        !reference && 'text-muted-foreground'
-                      )}
-                    >
-                      {reference?.fullName ?? 'Välj referens'}
-                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent
-                    className="w-[--radix-popover-trigger-width] p-0"
-                    align="start"
-                  >
-                    <Command>
-                      <CommandInput placeholder="Sök referens..." />
-                      <CommandList>
-                        <CommandEmpty>Inga resultat</CommandEmpty>
-                        <CommandGroup>
-                          {[...(contacts ?? [])]
-                            .sort((a, b) =>
-                              a.fullName.localeCompare(b.fullName)
-                            )
-                            .map((contact) => (
-                              <CommandItem
-                                key={contact.dbId}
-                                value={contact.fullName}
-                                onSelect={() => {
-                                  setReference(contact)
-                                  setReferenceOpen(false)
-                                }}
-                              >
-                                <Check
-                                  className={cn(
-                                    'mr-2 h-4 w-4',
-                                    reference?.dbId === contact.dbId
-                                      ? 'opacity-100'
-                                      : 'opacity-0'
-                                  )}
-                                />
-                                {contact.fullName}
-                              </CommandItem>
-                            ))}
-                        </CommandGroup>
-                      </CommandList>
-                    </Command>
-                  </PopoverContent>
-                </Popover>
+                <SearchableSelect
+                  id="contact"
+                  items={[...(contacts ?? [])].sort((a, b) =>
+                    a.fullName.localeCompare(b.fullName)
+                  )}
+                  value={reference}
+                  onChange={setReference}
+                  getKey={(contact) => contact.dbId}
+                  getLabel={(contact) => contact.fullName}
+                  placeholder="Välj referens"
+                  searchPlaceholder="Sök referens..."
+                />
               )}
               {errors.reference && (
                 <span className={cn('text-destructive')}>

--- a/apps/property-tree/src/features/property-areas/ui/admin/StewardAssignmentDialog.tsx
+++ b/apps/property-tree/src/features/property-areas/ui/admin/StewardAssignmentDialog.tsx
@@ -1,16 +1,6 @@
 import { useState } from 'react'
-import { Check, ChevronsUpDown } from 'lucide-react'
 
-import { cn } from '@/shared/lib/utils'
 import { Button } from '@/shared/ui/Button'
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/shared/ui/Command'
 import {
   Dialog,
   DialogContent,
@@ -19,7 +9,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/ui/Dialog'
-import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/Popover'
+import { SearchableSelect } from '@/shared/ui/SearchableSelect'
 
 interface Steward {
   id: string
@@ -45,19 +35,15 @@ export function StewardAssignmentDialog({
   allStewards,
   onAssign,
 }: StewardAssignmentDialogProps) {
-  const [selectedSteward, setSelectedSteward] = useState<string>(
-    currentSteward.id
-  )
-  const [popoverOpen, setPopoverOpen] = useState(false)
+  const [selectedSteward, setSelectedSteward] =
+    useState<Steward>(currentSteward)
 
   const handleSave = () => {
-    if (selectedSteward !== currentSteward.id) {
-      onAssign(selectedSteward)
+    if (selectedSteward.id !== currentSteward.id) {
+      onAssign(selectedSteward.id)
     }
     onOpenChange(false)
   }
-
-  const selectedStewardData = allStewards.find((s) => s.id === selectedSteward)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -73,69 +59,36 @@ export function StewardAssignmentDialog({
 
         <div className="py-4">
           <label className="text-sm font-medium mb-2 block">Kvartersvärd</label>
-          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="outline"
-                role="combobox"
-                aria-expanded={popoverOpen}
-                className="w-full justify-between"
-              >
-                {selectedStewardData ? (
-                  <span>
-                    {selectedStewardData.name}
-                    {selectedStewardData.employeeId
-                      ? ` (${selectedStewardData.employeeId})`
-                      : ''}
-                  </span>
-                ) : (
-                  <span className="text-muted-foreground">
-                    Välj kvartersvärd...
+          <SearchableSelect
+            items={allStewards}
+            value={selectedSteward}
+            onChange={setSelectedSteward}
+            getKey={(steward) => steward.id}
+            getLabel={(steward) =>
+              steward.employeeId
+                ? `${steward.name} (${steward.employeeId})`
+                : steward.name
+            }
+            getSearchValue={(steward) =>
+              `${steward.name} ${steward.employeeId ?? ''}`
+            }
+            placeholder="Välj kvartersvärd..."
+            searchPlaceholder="Sök kvartersvärd..."
+            emptyText="Ingen kvartersvärd hittades."
+            contentClassName="z-50"
+            renderItem={(steward) => (
+              <div className="flex flex-col">
+                <span>{steward.name}</span>
+                {(steward.employeeId || steward.phone) && (
+                  <span className="opacity-70 text-xs">
+                    {steward.employeeId}
+                    {steward.employeeId && steward.phone && ' • '}
+                    {steward.phone}
                   </span>
                 )}
-                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-[380px] p-0 z-50" align="start">
-              <Command>
-                <CommandInput placeholder="Sök kvartersvärd..." />
-                <CommandList>
-                  <CommandEmpty>Ingen kvartersvärd hittades.</CommandEmpty>
-                  <CommandGroup>
-                    {allStewards.map((steward) => (
-                      <CommandItem
-                        key={steward.id}
-                        value={`${steward.name} ${steward.employeeId ?? ''}`}
-                        onSelect={() => {
-                          setSelectedSteward(steward.id)
-                          setPopoverOpen(false)
-                        }}
-                      >
-                        <Check
-                          className={cn(
-                            'mr-2 h-4 w-4',
-                            selectedSteward === steward.id
-                              ? 'opacity-100'
-                              : 'opacity-0'
-                          )}
-                        />
-                        <div className="flex flex-col">
-                          <span>{steward.name}</span>
-                          {(steward.employeeId || steward.phone) && (
-                            <span className="opacity-70 text-xs">
-                              {steward.employeeId}
-                              {steward.employeeId && steward.phone && ' • '}
-                              {steward.phone}
-                            </span>
-                          )}
-                        </div>
-                      </CommandItem>
-                    ))}
-                  </CommandGroup>
-                </CommandList>
-              </Command>
-            </PopoverContent>
-          </Popover>
+              </div>
+            )}
+          />
         </div>
 
         <DialogFooter>
@@ -144,7 +97,7 @@ export function StewardAssignmentDialog({
           </Button>
           <Button
             onClick={handleSave}
-            disabled={selectedSteward === currentSteward.id}
+            disabled={selectedSteward.id === currentSteward.id}
           >
             Spara
           </Button>

--- a/apps/property-tree/src/shared/ui/SearchableSelect.tsx
+++ b/apps/property-tree/src/shared/ui/SearchableSelect.tsx
@@ -1,0 +1,129 @@
+import { useState } from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+
+import { cn } from '@/shared/lib/utils'
+import { Button } from '@/shared/ui/Button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/shared/ui/Command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/shared/ui/Popover'
+
+interface SearchableSelectProps<T> {
+  /** The options to choose from. */
+  items: T[]
+  /** Currently selected item, or null when nothing is selected. */
+  value: T | null
+  /** Called with the chosen item when the user picks one. */
+  onChange: (item: T) => void
+  /** Stable key per item — used for React keys and selection comparison. */
+  getKey: (item: T) => string
+  /** Plain-text label, used for the trigger and as the default search text. */
+  getLabel: (item: T) => string
+  /** Custom rendering of a list row. Defaults to {@link getLabel}. */
+  renderItem?: (item: T) => React.ReactNode
+  /** Custom rendering of the selected value in the trigger. Defaults to {@link getLabel}. */
+  renderValue?: (item: T) => React.ReactNode
+  /** Text cmdk filters against. Defaults to {@link getLabel}. */
+  getSearchValue?: (item: T) => string
+  /** Trigger text shown when nothing is selected. */
+  placeholder?: string
+  searchPlaceholder?: string
+  emptyText?: string
+  disabled?: boolean
+  /** Forwarded to the trigger button (e.g. to associate a <Label htmlFor>). */
+  id?: string
+  /** Extra classes for the trigger button. */
+  className?: string
+  /** Extra classes for the popover content (e.g. a fixed width). */
+  contentClassName?: string
+}
+
+/**
+ * Single-select dropdown with type-to-filter search (shadcn "Combobox" pattern:
+ * a Popover trigger with a cmdk Command list inside). Generic over the item type.
+ */
+export function SearchableSelect<T>({
+  items,
+  value,
+  onChange,
+  getKey,
+  getLabel,
+  renderItem,
+  renderValue,
+  getSearchValue,
+  placeholder = 'Välj...',
+  searchPlaceholder = 'Sök...',
+  emptyText = 'Inga resultat',
+  disabled,
+  id,
+  className,
+  contentClassName,
+}: SearchableSelectProps<T>) {
+  const [open, setOpen] = useState(false)
+  const selectedKey = value ? getKey(value) : null
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn(
+            'w-full justify-between font-normal',
+            !value && 'text-muted-foreground',
+            className
+          )}
+        >
+          {value ? (renderValue ?? renderItem ?? getLabel)(value) : placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className={cn(
+          'w-[--radix-popover-trigger-width] p-0',
+          contentClassName
+        )}
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {items.map((item) => {
+                const key = getKey(item)
+                return (
+                  <CommandItem
+                    key={key}
+                    value={(getSearchValue ?? getLabel)(item)}
+                    onSelect={() => {
+                      onChange(item)
+                      setOpen(false)
+                    }}
+                  >
+                    <Check
+                      className={cn(
+                        'mr-2 h-4 w-4 shrink-0',
+                        selectedKey === key ? 'opacity-100' : 'opacity-0'
+                      )}
+                    />
+                    {(renderItem ?? getLabel)(item)}
+                  </CommandItem>
+                )
+              })}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/apps/property-tree/src/shared/ui/SearchableSelect.tsx
+++ b/apps/property-tree/src/shared/ui/SearchableSelect.tsx
@@ -67,6 +67,10 @@ export function SearchableSelect<T>({
   const [open, setOpen] = useState(false)
   const selectedKey = value ? getKey(value) : null
 
+  // Resolve which render function to use, falling back to sensible defaults.
+  const renderTriggerValue = renderValue ?? renderItem ?? getLabel
+  const renderRow = renderItem ?? getLabel
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -83,7 +87,7 @@ export function SearchableSelect<T>({
             className
           )}
         >
-          {value ? (renderValue ?? renderItem ?? getLabel)(value) : placeholder}
+          {value ? renderTriggerValue(value) : placeholder}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -116,7 +120,7 @@ export function SearchableSelect<T>({
                         selectedKey === key ? 'opacity-100' : 'opacity-0'
                       )}
                     />
-                    {(renderItem ?? getLabel)(item)}
+                    {renderRow(item)}
                   </CommandItem>
                 )
               })}


### PR DESCRIPTION
## Summary

Makes the **Referens** field on the ströfaktura form a searchable single-select
(type-to-filter by name) instead of a plain dropdown - [MIM-1824](https://linear.app/mimer-onecore/issue/MIM-1824).

## Changes
- Referens `<Select>` → searchable combobox (auto-preselect, validation, payload unchanged).
- Fixed `.sort()` mutating the React Query cache in place.
- Extracted the shared combobox into `SearchableSelect<T>` in `shared/ui/`; migrated the
  ströfaktura field + steward-assignment dialog onto it.