### PR TITLE
make contactCode required through the single SMS/email send flow

### DIFF
--- a/apps/property-tree/src/features/tenants/ui/CurrentTenant.tsx
+++ b/apps/property-tree/src/features/tenants/ui/CurrentTenant.tsx
@@ -81,37 +81,45 @@ export function CurrentTenant({
               <TenantLeaseCard
                 tenant={tenant}
                 onSendSms={(phone) =>
-                  sms.openSmsModal(
-                    formatTenantName(tenant),
-                    phone,
-                    tenant.contactCode
-                  )
+                  sms.openSmsModal({
+                    name: formatTenantName(tenant),
+                    phoneNumber: phone,
+                    contactCode: tenant.contactCode,
+                  })
                 }
                 onSendEmail={(addr) =>
-                  email.openEmailModal(
-                    formatTenantName(tenant),
-                    addr,
-                    tenant.contactCode
-                  )
+                  email.openEmailModal({
+                    name: formatTenantName(tenant),
+                    emailAddress: addr,
+                    contactCode: tenant.contactCode,
+                  })
                 }
               />
             </div>
           ))}
         </div>
-        <SmsModal
-          open={sms.smsModalOpen}
-          onOpenChange={sms.onOpenChange}
-          recipientName={sms.smsRecipientName}
-          phoneNumber={sms.smsPhoneNumber}
-          onSend={sms.handleSendSms}
-        />
-        <EmailModal
-          open={email.emailModalOpen}
-          onOpenChange={email.onOpenChange}
-          recipientName={email.emailRecipientName}
-          emailAddress={email.emailAddress}
-          onSend={email.handleSendEmail}
-        />
+        {sms.recipient && (
+          <SmsModal
+            open
+            onOpenChange={(open) => {
+              if (!open) sms.closeSms()
+            }}
+            recipientName={sms.recipient.name}
+            phoneNumber={sms.recipient.phoneNumber}
+            onSend={sms.handleSendSms}
+          />
+        )}
+        {email.recipient && (
+          <EmailModal
+            open
+            onOpenChange={(open) => {
+              if (!open) email.closeEmail()
+            }}
+            recipientName={email.recipient.name}
+            emailAddress={email.recipient.emailAddress}
+            onSend={email.handleSendEmail}
+          />
+        )}
       </div>
     </TabLayout>
   )

--- a/apps/property-tree/src/features/tenants/ui/TenantsTabContent.tsx
+++ b/apps/property-tree/src/features/tenants/ui/TenantsTabContent.tsx
@@ -56,37 +56,45 @@ export function TenantsTabContent({
                   tenant={tenant}
                   key={i}
                   onSendSms={(phone) =>
-                    sms.openSmsModal(
-                      formatTenantName(tenant),
-                      phone,
-                      tenant.contactCode
-                    )
+                    sms.openSmsModal({
+                      name: formatTenantName(tenant),
+                      phoneNumber: phone,
+                      contactCode: tenant.contactCode,
+                    })
                   }
                   onSendEmail={(addr) =>
-                    email.openEmailModal(
-                      formatTenantName(tenant),
-                      addr,
-                      tenant.contactCode
-                    )
+                    email.openEmailModal({
+                      name: formatTenantName(tenant),
+                      emailAddress: addr,
+                      contactCode: tenant.contactCode,
+                    })
                   }
                 />
               </>
             ))}
           </div>
