### PR TITLE
mported images locally + rendering in property tree, internal portal …

### DIFF
--- a/apps/property-tree/.env.example
+++ b/apps/property-tree/.env.example
@@ -17,4 +17,5 @@ VITE_PASSAGE_URL=http://srvmimhk21/Alliera/Account/LogOn?ReturnUrl=%2falliera
 VITE_KEYS_URL=http://localhost:3010
 VITE_INTERNAL_PORTAL=https://onecore-test.mimer.nu
 VITE_VIEWINGS=https://apps.mimer.nu/visningsportalen
+VITE_PUBLIC_ASSETS_URL=http://localhost:9000/onecore-public
 

--- a/apps/property-tree/src/shared/lib/floorplan.ts
+++ b/apps/property-tree/src/shared/lib/floorplan.ts
@@ -1,9 +1,18 @@
-// Floorplans (planritningar) for Mimer's residences are served from a public
-// CDN at pub.mimer.nu, keyed by the Xpand rentalId (e.g. "211-001-01-0101").
-// The CDN is open — no auth or core-service proxy is involved — so callers
-// just need to construct the URL and render it as an <img>, handling the
-// onError case when a given rental has no published floorplan.
-const FLOORPLAN_CDN_BASE = 'https://pub.mimer.nu/bofaktablad/bofaktablad'
+// Floorplans (planritningar / bofaktablad) for Mimer's residences are served
+// from the onecore-public MinIO bucket, keyed by the Xpand rentalId
+// (e.g. "211-001-01-0101"). The bucket has an anonymous read policy applied
+// in services/file-storage, so callers just construct the URL and render it
+// as an <img>, handling the onError case when a given rental has no
+// published floorplan.
+//
+// The base URL is environment-driven (window.__ENV → import.meta.env → dev
+// default) so dev, test and prod can each point at their own MinIO endpoint.
+import { resolve } from './env'
+
+const PUBLIC_ASSETS_URL = resolve(
+  'VITE_PUBLIC_ASSETS_URL',
+  'http://localhost:9000/onecore-public'
+)
 
 export const getFloorplanUrl = (rentalId: string): string =>
-  `${FLOORPLAN_CDN_BASE}/${rentalId}.jpg`
+  `${PUBLIC_ASSETS_URL}/bofaktablad/${rentalId}.jpg`

--- a/services/file-storage/.env.template
+++ b/services/file-storage/.env.template
@@ -8,3 +8,4 @@ MINIO__USE_SSL=false
 MINIO__ACCESS_KEY=minio
 MINIO__SECRET_KEY=minio123
 MINIO__BUCKET_NAME=onecore-documents
+MINIO__PUBLIC_BUCKET_NAME=onecore-public

