### PR TITLE
Feature/avtal 157 trigga synccontacts pa andringar hos goda man och forvaltare

### DIFF
--- a/core/src/adapters/contacts-adapter/index.ts
+++ b/core/src/adapters/contacts-adapter/index.ts
@@ -142,12 +142,18 @@ export const makeContactsAdapter = (contactsServiceUrl: string) => {
       return listResponse(response)
     },
 
-    async getUpdatedContacts(
+    async getUpdatedContacts({
+      since,
+      includeRelations = false,
+    }: {
       since: Date | null
-    ): Promise<
+      includeRelations: boolean
+    }): Promise<
       AdapterResult<{ contact: Contact; timestamp: Date }[], 'unknown'>
     > {
-      const params = since ? { since: since.toISOString() } : {}
+      const params = since
+        ? { since: since.toISOString(), includeRelations }
+        : {}
       const response = await axios<SyncContactsResponseBody>(`/contacts/sync`, {
         params,
       })

--- a/core/src/scripts/sync-contacts/index.test.ts
+++ b/core/src/scripts/sync-contacts/index.test.ts
@@ -296,4 +296,206 @@ describe('syncContacts', () => {
     const written = (await fs.readFile(stateFile, 'utf-8')).trim()
     expect(written).toBe(ts.toISOString())
   })
+
+  it('case 6: related contacts (all triggering roles) — additional leasing calls with correct payloads', async () => {
+    const relatedTrusteeFor = {
+      contactCode: 'P200001',
+      role: 'trusteeFor' as const,
+      fullName: 'Anna Andersson',
+      firstName: 'Anna',
+      lastName: 'Andersson',
+    }
+    const relatedAdministratorFor = {
+      contactCode: 'P200002',
+      role: 'administratorFor' as const,
+      fullName: 'Bo Bengtsson',
+      firstName: 'Bo',
+      lastName: 'Bengtsson',
+    }
+    const relatedInvoiceRecipientFor = {
+      contactCode: 'P200003',
+      role: 'otherInvoiceRecipientFor' as const,
+      fullName: 'Carin Carlsson',
+      firstName: 'Carin',
+      lastName: 'Carlsson',
+    }
+    const contact = factory.domainContact.build({
+      relatedContacts: [
+        relatedTrusteeFor,
+        relatedAdministratorFor,
+        relatedInvoiceRecipientFor,
+      ],
+    })
+    const ts = new Date('2026-05-02T10:00:00.000Z')
+
+    jest.spyOn(contactsAdapterModule, 'makeContactsAdapter').mockReturnValue({
+      getUpdatedContacts: jest.fn().mockResolvedValue({
+        ok: true,
+        data: [{ contact, timestamp: ts }],
+      }),
+    } as any)
+
+    const syncLeasingSpy = jest
+      .spyOn(leasingAdapter, 'syncContactToLeasing')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(economyAdapter, 'syncContactToEconomy')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(workOrderAdapter, 'syncContactToWorkOrder')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(communicationAdapter, 'sendEmail')
+      .mockResolvedValue({ ok: true, data: null })
+
+    await syncContacts({ stateFile, queueFile })
+
+    // 1 call for main contact + 3 calls for related contacts
+    expect(syncLeasingSpy).toHaveBeenCalledTimes(4)
+
+    // trusteeFor: related contact called with trustee field
+    expect(syncLeasingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactCode: relatedTrusteeFor.contactCode,
+        firstName: relatedTrusteeFor.firstName,
+        lastName: relatedTrusteeFor.lastName,
+        trustee: expect.objectContaining({ name: expect.any(String) }),
+      })
+    )
+
+    // administratorFor: related contact called with administrator field
+    expect(syncLeasingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactCode: relatedAdministratorFor.contactCode,
+        firstName: relatedAdministratorFor.firstName,
+        lastName: relatedAdministratorFor.lastName,
+        administrator: expect.objectContaining({ name: expect.any(String) }),
+      })
+    )
+
+    // otherInvoiceRecipientFor: related contact called with invoiceRecipient field
+    expect(syncLeasingSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contactCode: relatedInvoiceRecipientFor.contactCode,
+        firstName: relatedInvoiceRecipientFor.firstName,
+        lastName: relatedInvoiceRecipientFor.lastName,
+        invoiceRecipient: expect.objectContaining({ name: expect.any(String) }),
+      })
+    )
+
+    expect(await readQueue(queueFile)).toHaveLength(0)
+  })
+
+  it('case 7: related contact leasing sync fails — main contact queued for retry', async () => {
+    const relatedContact = {
+      contactCode: 'P200004',
+      role: 'trusteeFor' as const,
+      fullName: 'Diana Davidsson',
+      firstName: 'Diana',
+      lastName: 'Davidsson',
+    }
+    const contact = factory.domainContact.build({
+      relatedContacts: [relatedContact],
+    })
+    const ts = new Date('2026-05-02T11:00:00.000Z')
+
+    jest.spyOn(contactsAdapterModule, 'makeContactsAdapter').mockReturnValue({
+      getUpdatedContacts: jest.fn().mockResolvedValue({
+        ok: true,
+        data: [{ contact, timestamp: ts }],
+      }),
+    } as any)
+
+    jest
+      .spyOn(leasingAdapter, 'syncContactToLeasing')
+      .mockResolvedValueOnce({ ok: true, data: { skipped: false } }) // main contact ok
+      .mockResolvedValueOnce({ ok: false, err: 'sync-failed' }) // related contact fails
+
+    jest
+      .spyOn(economyAdapter, 'syncContactToEconomy')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(workOrderAdapter, 'syncContactToWorkOrder')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    const sendEmailSpy = jest
+      .spyOn(communicationAdapter, 'sendEmail')
+      .mockResolvedValue({ ok: true, data: null })
+
+    await syncContacts({ stateFile, queueFile })
+
+    // Main contact queued (not the related contact)
+    const queue = await readQueue(queueFile)
+    expect(queue).toHaveLength(1)
+    expect(queue[0].key).toBe(`${contact.contactCode}:${ts.toISOString()}`)
+    expect(queue[0].type).toBe('contact')
+
+    // Failure email sent
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1)
+    expect(sendEmailSpy.mock.calls[0][0].subject).toMatch(
+      `sync-contacts: nytt fel på kontakt ${contact.contactCode}`
+    )
+  })
+
+  it('case 8: non-triggering roles (trustee, administrator, otherInvoiceRecipient) — no additional leasing calls', async () => {
+    const contact = factory.domainContact.build({
+      relatedContacts: [
+        {
+          contactCode: 'P300001',
+          role: 'trustee' as const,
+          fullName: 'Erik Eriksson',
+          firstName: 'Erik',
+          lastName: 'Eriksson',
+        },
+        {
+          contactCode: 'P300002',
+          role: 'administrator' as const,
+          fullName: 'Frida Friberg',
+          firstName: 'Frida',
+          lastName: 'Friberg',
+        },
+        {
+          contactCode: 'P300003',
+          role: 'otherInvoiceRecipient' as const,
+          fullName: 'Gustav Gustafsson',
+          firstName: 'Gustav',
+          lastName: 'Gustafsson',
+        },
+      ],
+    })
+    const ts = new Date('2026-05-02T12:00:00.000Z')
+
+    jest.spyOn(contactsAdapterModule, 'makeContactsAdapter').mockReturnValue({
+      getUpdatedContacts: jest.fn().mockResolvedValue({
+        ok: true,
+        data: [{ contact, timestamp: ts }],
+      }),
+    } as any)
+
+    const syncLeasingSpy = jest
+      .spyOn(leasingAdapter, 'syncContactToLeasing')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(economyAdapter, 'syncContactToEconomy')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(workOrderAdapter, 'syncContactToWorkOrder')
+      .mockResolvedValue({ ok: true, data: { skipped: false } })
+
+    jest
+      .spyOn(communicationAdapter, 'sendEmail')
+      .mockResolvedValue({ ok: true, data: null })
+
+    await syncContacts({ stateFile, queueFile })
+
+    // Only 1 leasing call — main contact only, non-triggering roles not synced
+    expect(syncLeasingSpy).toHaveBeenCalledTimes(1)
+    expect(await readQueue(queueFile)).toHaveLength(0)
+  })
 })