-          <SmsModal
-            open={sms.smsModalOpen}
-            onOpenChange={sms.onOpenChange}
-            recipientName={sms.smsRecipientName}
-            phoneNumber={sms.smsPhoneNumber}
-            onSend={sms.handleSendSms}
-          />
-          <EmailModal
-            open={email.emailModalOpen}
-            onOpenChange={email.onOpenChange}
-            recipientName={email.emailRecipientName}
-            emailAddress={email.emailAddress}
-            onSend={email.handleSendEmail}
-          />
+          {sms.recipient && (
+            <SmsModal
+              open
+              onOpenChange={(open) => {
+                if (!open) sms.closeSms()
+              }}
+              recipientName={sms.recipient.name}
+              phoneNumber={sms.recipient.phoneNumber}
+              onSend={sms.handleSendSms}
+            />
+          )}
+          {email.recipient && (
+            <EmailModal
+              open
+              onOpenChange={(open) => {
+                if (!open) email.closeEmail()
+              }}
+              recipientName={email.recipient.name}
+              emailAddress={email.recipient.emailAddress}
+              onSend={email.handleSendEmail}
+            />
+          )}
         </>
       )}
     </TabLayout>

--- a/apps/property-tree/src/pages/TenantPage.tsx
+++ b/apps/property-tree/src/pages/TenantPage.tsx
@@ -144,18 +144,18 @@ export function TenantPage() {
               <TenantCard
                 tenant={tenant}
                 onSendSms={(phone) =>
-                  sms.openSmsModal(
-                    `${tenant.firstName} ${tenant.lastName}`,
-                    phone,
-                    tenant.contactCode
-                  )
+                  sms.openSmsModal({
+                    name: `${tenant.firstName} ${tenant.lastName}`,
+                    phoneNumber: phone,
+                    contactCode: tenant.contactCode,
+                  })
                 }
                 onSendEmail={(addr) =>
-                  email.openEmailModal(
-                    `${tenant.firstName} ${tenant.lastName}`,
-                    addr,
-                    tenant.contactCode
-                  )
+                  email.openEmailModal({
+                    name: `${tenant.firstName} ${tenant.lastName}`,
+                    emailAddress: addr,
+                    contactCode: tenant.contactCode,
+                  })
                 }
               />
             </div>
@@ -167,20 +167,28 @@ export function TenantPage() {
               leasesError={leasesError}
               rentalPropertiesLoading={rentalPropertiesLoading}
             />
-            <SmsModal
-              open={sms.smsModalOpen}
-              onOpenChange={sms.onOpenChange}
-              recipientName={sms.smsRecipientName}
-              phoneNumber={sms.smsPhoneNumber}
-              onSend={sms.handleSendSms}
-            />
-            <EmailModal
-              open={email.emailModalOpen}
-              onOpenChange={email.onOpenChange}
-              recipientName={email.emailRecipientName}
-              emailAddress={email.emailAddress}
-              onSend={email.handleSendEmail}
-            />
+            {sms.recipient && (
+              <SmsModal
+                open
+                onOpenChange={(open) => {
+                  if (!open) sms.closeSms()
+                }}
+                recipientName={sms.recipient.name}
+                phoneNumber={sms.recipient.phoneNumber}
+                onSend={sms.handleSendSms}
+              />
+            )}
+            {email.recipient && (
+              <EmailModal
+                open
+                onOpenChange={(open) => {
+                  if (!open) email.closeEmail()
+                }}
+                recipientName={email.recipient.name}
+                emailAddress={email.recipient.emailAddress}
+                onSend={email.handleSendEmail}
+              />
+            )}
           </>
         )}
       </ObjectPageLayout>