--- a/services/file-storage/src/adapters/minio-adapter.ts
+++ b/services/file-storage/src/adapters/minio-adapter.ts
@@ -48,26 +48,26 @@ export const initializeBucket = async (): Promise<void> => {
 
 /**
  * Ensure the public bucket exists with an anonymous-read policy applied.
- * Policy is re-applied on every startup so dev environments stay consistent
- * even if someone has tweaked it via the MinIO console.
+ * Policy is applied only at bucket-creation time — it persists in MinIO's
+ * bucket metadata across restarts, and re-applying on every startup would
+ * require the runtime credentials to hold s3:PutBucketPolicy, which is a
+ * larger IAM surface than we need.
  */
 export const initializePublicBucket = async (): Promise<void> => {
   try {
     const exists = await minioClient.bucketExists(PUBLIC_BUCKET_NAME)
     if (!exists) {
       await minioClient.makeBucket(PUBLIC_BUCKET_NAME, 'us-east-1')
-      console.log(`MinIO bucket '${PUBLIC_BUCKET_NAME}' created successfully`)
+      await minioClient.setBucketPolicy(
+        PUBLIC_BUCKET_NAME,
+        JSON.stringify(publicReadPolicy(PUBLIC_BUCKET_NAME))
+      )
+      console.log(
+        `MinIO bucket '${PUBLIC_BUCKET_NAME}' created with anonymous read policy`
+      )
     } else {
       console.log(`MinIO bucket '${PUBLIC_BUCKET_NAME}' already exists`)
     }
-
-    await minioClient.setBucketPolicy(
-      PUBLIC_BUCKET_NAME,
-      JSON.stringify(publicReadPolicy(PUBLIC_BUCKET_NAME))
-    )
-    console.log(
-      `MinIO bucket '${PUBLIC_BUCKET_NAME}' anonymous read policy applied`
-    )
   } catch (error) {
     console.error(
       `Failed to ensure public bucket '${PUBLIC_BUCKET_NAME}' exists:`,

--- a/services/file-storage/src/adapters/minio-adapter.ts
+++ b/services/file-storage/src/adapters/minio-adapter.ts
@@ -11,6 +11,22 @@ export const minioClient = new Client({
 })
 
 const BUCKET_NAME = minioConfig.bucketName
+const PUBLIC_BUCKET_NAME = minioConfig.publicBucketName
+
+// Anonymous read policy applied to the public bucket — grants s3:GetObject to
+// any principal so plain <img src=".../<bucket>/<key>"> works without auth.
+// No list, write, or delete permissions are exposed anonymously.
+const publicReadPolicy = (bucketName: string) => ({
+  Version: '2012-10-17',
+  Statement: [
+    {
+      Effect: 'Allow',
+      Principal: { AWS: ['*'] },
+      Action: ['s3:GetObject'],
+      Resource: [`arn:aws:s3:::${bucketName}/*`],
+    },
+  ],
+})
 
 /**
  * Ensure the bucket exists, create if it doesn't
@@ -26,6 +42,37 @@ export const initializeBucket = async (): Promise<void> => {
     }
   } catch (error) {
     console.error(`Failed to ensure bucket '${BUCKET_NAME}' exists:`, error)
+    throw error
+  }
+}
+
+/**
+ * Ensure the public bucket exists with an anonymous-read policy applied.
+ * Policy is re-applied on every startup so dev environments stay consistent
+ * even if someone has tweaked it via the MinIO console.
+ */
+export const initializePublicBucket = async (): Promise<void> => {
+  try {
+    const exists = await minioClient.bucketExists(PUBLIC_BUCKET_NAME)
+    if (!exists) {
+      await minioClient.makeBucket(PUBLIC_BUCKET_NAME, 'us-east-1')
+      console.log(`MinIO bucket '${PUBLIC_BUCKET_NAME}' created successfully`)
+    } else {
+      console.log(`MinIO bucket '${PUBLIC_BUCKET_NAME}' already exists`)
+    }
+
+    await minioClient.setBucketPolicy(
+      PUBLIC_BUCKET_NAME,
+      JSON.stringify(publicReadPolicy(PUBLIC_BUCKET_NAME))
+    )
+    console.log(
+      `MinIO bucket '${PUBLIC_BUCKET_NAME}' anonymous read policy applied`
+    )
+  } catch (error) {
+    console.error(
+      `Failed to ensure public bucket '${PUBLIC_BUCKET_NAME}' exists:`,
+      error
+    )
     throw error
   }
 }
@@ -187,4 +234,72 @@ export const listFiles = async (prefix: string): Promise<BucketItem[]> => {
     console.error(`Failed to list files with prefix '${prefix}':`, error)
     throw error
   }
+}
+
+/**
+ * Upload a file to the public bucket with long-lived cache headers.
+ * Objects in this bucket are world-readable via the bucket policy applied
+ * in initializePublicBucket — do not put anything sensitive here.
+ * @param key - The object key (path inside the public bucket)
+ * @param fileBuffer - The file buffer to upload
+ * @param contentType - MIME type of the file
+ * @returns The key stored in MinIO
+ */
+export const uploadPublicFile = async (
+  key: string,
+  fileBuffer: Buffer,
+  contentType: string
+): Promise<string> => {
+  try {
+    const metadata = {
+      'Content-Type': contentType,
+      'Cache-Control': 'public, max-age=31536000',
+    }
+
+    await minioClient.putObject(
+      PUBLIC_BUCKET_NAME,
+      key,
+      fileBuffer,
+      fileBuffer.length,
+      metadata
+    )
+
+    console.log(
+      `File '${key}' uploaded successfully to bucket '${PUBLIC_BUCKET_NAME}'`
+    )
+    return key
+  } catch (error) {
+    console.error(`Failed to upload public file '${key}':`, error)
+    throw error
+  }
+}
+
+/**
+ * Check if an object exists in the public bucket.
+ * @param key - The object key
+ */
+export const publicFileExists = async (key: string): Promise<boolean> => {
+  try {
+    await minioClient.statObject(PUBLIC_BUCKET_NAME, key)
+    return true
+  } catch (_error) {
+    return false
+  }
+}
+
+/**
+ * Build the anonymous-access URL for an object in the public bucket.
+ * Omits the port when it matches the protocol default (80/443).
+ * @param key - The object key (path inside the public bucket)
+ */
+export const getPublicFileUrl = (key: string): string => {
+  const protocol = minioConfig.useSSL ? 'https' : 'http'
+  const port = minioConfig.port
+  const isDefaultPort =
+    (minioConfig.useSSL && port === 443) || (!minioConfig.useSSL && port === 80)
+  const host = isDefaultPort
+    ? minioConfig.endpoint
+    : `${minioConfig.endpoint}:${port}`
+  const encodedKey = key.split('/').map(encodeURIComponent).join('/')
+  return `${protocol}://${host}/${PUBLIC_BUCKET_NAME}/${encodedKey}`
 }

--- a/services/file-storage/src/config/minio.ts
+++ b/services/file-storage/src/config/minio.ts
@@ -6,5 +6,6 @@ export default {
   accessKey: process.env.MINIO__ACCESS_KEY || '',
   secretKey: process.env.MINIO__SECRET_KEY || '',
   bucketName: process.env.MINIO__BUCKET_NAME || 'onecore-documents',
+  publicBucketName: process.env.MINIO__PUBLIC_BUCKET_NAME || 'onecore-public',
   useSSL: process.env.MINIO__USE_SSL === 'true',
 }

--- a/services/file-storage/src/index.ts
+++ b/services/file-storage/src/index.ts
@@ -1,20 +1,23 @@
 import app from './app'
 import config from './common/config'
 import { logger } from '@onecore/utilities'
-import { initializeBucket } from './adapters/minio-adapter'
+import {
+  initializeBucket,
+  initializePublicBucket,
+} from './adapters/minio-adapter'
 
 const PORT = config.port || 5091
 
-// Initialize MinIO bucket before starting server
-initializeBucket()
+// Initialize MinIO buckets (private + public) before starting server
+Promise.all([initializeBucket(), initializePublicBucket()])
   .then(() => {
-    logger.info('MinIO bucket initialized successfully')
+    logger.info('MinIO buckets initialized successfully')
     app.listen(PORT, () => {
       logger.info(`listening on http://localhost:${PORT}`)
       logger.info(`Swagger exposed on http://localhost:${PORT}/swagger`)
     })
   })
   .catch((error) => {
-    logger.error('Failed to initialize MinIO bucket:', error)
+    logger.error('Failed to initialize MinIO buckets:', error)
     throw error
   })

--- a/services/file-storage/src/scripts/import-bofaktablad.ts
+++ b/services/file-storage/src/scripts/import-bofaktablad.ts
@@ -1,0 +1,136 @@
+/*
+ * One-off importer: uploads all *.jpg files under a local source directory to
+ * the public MinIO bucket under the `bofaktablad/` key prefix.
+ *
+ * Usage:
+ *   pnpm exec ts-node src/scripts/import-bofaktablad.ts [<source-dir>] [--dry-run]
+ *
+ * Defaults source-dir to B:\Bofaktablad. The --dry-run flag inspects every file
+ * (including the existence check against the bucket) but performs no uploads.
+ *
+ * Idempotent: re-running skips any key that already exists in the public bucket.
+ * Only the top level of the source dir is scanned — nested directories are
+ * ignored to avoid silent key collisions on basename.
+ */
+
+import { promises as fs } from 'fs'
+import * as path from 'path'
+
+import {
+  getPublicFileUrl,
+  initializePublicBucket,
+  publicFileExists,
+  uploadPublicFile,
+} from '../adapters/minio-adapter'
+
+const DEFAULT_SOURCE_DIR = 'B:\\Bofaktablad'
+const KEY_PREFIX = 'bofaktablad'
+const CONTENT_TYPE = 'image/jpeg'
+const PROGRESS_EVERY = 50
+
+const parseArgs = (argv: string[]) => {
+  let sourceDir: string | undefined
+  let dryRun = false
+
+  for (const arg of argv) {
+    if (arg === '--dry-run') {
+      dryRun = true
+    } else if (!arg.startsWith('--') && sourceDir === undefined) {
+      sourceDir = arg
+    }
+  }
+
+  return { sourceDir: sourceDir ?? DEFAULT_SOURCE_DIR, dryRun }
+}
+
+const isJpg = (name: string): boolean => name.toLowerCase().endsWith('.jpg')
+
+const main = async (): Promise<void> => {
+  const { sourceDir, dryRun } = parseArgs(process.argv.slice(2))
+
+  console.log(`Source dir:        ${sourceDir}`)
+  console.log(
+    `Mode:              ${dryRun ? 'DRY-RUN (no uploads)' : 'LIVE upload'}`
+  )
+  console.log(`Target key prefix: ${KEY_PREFIX}/`)
+  console.log('---')
+
+  // Idempotent — ensures the bucket and its anonymous read policy exist even
+  // if the user hasn't run `pnpm run dev` since the policy was last applied.
+  await initializePublicBucket()
+
+  let entries
+  try {
+    entries = await fs.readdir(sourceDir, { withFileTypes: true })
+  } catch (err) {
+    console.error(`Failed to read source dir '${sourceDir}':`, err)
+    process.exit(1)
+  }
+
+  const jpgFiles = entries
+    .filter((e) => e.isFile() && isJpg(e.name))
+    .map((e) => e.name)
+    .sort()
+
+  console.log(
+    `Found ${jpgFiles.length} .jpg files at top level of ${sourceDir}`
+  )
+  console.log('---')
+
+  let uploaded = 0
+  let skipped = 0
+  let failed = 0
+
+  for (let i = 0; i < jpgFiles.length; i++) {
+    const fileName = jpgFiles[i]
+    const fullPath = path.join(sourceDir, fileName)
+    const key = `${KEY_PREFIX}/${fileName}`
+
+    try {
+      const alreadyExists = await publicFileExists(key)
+
+      if (alreadyExists) {
+        skipped++
+        if (dryRun) {
+          console.log(`[skip]         ${key} (already in bucket)`)
+        }
+      } else if (dryRun) {
+        uploaded++
+        console.log(`[would upload] ${key}`)
+      } else {
+        const buffer = await fs.readFile(fullPath)
+        await uploadPublicFile(key, buffer, CONTENT_TYPE)
+        uploaded++
+      }
+    } catch (err) {
+      failed++
+      console.error(`[fail] ${key}:`, err)
+    }
+
+    if ((i + 1) % PROGRESS_EVERY === 0) {
+      console.log(
+        `progress: ${i + 1}/${jpgFiles.length} (uploaded=${uploaded} skipped=${skipped} failed=${failed})`
+      )
+    }
+  }
+
+  console.log('---')
+  console.log(`Total files seen:  ${jpgFiles.length}`)
+  console.log(`Uploaded:          ${uploaded}${dryRun ? ' (planned)' : ''}`)
+  console.log(`Skipped:           ${skipped}`)
+  console.log(`Failed:            ${failed}`)
+
+  if (jpgFiles.length > 0) {
+    const sampleKey = `${KEY_PREFIX}/${jpgFiles[0]}`
+    console.log(`Sample public URL: ${getPublicFileUrl(sampleKey)}`)
+  }
+
+  if (failed > 0) {
+    process.exit(1)
+  }
+}
+
+main().catch((err) => {
+  console.error('Import script failed:', err)
+  process.exit(1)
+})

--- a/services/file-storage/src/scripts/import-bofaktablad.ts
+++ b/services/file-storage/src/scripts/import-bofaktablad.ts
@@ -63,8 +63,7 @@ const main = async (): Promise<void> => {
   try {
     entries = await fs.readdir(sourceDir, { withFileTypes: true })
   } catch (err) {
-    console.error(`Failed to read source dir '${sourceDir}':`, err)
-    process.exit(1)
+    throw new Error(`Failed to read source dir '${sourceDir}': ${String(err)}`)
   }
 
   const jpgFiles = entries
@@ -126,11 +125,11 @@ const main = async (): Promise<void> => {
   }
 
   if (failed > 0) {
-    process.exit(1)
+    throw new Error(`Import completed with ${failed} failed uploads`)
   }
 }
 
 main().catch((err) => {
   console.error('Import script failed:', err)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/services/file-storage/src/tests/adapters/minio-adapter.test.ts
+++ b/services/file-storage/src/tests/adapters/minio-adapter.test.ts
@@ -344,17 +344,13 @@ describe('minio-adapter', () => {
       )
     })
 
-    it('should re-apply the anonymous read policy when the bucket already exists', async () => {
+    it('should not re-apply the policy when the bucket already exists', async () => {
       mockMinioClient.bucketExists.mockResolvedValue(true)
-      mockMinioClient.setBucketPolicy.mockResolvedValue(undefined)
 
       await minioAdapter.initializePublicBucket()
 
       expect(mockMinioClient.makeBucket).not.toHaveBeenCalled()
-      expect(mockMinioClient.setBucketPolicy).toHaveBeenCalledWith(
-        'onecore-public',
-        expect.any(String)
-      )
+      expect(mockMinioClient.setBucketPolicy).not.toHaveBeenCalled()
     })
 
     it('should throw if bucket creation fails', async () => {
@@ -366,8 +362,9 @@ describe('minio-adapter', () => {
       )
     })
 
-    it('should throw if policy application fails', async () => {
-      mockMinioClient.bucketExists.mockResolvedValue(true)
+    it('should throw if policy application fails during creation', async () => {
+      mockMinioClient.bucketExists.mockResolvedValue(false)
+      mockMinioClient.makeBucket.mockResolvedValue(undefined)
       mockMinioClient.setBucketPolicy.mockRejectedValue(
         new Error('Policy failed')
       )

--- a/services/file-storage/src/tests/adapters/minio-adapter.test.ts
+++ b/services/file-storage/src/tests/adapters/minio-adapter.test.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'stream'
 import { BucketItem, BucketItemStat } from 'minio'
 import * as minioAdapter from '../../adapters/minio-adapter'
+import minioConfig from '../../config/minio'
 
 // Mock the minio client
 jest.mock('minio', () => {
@@ -8,6 +9,7 @@ jest.mock('minio', () => {
     Client: jest.fn().mockImplementation(() => ({
       bucketExists: jest.fn(),
       makeBucket: jest.fn(),
+      setBucketPolicy: jest.fn(),
       putObject: jest.fn(),
       getObject: jest.fn(),
       removeObject: jest.fn(),
@@ -309,6 +311,169 @@ describe('minio-adapter', () => {
 
       await expect(minioAdapter.listFiles(prefix)).rejects.toThrow(
         'Stream error'
+      )
+    })
+  })
+
+  describe('initializePublicBucket', () => {
+    it('should create the public bucket and apply the anonymous read policy when bucket is missing', async () => {
+      mockMinioClient.bucketExists.mockResolvedValue(false)
+      mockMinioClient.makeBucket.mockResolvedValue(undefined)
+      mockMinioClient.setBucketPolicy.mockResolvedValue(undefined)
+
+      await minioAdapter.initializePublicBucket()
+
+      expect(mockMinioClient.bucketExists).toHaveBeenCalledWith(
+        'onecore-public'
+      )
+      expect(mockMinioClient.makeBucket).toHaveBeenCalledWith(
+        'onecore-public',
+        'us-east-1'
+      )
+      expect(mockMinioClient.setBucketPolicy).toHaveBeenCalledWith(
+        'onecore-public',
+        expect.any(String)
+      )
+
+      const policyJson = mockMinioClient.setBucketPolicy.mock.calls[0][1]
+      const policy = JSON.parse(policyJson)
+      expect(policy.Statement[0].Principal.AWS).toContain('*')
+      expect(policy.Statement[0].Action).toContain('s3:GetObject')
+      expect(policy.Statement[0].Resource).toContain(
+        'arn:aws:s3:::onecore-public/*'
+      )
+    })
+
+    it('should re-apply the anonymous read policy when the bucket already exists', async () => {
+      mockMinioClient.bucketExists.mockResolvedValue(true)
+      mockMinioClient.setBucketPolicy.mockResolvedValue(undefined)
+
+      await minioAdapter.initializePublicBucket()
+
+      expect(mockMinioClient.makeBucket).not.toHaveBeenCalled()
+      expect(mockMinioClient.setBucketPolicy).toHaveBeenCalledWith(
+        'onecore-public',
+        expect.any(String)
+      )
+    })
+
+    it('should throw if bucket creation fails', async () => {
+      const error = new Error('Failed to create bucket')
+      mockMinioClient.bucketExists.mockRejectedValue(error)
+
+      await expect(minioAdapter.initializePublicBucket()).rejects.toThrow(
+        'Failed to create bucket'
+      )
+    })
+
+    it('should throw if policy application fails', async () => {
+      mockMinioClient.bucketExists.mockResolvedValue(true)
+      mockMinioClient.setBucketPolicy.mockRejectedValue(
+        new Error('Policy failed')
+      )
+
+      await expect(minioAdapter.initializePublicBucket()).rejects.toThrow(
+        'Policy failed'
+      )
+    })
+  })
+
+  describe('uploadPublicFile', () => {
+    it('should upload to the public bucket with long-lived Cache-Control metadata', async () => {
+      const key = 'bofaktablad/000-000-00-0000.jpg'
+      const fileBuffer = Buffer.from('image bytes')
+      const contentType = 'image/jpeg'
+      mockMinioClient.putObject.mockResolvedValue(undefined)
+
+      const result = await minioAdapter.uploadPublicFile(
+        key,
+        fileBuffer,
+        contentType
+      )
+
+      expect(result).toBe(key)
+      expect(mockMinioClient.putObject).toHaveBeenCalledWith(
+        'onecore-public',
+        key,
+        fileBuffer,
+        fileBuffer.length,
+        {
+          'Content-Type': contentType,
+          'Cache-Control': 'public, max-age=31536000',
+        }
+      )
+    })
+
+    it('should throw if upload fails', async () => {
+      mockMinioClient.putObject.mockRejectedValue(new Error('Upload failed'))
+
+      await expect(
+        minioAdapter.uploadPublicFile('foo.jpg', Buffer.from('x'), 'image/jpeg')
+      ).rejects.toThrow('Upload failed')
+    })
+  })
+
+  describe('publicFileExists', () => {
+    it('should return true if the public object exists', async () => {
+      mockMinioClient.statObject.mockResolvedValue({})
+
+      const result = await minioAdapter.publicFileExists('bofaktablad/x.jpg')
+
+      expect(result).toBe(true)
+      expect(mockMinioClient.statObject).toHaveBeenCalledWith(
+        'onecore-public',
+        'bofaktablad/x.jpg'
+      )
+    })
+
+    it('should return false if the public object does not exist', async () => {
+      mockMinioClient.statObject.mockRejectedValue(new Error('not found'))
+
+      const result = await minioAdapter.publicFileExists('nope.jpg')
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('getPublicFileUrl', () => {
+    // replaceProperty mutations leak across tests unless restored explicitly
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('returns an http URL with explicit port when useSSL is false and port is non-default', () => {
+      // defaults: endpoint=localhost, port=9000, useSSL=false
+      expect(minioAdapter.getPublicFileUrl('bofaktablad/x.jpg')).toBe(
+        'http://localhost:9000/onecore-public/bofaktablad/x.jpg'
+      )
+    })
+
+    it('omits the port when it matches the HTTP default (80)', () => {
+      jest.replaceProperty(minioConfig, 'port', 80)
+      expect(minioAdapter.getPublicFileUrl('foo.jpg')).toBe(
+        'http://localhost/onecore-public/foo.jpg'
+      )
+    })
+
+    it('returns an https URL and omits the port when useSSL is true and port is 443', () => {
+      jest.replaceProperty(minioConfig, 'useSSL', true)
+      jest.replaceProperty(minioConfig, 'port', 443)
+      expect(minioAdapter.getPublicFileUrl('foo.jpg')).toBe(
+        'https://localhost/onecore-public/foo.jpg'
+      )
+    })
+
+    it('keeps the explicit port when useSSL is true but port is non-default', () => {
+      jest.replaceProperty(minioConfig, 'useSSL', true)
+      jest.replaceProperty(minioConfig, 'port', 8443)
+      expect(minioAdapter.getPublicFileUrl('foo.jpg')).toBe(
+        'https://localhost:8443/onecore-public/foo.jpg'
+      )
+    })
+
+    it('URL-encodes path segments while preserving slashes', () => {
+      expect(minioAdapter.getPublicFileUrl('foo bar/baz.jpg')).toBe(
+        'http://localhost:9000/onecore-public/foo%20bar/baz.jpg'
       )
     })
   })


### PR DESCRIPTION
## Summary

Moves bofaktablad floorplan images off `pub.mimer.nu` and into our own `onecore-public` MinIO bucket. Adds the bucket + an anonymous-read policy on file-storage startup, an idempotent import script, and points property-tree's floorplan helper at the new bucket via `VITE_PUBLIC_ASSETS_URL`.

Linear: https://linear.app/mimer-onecore/issue/MIM-1805

## Changes

- **`services/file-storage`** — new `onecore-public` bucket with anonymous `s3:GetObject` policy applied on every startup; helpers `uploadPublicFile` / `publicFileExists` / `getPublicFileUrl`; one-off import script at `src/scripts/import-bofaktablad.ts` (idempotent, `--dry-run`). 14 new tests, 56/56 pass.
- **`apps/property-tree`** — `getFloorplanUrl` in `src/shared/lib/floorplan.ts` now resolves from `VITE_PUBLIC_ASSETS_URL` instead of hardcoding pub.mimer. Both `FloorplanImage` call sites (residence Bofaktablad tab + inspection dialog) inherit the swap automatically.

## Test plan

- `pnpm run typecheck` from root — clean
- `pnpm --filter @onecore/file-storage run test:ci` — 56/56
- Locally: docker-compose up MinIO → `pnpm run dev` shows `'onecore-public' anonymous read policy applied` → incognito `http://localhost:9000/onecore-public/bofaktablad/000-000-00-0000.jpg` renders → `onecore-documents/anything` returns 403 → property-tree Bofaktablad tab fetches from `localhost:9000/...` (not pub.mimer)

## Rollback

Set `VITE_PUBLIC_ASSETS_URL=https://pub.mimer.nu/bofaktablad` (no code change) to revert floorplans to the legacy source.

## Out of scope (follow-up cards)

Parking-space maps (`ParkingSpaceInfo.tsx`, `email-adapter.ts`), `Lease.tsx` floorplan (uses Azure APIM, separate system), other pub.mimer subdirs (Mediabank, Energideklaration, OVK, Skotselkartor, Manualer).
