### PR TITLE
Feat: AVTAL-155 Get Sublet For Leases From Tenfast And Add To OneCore…

### DIFF
--- a/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
+++ b/apps/property-tree/src/features/leases/ui/LeaseColumns.tsx
@@ -39,12 +39,19 @@ export const leaseColumns = [
         <div className="space-y-1">
           {lease.contacts.map((contact) => (
             <div key={contact.contactCode}>
-              <Link
-                to={paths.tenant(contact.contactCode)}
-                className="font-medium text-primary hover:underline"
-              >
-                {contact.name}
-              </Link>
+              <div className="flex items-center gap-1.5">
+                <Link
+                  to={paths.tenant(contact.contactCode)}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {contact.name}
+                </Link>
+                {contact.contactType === 'subletTenant' && (
+                  <span className="rounded bg-muted px-1 py-0.5 text-xs text-muted-foreground">
+                    Andrahand
+                  </span>
+                )}
+              </div>
               <div className="text-sm text-muted-foreground">
                 {contact.contactCode}
               </div>

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -10429,6 +10429,8 @@ export interface components {
           contactCode: string;
           email: string | null;
           phone: string | null;
+          /** @enum {string} */
+          contactType?: "tenant" | "subletTenant";
         })[];
       address: string | null;
       postalCode: string | null;
@@ -10453,6 +10455,8 @@ export interface components {
       contactCode: string;
       email: string | null;
       phone: string | null;
+      /** @enum {string} */
+      contactType?: "tenant" | "subletTenant";
     };
     PaginationMeta: {
       totalRecords: number;
@@ -13895,10 +13899,6 @@ export interface components {
         firstName: string | null;
         lastName: string | null;
         fullName: string;
-      };
-      trustee?: {
-        contactCode: string;
-        fullName?: string;
       };
     }) | ({
       contactCode: string;

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -10287,6 +10287,7 @@ export interface components {
       /** @enum {string} */
       status: "Current" | "Upcoming" | "AboutToEnd" | "Ended" | "PreliminaryTerminated" | "PendingSignature" | "NotSent";
       tenantContactIds?: string[];
+      subletContactId?: string;
       rentalPropertyId: string;
       rentalObject?: {
         rentalObjectCode: string;
@@ -12719,6 +12720,7 @@ export interface components {
         /** @enum {string} */
         status: "Current" | "Upcoming" | "AboutToEnd" | "Ended" | "PreliminaryTerminated" | "PendingSignature" | "NotSent";
         tenantContactIds?: string[];
+        subletContactId?: string;
         rentalPropertyId: string;
         rentalObject?: {
           rentalObjectCode: string;
@@ -13027,6 +13029,7 @@ export interface components {
         /** @enum {string} */
         status: "Current" | "Upcoming" | "AboutToEnd" | "Ended" | "PreliminaryTerminated" | "PendingSignature" | "NotSent";
         tenantContactIds?: string[];
+        subletContactId?: string;
         rentalPropertyId: string;
         rentalObject?: {
           rentalObjectCode: string;
@@ -13445,6 +13448,7 @@ export interface components {
         /** @enum {string} */
         status: "Current" | "Upcoming" | "AboutToEnd" | "Ended" | "PreliminaryTerminated" | "PendingSignature" | "NotSent";
         tenantContactIds?: string[];
+        subletContactId?: string;
         rentalPropertyId: string;
         rentalObject?: {
           rentalObjectCode: string;

--- a/core/src/services/inspection-service/helpers/tenant-contacts-builder.ts
+++ b/core/src/services/inspection-service/helpers/tenant-contacts-builder.ts
@@ -45,7 +45,7 @@ export const buildTenantContactsResponse = async (
   if (newTenant?.tenants) {
     response.new_tenant = {
       contacts: newTenant.tenants
-        .filter((t) => t.emailAddress)
+        .filter((t) => t.emailAddress && t.leaseContactType !== 'subletTenant')
         .map((t) => ({
           fullName: t.fullName,
           emailAddress: t.emailAddress!,
@@ -58,7 +58,7 @@ export const buildTenantContactsResponse = async (
   if (tenant?.tenants) {
     response.tenant = {
       contacts: tenant.tenants
-        .filter((t) => t.emailAddress)
+        .filter((t) => t.emailAddress && t.leaseContactType !== 'subletTenant')
         .map((t) => ({
           fullName: t.fullName,
           emailAddress: t.emailAddress!,

--- a/core/src/services/lease-service/leases.ts
+++ b/core/src/services/lease-service/leases.ts
@@ -782,19 +782,26 @@ export const routes = (router: KoaRouter) => {
     leases: Lease[]
   ): Promise<AdapterResult<Lease[], 'no-contact' | 'unknown'>> {
     for (const lease of leases) {
-      if (!lease.tenantContactIds) {
-        continue
-      }
+      let contacts: (Contact & { leaseContactType?: string })[] = []
 
-      let contacts: Contact[] = []
-      for (const contactCode of lease.tenantContactIds) {
+      for (const contactCode of lease.tenantContactIds ?? []) {
         const contact =
           await leasingAdapter.getContactByContactCode(contactCode)
         if (!contact.ok || !contact.data) {
           return { ok: false, err: 'no-contact' }
         }
-
         contacts.push(contact.data)
+      }
+
+      if (lease.subletContactId) {
+        const contact = await leasingAdapter.getContactByContactCode(
+          lease.subletContactId
+        )
+        if (!contact.ok || !contact.data) {
+          return { ok: false, err: 'no-contact' }
+        }
+        const leaseContactType: leasing.v1.LeaseContactType = 'subletTenant'
+        contacts.push({ ...contact.data, leaseContactType })
       }
 
       lease.tenants = contacts

--- a/core/src/services/lease-service/schemas/lease.ts
+++ b/core/src/services/lease-service/schemas/lease.ts
@@ -62,6 +62,7 @@ export const Lease = z.object({
     'NotSent',
   ]),
   tenantContactIds: z.array(z.string()).optional(),
+  subletContactId: z.string().optional(),
   rentalPropertyId: z.string(),
   rentalObject: z
     .object({
@@ -241,6 +242,7 @@ export function mapLease(lease: OnecoreTypesLease): z.infer<typeof Lease> {
     leaseEndDate: lease.leaseEndDate,
     status: mapLeaseStatus(lease.status),
     tenantContactIds: lease.tenantContactIds,
+    subletContactId: lease.subletContactId,
     rentalPropertyId: lease.rentalPropertyId,
     rentalObject: lease.rentalObject,
     type: lease.type,

--- a/libs/types/src/leasing/v1/lease-search.ts
+++ b/libs/types/src/leasing/v1/lease-search.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod'
 import { LeaseStatus, LeaseType } from '../../enums'
 
+export const LeaseContactTypeSchema = z.enum(['tenant', 'subletTenant'])
+
+export type LeaseContactType = z.infer<typeof LeaseContactTypeSchema>
+
 /**
  * Contact info schema - reusable for lease contacts
  */
@@ -9,6 +13,7 @@ export const ContactInfoSchema = z.object({
   contactCode: z.string(),
   email: z.string().nullable(),
   phone: z.string().nullable(),
+  contactType: LeaseContactTypeSchema.optional(),
 })
 
 export type ContactInfo = z.infer<typeof ContactInfoSchema>

--- a/libs/types/src/types.ts
+++ b/libs/types/src/types.ts
@@ -82,6 +82,7 @@ interface Lease {
   leaseEndDate: Date | undefined
   status: LeaseStatus
   tenantContactIds: string[] | undefined
+  subletContactId?: string
   tenants: (Contact & { leaseContactType?: string })[] | undefined //SHould really be renamed contacts if it should sitll include second hand tenants and incvopice recipients
   rentalPropertyId: string
   rentalObject?: RentalObject

--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -107,7 +107,7 @@ export const TenfastTagSchema = z.object({
 export type TenfastTag = z.infer<typeof TenfastTagSchema>
 export type TenfastRentalObject = z.infer<typeof TenfastRentalObjectSchema>
 
-export const TenfastAndraHandHGSchema = z.object({
+export const TenfastSubletTenantSchema = z.object({
   startDate: z.coerce.date().optional().nullable(),
   endDate: z.coerce.date().optional().nullable(),
   externalId: z.string().optional().nullable(),
@@ -118,7 +118,7 @@ export const TenfastAndraHandHGSchema = z.object({
   reason: z.string().nullable().optional(),
 })
 
-export type TenfastAndraHandHG = z.infer<typeof TenfastAndraHandHGSchema>
+export type TenfastSubletTenant = z.infer<typeof TenfastSubletTenantSchema>
 
 // TODO byt namn
 export const TenfastContractSchema = z.object({
@@ -282,7 +282,7 @@ export const TenfastLeaseSchema = z.object({
       originalName: z.string(),
     })
   ),
-  andraHandHG: TenfastAndraHandHGSchema.optional().nullable(),
+  andraHandHG: TenfastSubletTenantSchema.optional().nullable(),
   versions: z.unknown().optional(),
   createdAt: optionalDateField,
   updatedAt: optionalDateField,

--- a/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/schemas.ts
@@ -107,6 +107,19 @@ export const TenfastTagSchema = z.object({
 export type TenfastTag = z.infer<typeof TenfastTagSchema>
 export type TenfastRentalObject = z.infer<typeof TenfastRentalObjectSchema>
 
+export const TenfastAndraHandHGSchema = z.object({
+  startDate: z.coerce.date().optional().nullable(),
+  endDate: z.coerce.date().optional().nullable(),
+  externalId: z.string().optional().nullable(),
+  name: z.string().nullable().optional(),
+  email: z.string().nullable().optional(),
+  phone: z.string().nullable().optional(),
+  idbeteckning: z.string().nullable().optional(),
+  reason: z.string().nullable().optional(),
+})
+
+export type TenfastAndraHandHG = z.infer<typeof TenfastAndraHandHGSchema>
+
 // TODO byt namn
 export const TenfastContractSchema = z.object({
   _id: z.string(),
@@ -269,6 +282,7 @@ export const TenfastLeaseSchema = z.object({
       originalName: z.string(),
     })
   ),
+  andraHandHG: TenfastAndraHandHGSchema.optional().nullable(),
   versions: z.unknown().optional(),
   createdAt: optionalDateField,
   updatedAt: optionalDateField,

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-lease-search-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-lease-search-adapter.ts
@@ -70,6 +70,12 @@ interface BatchGetLease {
   }>
   tenants: BatchGetTenant[]
   rentalObjects: BatchGetRentalObject[]
+  subletTenant?: {
+    externalId: string
+    name?: string
+    email?: string
+    phone?: string
+  }
 }
 
 /** Raw shapes from Tenfast batch-get response (before transformation) */
@@ -89,6 +95,13 @@ interface RawBatchGetAvtal {
   hyror?: Partial<BatchGetLease['hyror'][number]>[]
   hyresgaster?: Partial<BatchGetTenant>[]
   originalData?: { hyresgaster?: Partial<BatchGetTenant>[] }
+  andraHandHG?: {
+    externalId?: string
+    name?: string
+    email?: string
+    phone?: string
+    idbeteckning?: string
+  }
 }
 
 interface RawBatchGetRentalObject extends Partial<BatchGetRentalObject> {
@@ -147,6 +160,14 @@ function parseBatchGetResponse(
           name: t.name,
           idbeteckning: t.idbeteckning ?? '',
         })),
+        subletTenant: raw.andraHandHG?.externalId
+          ? {
+              externalId: raw.andraHandHG.externalId,
+              name: raw.andraHandHG.name,
+              email: raw.andraHandHG.email,
+              phone: raw.andraHandHG.phone,
+            }
+          : undefined,
         rentalObjects: [
           {
             externalId: ro.externalId ?? '',
@@ -301,9 +322,16 @@ function mapBatchGetLeaseToSearchResult(
     phone: null,
     contactType: 'tenant' as const,
   }))
-  // TODO: andraHandHG is not included in the batch-get API response — sublet contacts
-  // are silently absent for leases fetched via this path (buildingCodes/areaCodes/districtNames
-  // filters). Fix requires either enriching the batch-get endpoint or switching to single-fetch.
+
+  if (lease.subletTenant?.externalId) {
+    contacts.push({
+      name: lease.subletTenant.name ?? lease.subletTenant.externalId,
+      contactCode: lease.subletTenant.externalId,
+      email: lease.subletTenant.email ?? null,
+      phone: lease.subletTenant.phone ?? null,
+      contactType: 'subletTenant' as const,
+    })
+  }
 
   return {
     leaseId: lease.externalId,

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-lease-search-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-lease-search-adapter.ts
@@ -248,7 +248,18 @@ function mapTenfastLeaseToSearchResult(
     contactCode: t.externalId,
     email: null,
     phone: null,
+    contactType: 'tenant' as const,
   }))
+
+  if (lease.andraHandHG?.externalId) {
+    contacts.push({
+      name: lease.andraHandHG.name ?? lease.andraHandHG.externalId,
+      contactCode: lease.andraHandHG.externalId,
+      email: lease.andraHandHG.email ?? null,
+      phone: lease.andraHandHG.phone ?? null,
+      contactType: 'subletTenant' as const,
+    })
+  }
 
   return {
     leaseId: lease.externalId,
@@ -288,7 +299,11 @@ function mapBatchGetLeaseToSearchResult(
     contactCode: t.externalId,
     email: null,
     phone: null,
+    contactType: 'tenant' as const,
   }))
+  // TODO: andraHandHG is not included in the batch-get API response — sublet contacts
+  // are silently absent for leases fetched via this path (buildingCodes/areaCodes/districtNames
+  // filters). Fix requires either enriching the batch-get endpoint or switching to single-fetch.
 
   return {
     leaseId: lease.externalId,

--- a/services/leasing/src/services/lease-service/helpers/tenfast.ts
+++ b/services/leasing/src/services/lease-service/helpers/tenfast.ts
@@ -139,6 +139,7 @@ export const mapToOnecoreLease = (lease: TenfastLease): Lease => {
       ? { code: stadsdel, caption: stadsdel }
       : undefined,
     tenantContactIds: lease.hyresgaster.map((tenant) => tenant.externalId),
+    subletContactId: lease.andraHandHG?.externalId ?? undefined,
     tenants: undefined,
     rentalPropertyId: lease.hyresobjekt[0]?.externalId ?? 'missing',
     rentalObject: rentalObject

--- a/services/leasing/src/services/lease-service/routes/leases.ts
+++ b/services/leasing/src/services/lease-service/routes/leases.ts
@@ -223,8 +223,14 @@ export const routes = (router: KoaRouter) => {
         rowMapper: (lease: leasing.v1.LeaseSearchResult) => ({
           leaseId: lease.leaseId,
           rentalObjectCode: lease.rentalObjectCode || '',
-          tenantName: joinField(lease.contacts, (c) => c.name),
-          contactCode: joinField(lease.contacts, (c) => c.contactCode),
+          tenantName: joinField(lease.contacts, (c) =>
+            c.contactType === 'subletTenant' ? `${c.name} (andrahand)` : c.name
+          ),
+          contactCode: joinField(lease.contacts, (c) =>
+            c.contactType === 'subletTenant'
+              ? `${c.contactCode} (andrahand)`
+              : c.contactCode
+          ),
           email: joinField(lease.contacts, (c) => c.email),
           phone: joinField(lease.contacts, (c) => c.phone),
           objectType: lease.parkingSpaceType || lease.objectTypeCode,


### PR DESCRIPTION
… Model

Tenfast returnerar nu andraHandHG på avtal. Tidigare blandades andrahandshyresgästens kontaktkod in i
  tenantContactIds-arrayen utan att det gick att skilja den från primära hyresgäster.

  Ändringarna separerar dem:
  - tenantContactIds innehåller nu enbart primära hyresgäster
  - Det nya fältet subletContactId håller andrahandshyresgästens kontaktkod
  - I söksvar (LeaseSearchResult) är andrahandshyresgästen en kontakt med contactType: 'subletTenant'
  - När kontakter hämtas med includeContacts=true taggas andrahandshyresgästen med leaseContactType: 'subletTenant' i tenants-arrayen
  - Inspektionsprotokoll skickas inte längre till andrahandshyresgäster
  - På avtal i property tree visas nu vilka kontakter som är andrahandshyresgäster

  TenfastAndraHandHGSchema uppdaterades också med de faktiska fältnamnen från Tenfast API:et (name, email, idbeteckning,  reason istället för de tidigare svenska namnen).
