### PR TITLE
Feature/mim 1734 sortera soksvar i ordning

### DIFF
--- a/services/property/src/adapters/building-adapter.ts
+++ b/services/property/src/adapters/building-adapter.ts
@@ -189,6 +189,7 @@ const searchBuildings = async (
             },
           },
         },
+        orderBy: { buildingCode: 'asc' },
         take: 10,
       })
       .then(trimStrings)

--- a/services/property/src/adapters/facility-adapter.ts
+++ b/services/property/src/adapters/facility-adapter.ts
@@ -45,6 +45,7 @@ export async function searchFacilities(q: string, searchFields: string[]) {
           },
         })),
       },
+      orderBy: { rentalId: 'asc' },
       take: 10,
     })
     .then(trimStrings)

--- a/services/property/src/adapters/maintenance-units-adapter.ts
+++ b/services/property/src/adapters/maintenance-units-adapter.ts
@@ -175,6 +175,7 @@ export const searchMaintenanceUnits = async (
       code: { contains: q },
     },
     select: maintenanceUnitWithPropertySelect,
+    orderBy: { code: 'asc' },
     take: 10,
   })
 

--- a/services/property/src/adapters/parking-spaces-adapter.ts
+++ b/services/property/src/adapters/parking-spaces-adapter.ts
@@ -41,6 +41,7 @@ export async function searchParkingSpaces(q: string, searchFields: string[]) {
           },
         })),
       },
+      orderBy: { rentalId: 'asc' },
     })
     .then(trimStrings)
 

--- a/services/property/src/adapters/property-adapter.ts
+++ b/services/property/src/adapters/property-adapter.ts
@@ -158,6 +158,7 @@ const searchProperties = (
         where: {
           designation: { contains: q },
         },
+        orderBy: { code: 'asc' },
       })
       .then(trimStrings)
   } catch (err) {

--- a/services/property/src/adapters/staircase-adapter.ts
+++ b/services/property/src/adapters/staircase-adapter.ts
@@ -166,6 +166,7 @@ async function searchStaircases(q: string): Promise<Staircase[]> {
             },
           },
         },
+        orderBy: { code: 'asc' },
         take: 10,
       })
       .then(trimStrings)

--- a/services/property/src/routes/residences.ts
+++ b/services/property/src/routes/residences.ts
@@ -301,12 +301,13 @@ export const routes = (router: KoaRouter) => {
         )
 
         // rentalId comes from a nested to-many relation, so it can't be ordered
-        // in the Prisma query — sort the mapped results by object number here.
-        // Numeric collation keeps "…0010" after "…0002".
+        // in the Prisma query like the other search endpoints — sort the mapped
+        // results here instead. Object numbers are zero-padded fixed-width
+        // (e.g. "807-033-03-0302"), so a plain lexicographic sort yields numeric
+        // order and stays consistent with the DB-side `orderBy` used by the
+        // other search endpoints (and with keys-portal's sortByRentalId).
         content.sort((a, b) =>
-          (a.rentalId ?? '').localeCompare(b.rentalId ?? '', 'sv', {
-            numeric: true,
-          })
+          (a.rentalId ?? '').localeCompare(b.rentalId ?? '', 'sv')
         )
 
         ctx.status = 200

--- a/services/property/src/routes/residences.ts
+++ b/services/property/src/routes/residences.ts
@@ -281,26 +281,37 @@ export const routes = (router: KoaRouter) => {
         // Search for residences by rental id and name
         const residences = await searchResidences(q, ['rentalId', 'name'])
 
+        const content = residences.map(
+          (r): ResidenceSearchResult => ({
+            id: r.id,
+            code: r.code,
+            name: r.name || '',
+            deleted: Boolean(r.deleted),
+            validityPeriod: { fromDate: r.fromDate, toDate: r.toDate },
+            rentalId: r.propertyObject.propertyStructures[0].rentalId,
+            property: {
+              code: r.propertyObject.propertyStructures[0].propertyCode,
+              name: r.propertyObject.propertyStructures[0].propertyName,
+            },
+            building: {
+              code: r.propertyObject.propertyStructures[0].buildingCode,
+              name: r.propertyObject.propertyStructures[0].buildingName,
+            },
+          })
+        )
+
+        // rentalId comes from a nested to-many relation, so it can't be ordered
+        // in the Prisma query — sort the mapped results by object number here.
+        // Numeric collation keeps "…0010" after "…0002".
+        content.sort((a, b) =>
+          (a.rentalId ?? '').localeCompare(b.rentalId ?? '', 'sv', {
+            numeric: true,
+          })
+        )
+
         ctx.status = 200
         ctx.body = {
-          content: residences.map(
-            (r): ResidenceSearchResult => ({
-              id: r.id,
-              code: r.code,
-              name: r.name || '',
-              deleted: Boolean(r.deleted),
-              validityPeriod: { fromDate: r.fromDate, toDate: r.toDate },
-              rentalId: r.propertyObject.propertyStructures[0].rentalId,
-              property: {
-                code: r.propertyObject.propertyStructures[0].propertyCode,
-                name: r.propertyObject.propertyStructures[0].propertyName,
-              },
-              building: {
-                code: r.propertyObject.propertyStructures[0].buildingCode,
-                name: r.propertyObject.propertyStructures[0].buildingName,
-              },
-            })
-          ),
+          content,
           ...metadata,
         }
       } catch (err) {


### PR DESCRIPTION
## Sort search results by object number (MIM-1734)

Search results were returned in arbitrary order, making objects hard to find. This sorts all search endpoints by object number ascending.

### Changes
- **6 search adapters** (buildings, facilities, maintenance units, parking spaces, properties, staircases) — added DB-side `orderBy ... 'asc'`.
- **Residence search** — sorted in-memory by `rentalId`, since it comes from a nested to-many relation that Prisma can't order directly.

Object numbers are zero-padded fixed-width, so a plain lexicographic sort yields correct numeric order, consistent across all seven endpoints.

Closes MIM-1734
