### PR TITLE
log work-order tenant SMS/email to the communication log

### DIFF
--- a/core/src/adapters/communication-adapter/index.ts
+++ b/core/src/adapters/communication-adapter/index.ts
@@ -268,6 +268,8 @@ export const sendWorkOrderSms = async ({
   phoneNumber,
   text,
   externalContractorName,
+  contactCode,
+  triggeredByUser,
 }: WorkOrderSms): Promise<AdapterResult<any, 'error'>> => {
   try {
     const axiosOptions = {
@@ -281,7 +283,13 @@ export const sendWorkOrderSms = async ({
       `${config.communicationService.url}/sendWorkOrderSms`,
       {
         ...axiosOptions,
-        data: { phoneNumber, text, externalContractorName },
+        data: {
+          phoneNumber,
+          text,
+          externalContractorName,
+          contactCode,
+          triggeredByUser,
+        },
       }
     )
 
@@ -300,6 +308,8 @@ export const sendWorkOrderEmail = async ({
   subject,
   text,
   externalContractorName,
+  contactCode,
+  triggeredByUser,
 }: WorkOrderEmail): Promise<AdapterResult<any, 'error'>> => {
   try {
     const axiosOptions = {
@@ -313,7 +323,14 @@ export const sendWorkOrderEmail = async ({
       `${config.communicationService.url}/sendWorkOrderEmail`,
       {
         ...axiosOptions,
-        data: { to, subject, text, externalContractorName },
+        data: {
+          to,
+          subject,
+          text,
+          externalContractorName,
+          contactCode,
+          triggeredByUser,
+        },
       }
     )
 

--- a/core/src/services/work-order-service/index.ts
+++ b/core/src/services/work-order-service/index.ts
@@ -1877,7 +1877,13 @@ export const routes = (router: KoaRouter) => {
    */
   router.post('/work-orders/send-sms', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const { phoneNumber, text, externalContractorName } = ctx.request.body
+    const {
+      phoneNumber,
+      text,
+      externalContractorName,
+      contactCode,
+      triggeredByUser,
+    } = ctx.request.body
 
     if (!phoneNumber || !text) {
       ctx.status = 400
@@ -1893,6 +1899,8 @@ export const routes = (router: KoaRouter) => {
         phoneNumber,
         text,
         externalContractorName,
+        contactCode,
+        triggeredByUser,
       })
 
       if (result.ok) {
@@ -1982,7 +1990,14 @@ export const routes = (router: KoaRouter) => {
    */
   router.post('/work-orders/send-email', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
-    const { to, subject, text, externalContractorName } = ctx.request.body
+    const {
+      to,
+      subject,
+      text,
+      externalContractorName,
+      contactCode,
+      triggeredByUser,
+    } = ctx.request.body
 
     if (to === undefined || subject === undefined || text === undefined) {
       ctx.status = 400
@@ -1999,6 +2014,8 @@ export const routes = (router: KoaRouter) => {
       subject,
       text,
       externalContractorName,
+      contactCode,
+      triggeredByUser,
     })
 
     if (result.ok) {

--- a/libs/types/src/mail-types.ts
+++ b/libs/types/src/mail-types.ts
@@ -32,7 +32,19 @@ interface ParkingSpaceOfferSms extends Sms {
 
 interface WorkOrderSms extends Sms {
   text: string
+  // Sender attribution: the maintenance team name, set only when the Odoo
+  // sender is an external contractor. Shapes the SMS sign-off — NOT the
+  // initiator (use triggeredByUser for that).
   externalContractorName?: string
+  // The Odoo user who triggered the send, logged as triggeredByUser. Optional:
+  // older Odoo callers don't send it yet, and it degrades to null in the log.
+  triggeredByUser?: string
+  // TODO: TEMPORARILY OPTIONAL. Required for communication-log linkage to the
+  // customer timeline, but Odoo deploys independently of OneCore and older Odoo
+  // callers don't send it yet. While optional, the send route only logs the
+  // dispatch when contactCode is present. Once every Odoo caller sends it,
+  // make this required and drop the "only log when present" guard.
+  contactCode?: string
 }
 
 // Sidecar meta on bulk-send requests; shapes the dispatch row, not the send itself.
@@ -84,7 +96,19 @@ interface BulkEmailResult {
 }
 
 interface WorkOrderEmail extends Email {
+  // Sender attribution: the maintenance team name, set only when the Odoo
+  // sender is an external contractor. Selects the email template — NOT the
+  // initiator (use triggeredByUser for that).
   externalContractorName?: string
+  // The Odoo user who triggered the send, logged as triggeredByUser. Optional:
+  // older Odoo callers don't send it yet, and it degrades to null in the log.
+  triggeredByUser?: string
+  // TODO: TEMPORARILY OPTIONAL. Required for communication-log linkage to the
+  // customer timeline, but Odoo deploys independently of OneCore and older Odoo
+  // callers don't send it yet. While optional, the send route only logs the
+  // dispatch when contactCode is present. Once every Odoo caller sends it,
+  // make this required and drop the "only log when present" guard.
+  contactCode?: string
 }
 
 interface InspectionProtocolEmail extends Email {

--- a/services/communication/src/services/infobip-service/routes/email.ts
+++ b/services/communication/src/services/infobip-service/routes/email.ts
@@ -83,6 +83,50 @@ const logParkingSpaceEmail = async (params: {
   }
 }
 
+// Records a tenant-facing work-order email (sent from Odoo via
+// /sendWorkOrderEmail) in the communication log. Strict but non-blocking: the
+// email already went out, so a logging failure must not fail the send. Instead
+// we log loudly for monitoring and return a non-blocking warning the route
+// surfaces via `warnings` (same shape as the bulk routes). Returns [] on
+// success. Mirrors logWorkOrderTenantSms in sms.ts.
+const logWorkOrderTenantEmail = async (params: {
+  to: string
+  contactCode: string
+  subject: string
+  body: string
+  triggeredByUser?: string
+  sendResult: { messages?: Array<{ messageId: string }> }
+}): Promise<string[]> => {
+  try {
+    await logOutboundDispatch({
+      channel: 'email',
+      fromAddress: EMAIL_SENDER,
+      subject: params.subject,
+      body: params.body,
+      messageType: 'work_order_tenant_mail',
+      provider: EMAIL_PROVIDER,
+      triggeredByUser: params.triggeredByUser,
+      recipients: [
+        {
+          contactCode: params.contactCode,
+          toAddress: params.to,
+          externalMessageId: params.sendResult.messages?.[0]?.messageId,
+          status: 'pending',
+        },
+      ],
+    })
+    return []
+  } catch (logError) {
+    // Keep the warning generic for the client; the real error (which can
+    // contain internal/DB detail) stays in logger.error only.
+    logger.error(
+      { err: logError, to: params.to },
+      'Failed to write communication-log entry for work order tenant email'
+    )
+    return ['Communication log failed']
+  }
+}
+
 const toArray = (input: unknown) => {
   if (Array.isArray(input)) {
     return input
@@ -343,8 +387,28 @@ export const routes = (router: KoaRouter) => {
 
     try {
       const result = await sendWorkOrderEmail(emailData)
+
+      // TODO: contactCode is TEMPORARILY OPTIONAL while older Odoo callers are
+      // updated to send it. We only log the dispatch when it's present so the
+      // row attaches to the customer timeline. Once every caller sends it,
+      // make contactCode required and drop this `if`.
+      const warnings = emailData.contactCode
+        ? await logWorkOrderTenantEmail({
+            to: emailData.to,
+            contactCode: emailData.contactCode,
+            subject: emailData.subject,
+            body: emailData.text,
+            triggeredByUser: emailData.triggeredByUser,
+            sendResult: result.data,
+          })
+        : []
+
       ctx.status = 200
-      ctx.body = { content: result.data, ...metadata }
+      ctx.body = {
+        content: result.data,
+        ...(warnings.length && { warnings }),
+        ...metadata,
+      }
     } catch (error: any) {
       ctx.status = 500
       ctx.body = {

--- a/services/communication/src/services/infobip-service/routes/sms.ts
+++ b/services/communication/src/services/infobip-service/routes/sms.ts
@@ -1,7 +1,7 @@
 import KoaRouter from '@koa/router'
 import { validator as phoneValidator, normalize } from 'telefonnummer'
 import { ParkingSpaceOfferSms, WorkOrderSms, BulkSms } from '@onecore/types'
-import { generateRouteMetadata } from '@onecore/utilities'
+import { generateRouteMetadata, logger } from '@onecore/utilities'
 import z from 'zod'
 
 import {
@@ -19,6 +19,47 @@ const SMS_SENDER = 'Mimer'
 const SMS_PROVIDER = 'tele2'
 
 export const MAX_BULK_SMS_RECIPIENTS = 15000
+
+// Records a tenant-facing work-order SMS (sent from Odoo via /sendWorkOrderSms)
+// in the communication log. Strict but non-blocking: the SMS already went out,
+// so a logging failure must not fail the request. Instead we log loudly for
+// monitoring and return a non-blocking warning the route surfaces via
+// `warnings` (same shape as the bulk routes). Returns [] on success.
+const logWorkOrderTenantSms = async (params: {
+  to: string
+  contactCode: string
+  body: string
+  triggeredByUser?: string
+  sendResult: { messages?: Array<{ messageId: string }> }
+}): Promise<string[]> => {
+  try {
+    await logOutboundDispatch({
+      channel: 'sms',
+      fromAddress: SMS_SENDER,
+      body: params.body,
+      messageType: 'work_order_tenant_sms',
+      provider: SMS_PROVIDER,
+      triggeredByUser: params.triggeredByUser,
+      recipients: [
+        {
+          contactCode: params.contactCode,
+          toAddress: params.to,
+          externalMessageId: params.sendResult.messages?.[0]?.messageId,
+          status: 'pending',
+        },
+      ],
+    })
+    return []
+  } catch (logError) {
+    // Keep the warning generic for the client; the real error (which can
+    // contain internal/DB detail) stays in logger.error only.
+    logger.error(
+      { err: logError, to: params.to },
+      'Failed to write communication-log entry for work order tenant SMS'
+    )
+    return ['Communication log failed']
+  }
+}
 
 /**
  * Extract a Swedish phone number from text that may contain names/labels.
@@ -97,8 +138,27 @@ export const routes = (router: KoaRouter) => {
         phoneNumber,
         externalContractorName: sms.externalContractorName,
       })
+
+      // TODO: contactCode is TEMPORARILY OPTIONAL while older Odoo callers are
+      // updated to send it. We only log the dispatch when it's present so the
+      // row attaches to the customer timeline. Once every caller sends it,
+      // make contactCode required and drop this `if`.
+      const warnings = sms.contactCode
+        ? await logWorkOrderTenantSms({
+            to: phoneNumber,
+            contactCode: sms.contactCode,
+            body: sms.text,
+            triggeredByUser: sms.triggeredByUser,
+            sendResult: result,
+          })
+        : []
+
       ctx.status = 200
-      ctx.body = { content: result, ...metadata }
+      ctx.body = {
+        content: result,
+        ...(warnings.length && { warnings }),
+        ...metadata,
+      }
     } catch (error: any) {
       ctx.status = 500
       ctx.body = {

--- a/services/communication/src/services/infobip-service/tests/index.test.ts
+++ b/services/communication/src/services/infobip-service/tests/index.test.ts
@@ -175,6 +175,156 @@ describe('/sendWorkOrderEmail', () => {
   })
 })
 
+describe('work order tenant message logging', () => {
+  const logOutboundDispatchMock = logOutboundDispatch as jest.Mock
+
+  // The SMS adapter returns the Infobip v3 response directly (no `.data`
+  // wrapper, unlike the email adapter), so the route reads messages[0] off it.
+  const smsSendResult = (messageId: string) => ({
+    messages: [
+      {
+        to: '46701234567',
+        messageId,
+        status: {
+          groupId: 1,
+          groupName: 'PENDING',
+          id: 26,
+          name: 'PENDING_ACCEPTED',
+          description: 'Message accepted',
+        },
+      },
+    ],
+  })
+
+  beforeEach(() => {
+    logOutboundDispatchMock.mockReset()
+    logOutboundDispatchMock.mockResolvedValue({ dispatchId: 'test-id' })
+  })
+
+  it('logs the SMS with contactCode, messageId and the triggering user', async () => {
+    jest
+      .spyOn(smsAdapter, 'sendWorkOrderSms')
+      .mockResolvedValue(smsSendResult('mid-wo-sms'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderSms').send({
+      phoneNumber: '0701234567',
+      text: 'Ditt ärende är uppdaterat',
+      contactCode: 'P123456',
+      triggeredByUser: 'Anna Handläggare',
+    })
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).toHaveBeenCalledTimes(1)
+    expect(logOutboundDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'sms',
+        messageType: 'work_order_tenant_sms',
+        triggeredByUser: 'Anna Handläggare',
+        recipients: [
+          expect.objectContaining({
+            contactCode: 'P123456',
+            toAddress: '46701234567',
+            externalMessageId: 'mid-wo-sms',
+            status: 'pending',
+          }),
+        ],
+      })
+    )
+  })
+
+  it('does not log the SMS when contactCode is absent (back-compat)', async () => {
+    jest
+      .spyOn(smsAdapter, 'sendWorkOrderSms')
+      .mockResolvedValue(smsSendResult('mid-wo-sms'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderSms').send({
+      phoneNumber: '0701234567',
+      text: 'hello',
+    })
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a non-blocking warning when SMS logging throws', async () => {
+    jest
+      .spyOn(smsAdapter, 'sendWorkOrderSms')
+      .mockResolvedValue(smsSendResult('mid-wo-sms'))
+    logOutboundDispatchMock.mockRejectedValueOnce(new Error('db down'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderSms').send({
+      phoneNumber: '0701234567',
+      text: 'hello',
+      contactCode: 'P123456',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.warnings).toEqual(['Communication log failed'])
+  })
+
+  it('logs the email with contactCode and messageId', async () => {
+    jest
+      .spyOn(emailAdapter, 'sendWorkOrderEmail')
+      .mockResolvedValue(emailSendResult('mid-wo-mail'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderEmail').send({
+      to: 'tenant@example.com',
+      subject: 'Ditt ärende',
+      text: 'Ditt ärende är uppdaterat',
+      contactCode: 'P123456',
+    })
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).toHaveBeenCalledTimes(1)
+    expect(logOutboundDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: 'email',
+        messageType: 'work_order_tenant_mail',
+        recipients: [
+          expect.objectContaining({
+            contactCode: 'P123456',
+            toAddress: 'tenant@example.com',
+            externalMessageId: 'mid-wo-mail',
+            status: 'pending',
+          }),
+        ],
+      })
+    )
+  })
+
+  it('does not log the email when contactCode is absent (back-compat)', async () => {
+    jest
+      .spyOn(emailAdapter, 'sendWorkOrderEmail')
+      .mockResolvedValue(emailSendResult('mid-wo-mail'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderEmail').send({
+      to: 'tenant@example.com',
+      subject: 'subject',
+      text: 'hello',
+    })
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a non-blocking warning when email logging throws', async () => {
+    jest
+      .spyOn(emailAdapter, 'sendWorkOrderEmail')
+      .mockResolvedValue(emailSendResult('mid-wo-mail'))
+    logOutboundDispatchMock.mockRejectedValueOnce(new Error('db down'))
+
+    const res = await request(app.callback()).post('/sendWorkOrderEmail').send({
+      to: 'tenant@example.com',
+      subject: 'subject',
+      text: 'hello',
+      contactCode: 'P123456',
+    })
+
+    expect(res.status).toBe(200)
+    expect(res.body.warnings).toEqual(['Communication log failed'])
+  })
+})
+
 describe('isMessageEmail', () => {
   it('should return true for valid email objects', () => {
     const validEmail = {


### PR DESCRIPTION
Tenant-facing work-order messages are dispatched from Odoo through /sendWorkOrderSms and /sendWorkOrderEmail, but were never recorded in the communication log. Log them at those routes the same way the parking offer flow does, so they surface on the customer timeline.

Thread optional contactCode and triggeredByUser end-to-end (Odoo -> core routes -> communication-adapter -> send routes). Both are TEMPORARILY optional: Odoo deploys independently of OneCore, so older callers don't send them yet. While optional, the route only logs when contactCode is present (no contactCode -> no log row, no behavior change). A TODO marks where to make contactCode required and drop the guard once every Odoo caller sends it