--- a/core/src/scripts/sync-contacts/index.ts
+++ b/core/src/scripts/sync-contacts/index.ts
@@ -1,12 +1,13 @@
 import fs from 'fs/promises'
 import { logger } from '@onecore/utilities'
+import { SyncContactToLeasingPayload } from '@onecore/types'
+import type { Contact, RelatedContactRole } from '@onecore/contacts/schema'
 import config from '../../common/config'
 import { makeContactsAdapter } from '../../adapters/contacts-adapter'
 import { sendEmail } from '../../adapters/communication-adapter'
 import { syncContactToLeasing } from '../../adapters/leasing-adapter'
 import { syncContactToEconomy } from '../../adapters/economy-adapter'
 import { syncContactToWorkOrder } from '../../adapters/work-order-adapter'
-import type { Contact } from '@onecore/contacts/schema'
 import { toSyncPayload } from './payload'
 import {
   addEntry,
@@ -130,6 +131,74 @@ const syncContact = async (update: ContactUpdate): Promise<void> => {
       }, odoo=${odooResult.ok ? 'ok' : odooResult.err}`
     )
   }
+
+  if (update.contact.relatedContacts) {
+    /*
+      If updated contact A is trustee, administrator (förvaltare) or invoice recipient for another contact B,
+      contact B must currently be manually updated in the leasing service whenever contact A is updated.
+    */
+    const relatedContactsToUpdate = update.contact.relatedContacts.filter(
+      (c) => {
+        const roles: RelatedContactRole[] = [
+          'trusteeFor',
+          'administratorFor',
+          'otherInvoiceRecipientFor',
+        ]
+        return roles.includes(c.role)
+      }
+    )
+
+    const leasingResults = await Promise.all(
+      relatedContactsToUpdate.map((c) => {
+        var syncRelatedContactPayload: SyncContactToLeasingPayload = {
+          contactCode: c.contactCode,
+          firstName: c.firstName,
+          lastName: c.lastName,
+        }
+
+        if (c.role === 'trusteeFor') {
+          syncRelatedContactPayload.trustee = {
+            name: payload.fullName,
+            nationalRegistrationNumber: payload.nationalId,
+            email: payload.emailAddress ?? null,
+            phone: payload.phoneNumber ?? null,
+            address: payload.street ?? null,
+            zipCode: payload.zipCode ?? null,
+          }
+        } else if (c.role === 'administratorFor') {
+          syncRelatedContactPayload.administrator = {
+            name: payload.fullName,
+            nationalRegistrationNumber: payload.nationalId,
+            email: payload.emailAddress ?? null,
+            phone: payload.phoneNumber ?? null,
+            address: payload.street ?? null,
+            zipCode: payload.zipCode ?? null,
+          }
+        } else if (c.role === 'otherInvoiceRecipientFor') {
+          syncRelatedContactPayload.invoiceRecipient = {
+            name: payload.fullName,
+            nationalRegistrationNumber: payload.nationalId,
+            email: payload.emailAddress ?? null,
+            phone: payload.phoneNumber ?? null,
+            address: payload.street ?? null,
+            zipCode: payload.zipCode ?? null,
+          }
+        }
+
+        return syncContactToLeasing(syncRelatedContactPayload)
+      })
+    )
+
+    var failedResult = leasingResults.find((result) => !result.ok)
+    if (failedResult) {
+      throw new Error(
+        `contact ${payload.contactCode} failed to sync related contacts: tenfast=${
+          failedResult.ok ? 'ok' : failedResult.err
+        }`
+      )
+    }
+  }
+
   logger.info({ contactCode: payload.contactCode }, 'contact synced')
 }
 
@@ -165,7 +234,10 @@ export const syncContacts = async (
     logger.info('no saved timestamp, syncing all')
   }
   const contactsAdapter = makeContactsAdapter(config.contactsService.url)
-  const result = await contactsAdapter.getUpdatedContacts(lastTimestamp)
+  const result = await contactsAdapter.getUpdatedContacts({
+    since: lastTimestamp,
+    includeRelations: true,
+  })
   if (!result.ok) {
     logger.error({ err: result.err }, 'Failed to fetch updated contacts')
     throw new Error(result.err)

--- a/core/src/scripts/sync-contacts/index.ts
+++ b/core/src/scripts/sync-contacts/index.ts
@@ -150,7 +150,7 @@ const syncContact = async (update: ContactUpdate): Promise<void> => {
 
     const leasingResults = await Promise.all(
       relatedContactsToUpdate.map((c) => {
-        var syncRelatedContactPayload: SyncContactToLeasingPayload = {
+        const syncRelatedContactPayload: SyncContactToLeasingPayload = {
           contactCode: c.contactCode,
           firstName: c.firstName,
           lastName: c.lastName,
@@ -189,7 +189,7 @@ const syncContact = async (update: ContactUpdate): Promise<void> => {
       })
     )
 
-    var failedResult = leasingResults.find((result) => !result.ok)
+    const failedResult = leasingResults.find((result) => !result.ok)
     if (failedResult) {
       throw new Error(
         `contact ${payload.contactCode} failed to sync related contacts: tenfast=${

--- a/libs/types/src/schemas/v1/contact-sync.ts
+++ b/libs/types/src/schemas/v1/contact-sync.ts
@@ -1,16 +1,28 @@
 import { z } from 'zod'
 
+export const RelatedContactSchema = z.object({
+  name: z.string().nullable(),
+  nationalRegistrationNumber: z.string().nullable(),
+  email: z.string().nullable(),
+  phone: z.string().nullable(),
+  address: z.string().nullable(),
+  zipCode: z.string().nullable(),
+})
+
 export const SyncContactToLeasingSchema = z.object({
   contactCode: z.string(),
   firstName: z.string().nullable().optional(),
   lastName: z.string().nullable().optional(),
-  fullName: z.string(),
+  fullName: z.string().nullable().optional(),
   nationalRegistrationNumber: z.string().nullable().optional(),
   emailAddress: z.string().nullable().optional(),
   phoneNumber: z.string().nullable().optional(),
   street: z.string().nullable().optional(),
   zipCode: z.string().nullable().optional(),
   city: z.string().nullable().optional(),
+  trustee: RelatedContactSchema.optional(),
+  administrator: RelatedContactSchema.optional(),
+  invoiceRecipient: RelatedContactSchema.optional(),
 })
 
 export type SyncContactToLeasingPayload = z.infer<
@@ -40,3 +52,5 @@ export const SyncContactToWorkOrderSchema = z.object({
 export type SyncContactToWorkOrderPayload = z.infer<
   typeof SyncContactToWorkOrderSchema
 >
+
+export type RelatedContact = z.infer<typeof RelatedContactSchema>

--- a/services/contacts/src/services/contacts-service/index.ts
+++ b/services/contacts/src/services/contacts-service/index.ts
@@ -95,6 +95,15 @@ export const routes = (
           description: 'ISO 8601 timestamp to query changes from',
           schema: z.optional(z.string()),
         },
+        includeRelations: {
+          description: 'Whether to include related contacts in the response',
+          schema: z
+            .enum(['true', 'false'])
+            .optional()
+            .transform((value) =>
+              value ? value.toLowerCase() === 'true' : false
+            ),
+        },
       },
       response: {
         200: SyncContactsResponseBodySchema,
@@ -118,7 +127,8 @@ export const routes = (
       const changedCodes =
         await contactsRepository.getChangedContactCodes(since)
       const fetchedContacts = await contactsRepository.getByContactCodes(
-        changedCodes.map((c) => c.contactCode)
+        changedCodes.map((c) => c.contactCode),
+        { includeRelations: ctx.query.includeRelations }
       )
       const contactByCode = new Map(
         fetchedContacts.map((c) => [c.contactCode, c])

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -29,6 +29,7 @@ import { AdapterResult } from '../../adapters/types'
 import * as tenfastApi from './tenfast-api'
 import { filterByStatus, GetLeasesFilters } from './filters'
 import { mapTenfastRentalObjectToAvailabilityInfo } from './tenfast-rental-object-helpers'
+import { RelatedContact } from '@onecore/types/src/schemas/v1/contact-sync'
 
 const tenfastBaseUrl = config.tenfast.baseUrl
 const tenfastCompanyId = config.tenfast.companyId
@@ -844,6 +845,67 @@ function buildTenantRequestDataFromPayload(
   }
 }
 
+function buildPatchTenantRequestDataFromPayload(
+  payload: SyncContactToLeasingPayload
+) {
+  /*
+    The trustee (god man) and administrator (förvaltare) roles are both represented by the trustee property in Tenfast.
+    The trustee.godMan flag indicates which role, where true means it is a trustee, and false means it is an administrator.
+  */
+  var trusteeOrAdministrator:
+    | { contact: RelatedContact; isTrustee: boolean }
+    | undefined = undefined
+
+  if (payload.trustee) {
+    trusteeOrAdministrator = {
+      contact: payload.trustee,
+      isTrustee: true,
+    }
+  } else if (payload.administrator) {
+    trusteeOrAdministrator = {
+      contact: payload.administrator,
+      isTrustee: false,
+    }
+  }
+
+  return {
+    externalId: payload.contactCode,
+    idbeteckning: payload.nationalRegistrationNumber,
+    isCompany: false,
+    name: {
+      first: payload.firstName,
+      last: payload.lastName,
+    },
+    email: payload.emailAddress,
+    phone: payload.phoneNumber,
+    postadress: payload.street,
+    postnummer: payload.zipCode,
+    stad: payload.city,
+    trustee: trusteeOrAdministrator
+      ? {
+          name: trusteeOrAdministrator.contact.name,
+          idbeteckning:
+            trusteeOrAdministrator.contact.nationalRegistrationNumber,
+          email: trusteeOrAdministrator.contact.email,
+          phone: trusteeOrAdministrator.contact.phone,
+          postadress: trusteeOrAdministrator.contact.address,
+          postnummer: trusteeOrAdministrator.contact.zipCode,
+          godMan: trusteeOrAdministrator.isTrustee,
+        }
+      : undefined,
+    fakturaMottagare: payload.invoiceRecipient
+      ? {
+          name: payload.invoiceRecipient.name,
+          idbeteckning: payload.invoiceRecipient.nationalRegistrationNumber,
+          email: payload.invoiceRecipient.email,
+          phone: payload.invoiceRecipient.phone,
+          postadress: payload.invoiceRecipient.address,
+          postnummer: payload.invoiceRecipient.zipCode,
+        }
+      : undefined,
+  }
+}
+
 export const syncTenant = async (
   payload: SyncContactToLeasingPayload
 ): Promise<
@@ -870,7 +932,7 @@ export const syncTenant = async (
       return { ok: true, data: null }
     }
 
-    const requestData = buildTenantRequestDataFromPayload(payload)
+    const requestData = buildPatchTenantRequestDataFromPayload(payload)
 
     const tenantResponse = await tenfastApi.request({
       method: 'patch',

--- a/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/tenfast/tenfast-adapter.ts
@@ -852,7 +852,7 @@ function buildPatchTenantRequestDataFromPayload(
     The trustee (god man) and administrator (förvaltare) roles are both represented by the trustee property in Tenfast.
     The trustee.godMan flag indicates which role, where true means it is a trustee, and false means it is an administrator.
   */
-  var trusteeOrAdministrator:
+  let trusteeOrAdministrator:
     | { contact: RelatedContact; isTrustee: boolean }
     | undefined = undefined
 


### PR DESCRIPTION
När en kontakt A uppdateras i xpand hämtas nu deras relaterade kontakter. Varje kontakt B som kontakt A är god man, förvaltare eller annan fakturamottagare åt, uppdateras också i Tenfast.