--- a/apps/property-tree/src/services/api/core/tenantService.ts
+++ b/apps/property-tree/src/services/api/core/tenantService.ts
@@ -51,7 +51,7 @@ async function searchContacts(query: string): Promise<ContactSearchResult[]> {
 }
 
 async function sendBulkSms(
-  recipients: { contactCode?: string; phoneNumber: string }[],
+  recipients: { contactCode: string; phoneNumber: string }[],
   text: string
 ): Promise<BulkSmsResult> {
   const { data, error } = await POST('/sendBulkSms', {
@@ -65,7 +65,7 @@ async function sendBulkSms(
 }
 
 async function sendBulkEmail(
-  recipients: { contactCode?: string; emailAddress: string }[],
+  recipients: { contactCode: string; emailAddress: string }[],
   subject: string,
   text: string
 ): Promise<{ content: BulkEmailResult; warnings?: string[] }> {

--- a/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
+++ b/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
@@ -24,12 +24,12 @@ export interface UseBulkMessagingOptions<TItem> {
   fetchAllContacts?: () => Promise<Contact[]>
   /** Send bulk SMS - returns result with totalSent/totalInvalid */
   sendBulkSms: (
-    recipients: { contactCode?: string; phoneNumber: string }[],
+    recipients: { contactCode: string; phoneNumber: string }[],
     message: string
   ) => Promise<{ totalSent: number; totalInvalid: number }>
   /** Send bulk email - returns the result plus any non-blocking warnings */
   sendBulkEmail: (
-    recipients: { contactCode?: string; emailAddress: string }[],
+    recipients: { contactCode: string; emailAddress: string }[],
     subject: string,
     body: string
   ) => Promise<{

--- a/apps/property-tree/src/shared/hooks/useSingleEmail.ts
+++ b/apps/property-tree/src/shared/hooks/useSingleEmail.ts
@@ -1,18 +1,20 @@
 import { useCallback, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { useToast } from './useToast'
 
-interface SingleEmailState {
-  open: boolean
-  recipientName: string
+// A fully-resolved email recipient. Having one is the proof we can send: every
+// field is required, so there is no path to the API without a contactCode and
+// email address, and no empty-string placeholders to accidentally send.
+export interface SingleEmailRecipient {
+  name: string
   emailAddress: string
-  contactCode?: string
+  contactCode: string
 }
 
 interface UseSingleEmailOptions {
   sendEmail: (
-    recipients: { contactCode?: string; emailAddress: string }[],
+    recipients: { contactCode: string; emailAddress: string }[],
     subject: string,
     text: string
   ) => Promise<{
@@ -24,81 +26,86 @@ interface UseSingleEmailOptions {
 export function useSingleEmail({ sendEmail }: UseSingleEmailOptions) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
-  const [state, setState] = useState<SingleEmailState>({
-    open: false,
-    recipientName: '',
-    emailAddress: '',
-  })
 
-  const openEmailModal = useCallback(
-    (recipientName: string, emailAddress: string, contactCode?: string) => {
-      setState({ open: true, recipientName, emailAddress, contactCode })
-    },
-    []
-  )
+  // Selection is modal openness: null = closed, a recipient = open. There is
+  // never a half-filled "open but blank" object.
+  const [recipient, setRecipient] = useState<SingleEmailRecipient | null>(null)
 
-  const onOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setState((prev) => ({ ...prev, open: false }))
-    }
-  }, [])
+  const sendMutation = useMutation({
+    mutationFn: ({
+      recipient,
+      subject,
+      body,
+    }: {
+      recipient: SingleEmailRecipient
+      subject: string
+      body: string
+    }) =>
+      sendEmail(
+        [
+          {
+            contactCode: recipient.contactCode,
+            emailAddress: recipient.emailAddress,
+          },
+        ],
+        subject,
+        body
+      ),
+    onSuccess: (result) => {
+      // Refresh any open tenant communication log so the new message appears.
+      queryClient.invalidateQueries({ queryKey: ['tenant-communication'] })
+      toast({
+        title: 'Mejl skickat',
+        description: `Skickades till ${result.content.totalSent} mottagare${
+          result.content.totalInvalid > 0
+            ? `. ${result.content.totalInvalid} ogiltiga adresser.`
+            : ''
+        }`,
+      })
 
-  const handleSendEmail = useCallback(
-    async (subject: string, body: string) => {
-      try {
-        const result = await sendEmail(
-          [
-            {
-              contactCode: state.contactCode,
-              emailAddress: state.emailAddress,
-            },
-          ],
-          subject,
-          body
-        )
-
-        // Refresh any open tenant communication log so the new message appears.
-        queryClient.invalidateQueries({ queryKey: ['tenant-communication'] })
-
+      // Non-blocking: the email was sent, but something like communication-log
+      // writing failed. Surface it without blocking the success flow.
+      if (result.warnings?.length) {
         toast({
-          title: 'Mejl skickat',
-          description: `Skickades till ${result.content.totalSent} mottagare${
-            result.content.totalInvalid > 0
-              ? `. ${result.content.totalInvalid} ogiltiga adresser.`
-              : ''
-          }`,
-        })
-
-        // Non-blocking: the email was sent, but something like communication-log
-        // writing failed. Surface it without blocking the success flow.
-        if (result.warnings?.length) {
-          toast({
-            title: 'Mejlet skickades, men en åtgärd misslyckades',
-            description: result.warnings.join(' '),
-            variant: 'destructive',
-          })
-        }
-
-        setState((prev) => ({ ...prev, open: false }))
-      } catch (error) {
-        const errorMessage = extractErrorMessage(error)
-        toast({
-          title: 'Kunde inte skicka mejl',
-          description: errorMessage,
+          title: 'Mejlet skickades, men en åtgärd misslyckades',
+          description: result.warnings.join(' '),
           variant: 'destructive',
         })
       }
     },
-    [state.emailAddress, state.contactCode, sendEmail, toast, queryClient]
+    onError: (error) => {
+      toast({
+        title: 'Kunde inte skicka mejl',
+        description: extractErrorMessage(error),
+        variant: 'destructive',
+      })
+    },
+  })
+
+  const openEmailModal = useCallback(
+    (r: SingleEmailRecipient) => setRecipient(r),
+    []
+  )
+  const closeEmail = useCallback(() => setRecipient(null), [])
+
+  const handleSendEmail = useCallback(
+    async (subject: string, body: string) => {
+      if (!recipient) return
+      try {
+        await sendMutation.mutateAsync({ recipient, subject, body })
+      } catch {
+        // Surfaced via onError; swallow so the modal doesn't see a rejection.
+      }
+    },
+    [recipient, sendMutation]
   )
 
   return {
-    emailModalOpen: state.open,
-    emailRecipientName: state.recipientName,
-    emailAddress: state.emailAddress,
+    recipient,
     openEmailModal,
-    onOpenChange,
+    closeEmail,
     handleSendEmail,
+    isSending: sendMutation.isPending,
   }
 }
 

--- a/apps/property-tree/src/shared/hooks/useSingleSms.ts
+++ b/apps/property-tree/src/shared/hooks/useSingleSms.ts
@@ -1,18 +1,20 @@
 import { useCallback, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import { useToast } from './useToast'
 
-interface SingleSmsState {
-  open: boolean
-  recipientName: string
+// A fully-resolved SMS recipient. Having one is the proof we can send: every
+// field is required, so there is no path to the API without a contactCode and
+// phone number, and no empty-string placeholders to accidentally send.
+export interface SingleSmsRecipient {
+  name: string
   phoneNumber: string
-  contactCode?: string
+  contactCode: string
 }
 
 interface UseSingleSmsOptions {
   sendSms: (
-    recipients: { contactCode?: string; phoneNumber: string }[],
+    recipients: { contactCode: string; phoneNumber: string }[],
     message: string
   ) => Promise<{ totalSent: number; totalInvalid: number }>
 }
@@ -20,65 +22,73 @@ interface UseSingleSmsOptions {
 export function useSingleSms({ sendSms }: UseSingleSmsOptions) {
   const { toast } = useToast()
   const queryClient = useQueryClient()
-  const [state, setState] = useState<SingleSmsState>({
-    open: false,
-    recipientName: '',
-    phoneNumber: '',
+
+  // Selection is modal openness: null = closed, a recipient = open. There is
+  // never a half-filled "open but blank" object.
+  const [recipient, setRecipient] = useState<SingleSmsRecipient | null>(null)
+
+  const sendMutation = useMutation({
+    mutationFn: ({
+      recipient,
+      message,
+    }: {
+      recipient: SingleSmsRecipient
+      message: string
+    }) =>
+      sendSms(
+        [
+          {
+            contactCode: recipient.contactCode,
+            phoneNumber: recipient.phoneNumber,
+          },
+        ],
+        message
+      ),
+    onSuccess: (result) => {
+      // Refresh any open tenant communication log so the new message appears.
+      queryClient.invalidateQueries({ queryKey: ['tenant-communication'] })
+      toast({
+        title: 'SMS skickat',
+        description: `Skickades till ${result.totalSent} mottagare${
+          result.totalInvalid > 0
+            ? `. ${result.totalInvalid} ogiltiga nummer.`
+            : ''
+        }`,
+      })
+    },
+    onError: (error) => {
+      toast({
+        title: 'Kunde inte skicka SMS',
+        description: extractErrorMessage(error),
+        variant: 'destructive',
+      })
+    },
   })
 
   const openSmsModal = useCallback(
-    (recipientName: string, phoneNumber: string, contactCode?: string) => {
-      setState({ open: true, recipientName, phoneNumber, contactCode })
-    },
+    (r: SingleSmsRecipient) => setRecipient(r),
     []
   )
-
-  const onOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setState((prev) => ({ ...prev, open: false }))
-    }
-  }, [])
+  const closeSms = useCallback(() => setRecipient(null), [])
 
   const handleSendSms = useCallback(
     async (message: string) => {
+      if (!recipient) return
       try {
-        const result = await sendSms(
-          [{ contactCode: state.contactCode, phoneNumber: state.phoneNumber }],
-          message
-        )
-
-        // Refresh any open tenant communication log so the new message appears.
-        queryClient.invalidateQueries({ queryKey: ['tenant-communication'] })
-
-        toast({
-          title: 'SMS skickat',
-          description: `Skickades till ${result.totalSent} mottagare${
-            result.totalInvalid > 0
-              ? `. ${result.totalInvalid} ogiltiga nummer.`
-              : ''
-          }`,
-        })
-
-        setState((prev) => ({ ...prev, open: false }))
-      } catch (error) {
-        const errorMessage = extractErrorMessage(error)
-        toast({
-          title: 'Kunde inte skicka SMS',
-          description: errorMessage,
-          variant: 'destructive',
-        })
+        await sendMutation.mutateAsync({ recipient, message })
+      } catch {
+        // Surfaced via onError; swallow so the modal doesn't see a rejection.
       }
     },
-    [state.phoneNumber, state.contactCode, sendSms, toast, queryClient]
+    [recipient, sendMutation]
   )
 
   return {
-    smsModalOpen: state.open,
-    smsRecipientName: state.recipientName,
-    smsPhoneNumber: state.phoneNumber,
+    recipient,
     openSmsModal,
-    onOpenChange,
+    closeSms,
     handleSendSms,
+    isSending: sendMutation.isPending,
   }
 }
 


### PR DESCRIPTION
Prevents unattributed communication-log rows: single sends could reach /sendBulkSms|/sendBulkEmail with a null contactCode, so the dispatch never attached to the customer's timeline.

- Remodel useSingleSms/useSingleEmail state as `recipient | null` (a fully required recipient) instead of a flat object seeded with empty strings, so there is no "open but blank" state that can be sent — openness is derived from having a recipient.
- Send via React Query useMutation (toast + tenant-communication invalidation in onSuccess/onError, isPending for free) instead of hand-rolled async, matching the mutation pattern used across the app.
- Require contactCode on tenantService.sendBulkSms/sendBulkEmail and the useBulkMessaging option types, so every send path (single + bulk) must supply it at compile time.
- Update the three call sites (TenantPage, TenantsTabContent, CurrentTenant) to open with a full recipient object and render the modal only when a recipient exists.