### PR TITLE
feat: search Odoo errands by number from top search (MIM-1874)

### DIFF
--- a/apps/property-tree/src/features/search/hooks/useSearch.ts
+++ b/apps/property-tree/src/features/search/hooks/useSearch.ts
@@ -1,25 +1,47 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { searchService } from '@/services/api/core'
+import { searchService, workOrderService } from '@/services/api/core'
 import type { components } from '@/services/api/core/generated/api-types'
 import {
   type ContactSearchResult,
   tenantService,
 } from '@/services/api/core/tenantService'
+import type { InternalWorkOrder } from '@/services/api/core/workOrderService'
+import { parseErrandNumber } from '@/shared/lib/odooUtils'
 
 type SearchResult = components['schemas']['SearchResult']
 type ContactResult = ContactSearchResult & { type: 'contact'; id: string }
-export type CombinedSearchResult = SearchResult | ContactResult
+type WorkOrderResult = InternalWorkOrder & { type: 'work-order'; id: string }
+export type CombinedSearchResult =
+  | SearchResult
+  | ContactResult
+  | WorkOrderResult
 
 export function useSearch(query: string) {
   const trimmedQuery = query.trim()
   return useQuery({
     queryKey: ['search', trimmedQuery],
     enabled: Boolean(trimmedQuery) && trimmedQuery.length > 2,
-    queryFn: async () => {
+    queryFn: async (): Promise<CombinedSearchResult[]> => {
+      const errandNumber = parseErrandNumber(trimmedQuery)
+
+      // An `od-<number>` query only ever resolves to a single Odoo errand, so
+      // short-circuit to that endpoint and skip the property/contact backends.
+      if (errandNumber) {
+        const workOrder = await workOrderService
+          .getWorkOrderByCode(errandNumber)
+          .catch(() => null)
+
+        return workOrder
+          ? [{ ...workOrder, type: 'work-order' as const, id: workOrder.code }]
+          : []
+      }
+
+      // Non-errand query: each source is isolated so a slow/failing source
+      // degrades to an empty contribution instead of blanking the whole palette.
       const [propertyResults, contactResults] = await Promise.all([
-        searchService.search(trimmedQuery),
-        tenantService.searchContacts(trimmedQuery),
+        searchService.search(trimmedQuery).catch(() => []),
+        tenantService.searchContacts(trimmedQuery).catch(() => []),
       ])
 
       return [

--- a/apps/property-tree/src/features/search/ui/CommandPalette.tsx
+++ b/apps/property-tree/src/features/search/ui/CommandPalette.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react'
 
 import { debounce } from '@/shared/lib/debounce'
+import { linkToWorkOrderInOdoo } from '@/shared/lib/odooUtils'
 import { paths } from '@/shared/routes'
 
 import { useCommandPalette } from '../hooks/useCommandPalette'
@@ -116,6 +117,17 @@ function getResultProps(item: CombinedSearchResult) {
           propertyCode: item.property.code,
         },
       }
+    case 'work-order':
+      return {
+        icon: Wrench,
+        label: item.code,
+        prefix: '[ÄRENDE]',
+        subtitle: item.caption,
+        // Errands live in Odoo, so selecting opens Odoo in a new tab instead of
+        // navigating within the app.
+        onSelect: () =>
+          linkToWorkOrderInOdoo({ url: item.url, code: item.code }),
+      }
     default:
       return null
   }
@@ -143,8 +155,14 @@ export function CommandPalette() {
     }
   }, [isOpen])
 
-  const handleSelect = (path: string, state: Record<string, unknown>) => {
-    navigate(path, { state })
+  const handleSelect = (
+    props: NonNullable<ReturnType<typeof getResultProps>>
+  ) => {
+    if ('onSelect' in props && props.onSelect) {
+      props.onSelect()
+    } else {
+      navigate(props.path, { state: props.state })
+    }
     close()
   }
 
@@ -163,7 +181,7 @@ export function CommandPalette() {
         {
           const props = getResultProps(searchQuery.data[selectedIndex])
           if (props) {
-            handleSelect(props.path, props.state)
+            handleSelect(props)
           }
         }
         break
@@ -236,7 +254,7 @@ export function CommandPalette() {
                         prefix={props.prefix}
                         subtitle={props.subtitle}
                         isSelected={selectedIndex === index}
-                        onClick={() => handleSelect(props.path, props.state)}
+                        onClick={() => handleSelect(props)}
                       />
                     )
                   })}

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -2992,6 +2992,48 @@ export interface paths {
       }
     }
   }
+  '/work-orders/by-code/{code}': {
+    /**
+     * Get a single work order by its errand code
+     * @description Retrieves a single Odoo work order (errand) by its code. The code may be provided with or without the `od-` prefix (e.g. `od-12345` or `12345`).
+     */
+    get: {
+      parameters: {
+        path: {
+          /** @description The errand code, with or without the `od-` prefix. */
+          code: string
+        }
+      }
+      responses: {
+        /** @description Successfully retrieved the work order. */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['WorkOrder']
+            }
+          }
+        }
+        /** @description Work order not found. */
+        404: {
+          content: {
+            'application/json': {
+              /** @example Work order not found */
+              error?: string
+            }
+          }
+        }
+        /** @description Internal server error. Failed to retrieve the work order. */
+        500: {
+          content: {
+            'application/json': {
+              /** @example Internal server error */
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
   '/work-orders/xpand/{code}': {
     /**
      * Get work order details by rental property id from xpand

--- a/apps/property-tree/src/services/api/core/workOrderService.ts
+++ b/apps/property-tree/src/services/api/core/workOrderService.ts
@@ -10,6 +10,21 @@ export type ExternalWorkOrder = {
 export type WorkOrder = InternalWorkOrder | ExternalWorkOrder
 
 export const workOrderService = {
+  async getWorkOrderByCode(code: string): Promise<InternalWorkOrder | null> {
+    const response = await GET('/work-orders/by-code/{code}', {
+      params: { path: { code } },
+    })
+
+    if (response.response.status === 404) {
+      return null
+    }
+
+    if (response.error) throw response.error
+    if (!response.data.content) throw new Error('No data returned from API')
+
+    return { _tag: 'internal', ...response.data.content }
+  },
+
   async getWorkOrderForProperty(propertyId: string): Promise<WorkOrder[]> {
     const internalWorkOrders = await GET(
       '/work-orders/by-property-id/{propertyId}',

--- a/apps/property-tree/src/shared/lib/odooUtils.ts
+++ b/apps/property-tree/src/shared/lib/odooUtils.ts
@@ -28,6 +28,19 @@ export const linkToWorkOrderInOdoo = (order: OdooLinkableWorkOrder) => {
   )
 }
 
+/**
+ * Extracts the numeric Odoo errand id from a search query.
+ *
+ * Errand codes are formatted `od-<number>`. An errand search must start with the
+ * `od-` prefix (e.g. `od-12345`); this both disambiguates errand searches from
+ * other numeric input and lets short ids like `od-1` clear the top search's
+ * 3-character minimum. Returns the numeric id as a string, otherwise `null`.
+ */
+export const parseErrandNumber = (query: string): string | null => {
+  const match = query.trim().match(/^od-(\d+)$/i)
+  return match ? match[1] : null
+}
+
 export interface WorkOrderMetadata {
   propertyName?: string
   type?: string

--- a/core/src/adapters/work-order-adapter/generated/api-types.ts
+++ b/core/src/adapters/work-order-adapter/generated/api-types.ts
@@ -310,6 +310,67 @@ export interface paths {
       }
     }
   }
+  '/workOrders/id/{id}': {
+    /**
+     * Get a single work order by its Odoo id
+     * @description Retrieves a single work order (errand) by its numeric Odoo id.
+     */
+    get: {
+      parameters: {
+        path: {
+          /** @description The numeric Odoo id of the work order. */
+          id: string
+        }
+      }
+      responses: {
+        /** @description Successfully retrieved the work order. */
+        200: {
+          content: {
+            'application/json': {
+              content?: {
+                workOrder?: components['schemas']['WorkOrder']
+              }
+              /** @description Route metadata */
+              metadata?: Record<string, never>
+            }
+          }
+        }
+        /** @description Bad request. The id is not a valid number. */
+        400: {
+          content: {
+            'application/json': {
+              /** @example Invalid id */
+              error?: string
+              /** @description Route metadata */
+              metadata?: Record<string, never>
+            }
+          }
+        }
+        /** @description Work order not found. */
+        404: {
+          content: {
+            'application/json': {
+              /** @example Work order not found */
+              error?: string
+              /** @description Route metadata */
+              metadata?: Record<string, never>
+            }
+          }
+        }
+        /** @description Internal server error. Failed to retrieve the work order. */
+        500: {
+          content: {
+            'application/json': {
+              /** @example Internal server error */
+              error?: string
+              /** @description Route metadata */
+              metadata?: Record<string, never>
+            }
+          }
+        }
+      }
+    }
+  }
   '/workOrders/xpand/residenceId/{residenceId}': {
     /**
      * Get work orders by residence id from xpand

--- a/core/src/adapters/work-order-adapter/index.ts
+++ b/core/src/adapters/work-order-adapter/index.ts
@@ -397,6 +397,39 @@ export const getXpandWorkOrderDetails = async (
   }
 }
 
+export const getWorkOrderByCode = async (
+  code: string
+): Promise<AdapterResult<OdooWorkOrder, 'not-found' | 'unknown'>> => {
+  try {
+    // Errand codes are formatted `od-<id>`; the id is the Odoo record id.
+    const id = code.replace(/^od-/i, '')
+
+    const fetchResponse = await client().GET('/workOrders/id/{id}', {
+      params: { path: { id } },
+    })
+
+    if (fetchResponse.response.status === 404) {
+      return { ok: false, err: 'not-found' }
+    }
+
+    if (fetchResponse.error) {
+      throw fetchResponse.error
+    }
+
+    if (!fetchResponse.data.content?.workOrder) {
+      throw 'missing-content'
+    }
+
+    return {
+      ok: true,
+      data: fetchResponse.data.content.workOrder,
+    }
+  } catch (error) {
+    logger.error({ error }, 'work-order-adapter.getWorkOrderByCode')
+    return { ok: false, err: 'unknown' }
+  }
+}
+
 export const createWorkOrder = async (
   CreateWorkOrder: components['schemas']['CreateWorkOrderBody']
 ): Promise<AdapterResult<CreateWorkOrderResponse, string>> => {

--- a/core/src/services/work-order-service/index.ts
+++ b/core/src/services/work-order-service/index.ts
@@ -1451,7 +1451,7 @@ export const routes = (router: KoaRouter) => {
         'Error getting work order by code'
       )
       ctx.status = 500
-      ctx.body = { error: result.err, ...metadata }
+      ctx.body = { error: 'Internal server error', ...metadata }
     } catch (error) {
       logger.error(error, 'Error getting work order by code')
       ctx.status = 500

--- a/core/src/services/work-order-service/index.ts
+++ b/core/src/services/work-order-service/index.ts
@@ -1356,6 +1356,111 @@ export const routes = (router: KoaRouter) => {
 
   /**
    * @swagger
+   * /work-orders/by-code/{code}:
+   *   get:
+   *     summary: Get a single work order by its errand code
+   *     tags:
+   *       - Work Order Service
+   *     description: >
+   *       Retrieves a single Odoo work order (errand) by its code. The code may be
+   *       provided with or without the `od-` prefix (e.g. `od-12345` or `12345`).
+   *     parameters:
+   *       - in: path
+   *         name: code
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The errand code, with or without the `od-` prefix.
+   *     responses:
+   *       '200':
+   *         description: Successfully retrieved the work order.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   $ref: '#/components/schemas/WorkOrder'
+   *       '404':
+   *         description: Work order not found.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: Work order not found
+   *       '500':
+   *         description: Internal server error. Failed to retrieve the work order.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('/work-orders/by-code/:code', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+    try {
+      const result = await workOrderAdapter.getWorkOrderByCode(ctx.params.code)
+
+      if (result.ok) {
+        const v = result.data
+        ctx.status = 200
+        ctx.body = {
+          content: {
+            accessCaption: v.AccessCaption,
+            caption: v.Caption,
+            code: v.Code,
+            dueDate: v.DueDate ? new Date(v.DueDate) : null,
+            contactCode: v.ContactCode,
+            description: v.Description,
+            detailsCaption: v.DetailsCaption,
+            externalResource: v.ExternalResource,
+            id: v.Id,
+            lastChanged: new Date(v.LastChanged),
+            priority: v.Priority,
+            registered: new Date(v.Registered),
+            rentalObjectCode: v.RentalObjectCode,
+            status: v.Status,
+            url: v.Url,
+            workOrderRows: v.WorkOrderRows.map((row) => ({
+              description: row.Description,
+              locationCode: row.LocationCode,
+              equipmentCode: row.EquipmentCode,
+            })),
+          } satisfies schemas.CoreWorkOrder,
+          ...metadata,
+        }
+        return
+      }
+
+      if (result.err === 'not-found') {
+        ctx.status = 404
+        ctx.body = { error: 'Work order not found', ...metadata }
+        return
+      }
+
+      logger.error(
+        { err: result.err, metadata },
+        'Error getting work order by code'
+      )
+      ctx.status = 500
+      ctx.body = { error: result.err, ...metadata }
+    } catch (error) {
+      logger.error(error, 'Error getting work order by code')
+      ctx.status = 500
+      ctx.body = { error: 'Internal server error', ...metadata }
+    }
+  })
+
+  /**
+   * @swagger
    * /work-orders/xpand/{code}:
    *   get:
    *     summary: Get work order details by rental property id from xpand

--- a/core/src/services/work-order-service/tests/index.test.ts
+++ b/core/src/services/work-order-service/tests/index.test.ts
@@ -300,6 +300,67 @@ describe('work-order-service index', () => {
     })
   })
 
+  describe('GET /work-orders/by-code/:code', () => {
+    const odooWorkOrderMock = factory.externalOdooWorkOrder.build({
+      Code: 'od-12345',
+      Url: 'https://odoo.example.com/web#id=12345&model=maintenance.request&view_type=form',
+    })
+
+    it('should return the work order and pass the code through unchanged', async () => {
+      const getWorkOrderByCodeSpy = jest
+        .spyOn(workOrderAdapter, 'getWorkOrderByCode')
+        .mockResolvedValue({ ok: true, data: odooWorkOrderMock })
+
+      const res = await request(app.callback()).get(
+        '/work-orders/by-code/od-12345'
+      )
+
+      expect(res.status).toBe(200)
+      expect(() =>
+        schemas.CoreWorkOrderSchema.parse(res.body.content)
+      ).not.toThrow()
+      expect(res.body.content.code).toBe('od-12345')
+      expect(getWorkOrderByCodeSpy).toHaveBeenCalledWith('od-12345')
+    })
+
+    it('should accept a bare numeric code without the od- prefix', async () => {
+      const getWorkOrderByCodeSpy = jest
+        .spyOn(workOrderAdapter, 'getWorkOrderByCode')
+        .mockResolvedValue({ ok: true, data: odooWorkOrderMock })
+
+      const res = await request(app.callback()).get(
+        '/work-orders/by-code/12345'
+      )
+
+      expect(res.status).toBe(200)
+      expect(getWorkOrderByCodeSpy).toHaveBeenCalledWith('12345')
+    })
+
+    it('should return 404 when the work order is not found', async () => {
+      jest
+        .spyOn(workOrderAdapter, 'getWorkOrderByCode')
+        .mockResolvedValue({ ok: false, err: 'not-found' })
+
+      const res = await request(app.callback()).get(
+        '/work-orders/by-code/od-99999'
+      )
+
+      expect(res.status).toBe(404)
+    })
+
+    it('should return 500 on an unknown error', async () => {
+      jest
+        .spyOn(workOrderAdapter, 'getWorkOrderByCode')
+        .mockResolvedValue({ ok: false, err: 'unknown' })
+
+      const res = await request(app.callback()).get(
+        '/work-orders/by-code/od-12345'
+      )
+
+      expect(res.status).toBe(500)
+    })
+  })
+
   describe('GET /work-orders/by-rental-property-id/:rentalPropertyId', () => {
     it('should return work orders by rental property id', async () => {
       const getWorkOrdersByRentalPropertyIdSpy = jest

--- a/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
+++ b/services/work-order/src/services/work-order-service/adapters/odoo-adapter/index.ts
@@ -274,6 +274,40 @@ export const getWorkOrdersByMaintenanceUnitCode = async (
   }
 }
 
+export const getWorkOrderById = async (
+  id: number
+): Promise<WorkOrder | undefined> => {
+  try {
+    await odoo.connect()
+
+    const odooWorkOrders = await odoo.searchRead<OdooWorkOrder>(
+      'maintenance.request',
+      [['id', '=', id]],
+      WORK_ORDER_FIELDS
+    )
+
+    const workOrder = odooWorkOrders[0]
+    if (!workOrder) {
+      return undefined
+    }
+
+    const odooWorkOrderMessages = await odoo.searchRead<OdooWorkOrderMessage>(
+      'mail.message',
+      MESSAGE_DOMAIN([workOrder.id]),
+      MESSAGE_FIELDS
+    )
+
+    return {
+      ...transformWorkOrder(workOrder),
+      Messages: transformMessages(odooWorkOrderMessages),
+      Url: WorkOrderUrl(workOrder.id),
+    }
+  } catch (err) {
+    logger.error({ err }, 'odoo-adapter.getWorkOrderById')
+    throw err
+  }
+}
+
 export const createWorkOrder = async (
   rentalPropertyInfo: RentalProperty,
   tenant: Tenant,

--- a/services/work-order/src/services/work-order-service/index.ts
+++ b/services/work-order/src/services/work-order-service/index.ts
@@ -538,6 +538,120 @@ export const routes = (router: KoaRouter) => {
 
   /**
    * @swagger
+   * /workOrders/id/{id}:
+   *   get:
+   *     summary: Get a single work order by its Odoo id
+   *     tags:
+   *       - Work Order Service
+   *     description: Retrieves a single work order (errand) by its numeric Odoo id.
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The numeric Odoo id of the work order.
+   *     responses:
+   *       '200':
+   *         description: Successfully retrieved the work order.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: object
+   *                   properties:
+   *                     workOrder:
+   *                       $ref: '#/components/schemas/WorkOrder'
+   *                 metadata:
+   *                   type: object
+   *                   description: Route metadata
+   *       '400':
+   *         description: Bad request. The id is not a valid number.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: Invalid id
+   *                 metadata:
+   *                   type: object
+   *                   description: Route metadata
+   *       '404':
+   *         description: Work order not found.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: Work order not found
+   *                 metadata:
+   *                   type: object
+   *                   description: Route metadata
+   *       '500':
+   *         description: Internal server error. Failed to retrieve the work order.
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 error:
+   *                   type: string
+   *                   example: Internal server error
+   *                 metadata:
+   *                   type: object
+   *                   description: Route metadata
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.get('(.*)/workOrders/id/:id', async (ctx) => {
+    const metadata = generateRouteMetadata(ctx)
+
+    const id = Number(ctx.params.id)
+    if (!Number.isInteger(id)) {
+      ctx.status = 400
+      ctx.body = { error: 'Invalid id', ...metadata }
+      return
+    }
+
+    try {
+      const workOrder = await odooAdapter.getWorkOrderById(id)
+
+      if (!workOrder) {
+        ctx.status = 404
+        ctx.body = {
+          error: `Work order with id ${id} not found`,
+          ...metadata,
+        }
+        return
+      }
+
+      ctx.status = 200
+      ctx.body = {
+        content: {
+          workOrder: workOrder satisfies WorkOrder,
+        },
+        ...metadata,
+      }
+    } catch (error: unknown) {
+      ctx.status = 500
+
+      if (error instanceof Error) {
+        ctx.body = {
+          error: error.message,
+          ...metadata,
+        }
+      }
+    }
+  })
+
+  /**
+   * @swagger
    * /workOrders/xpand/residenceId/{residenceId}:
    *   get:
    *     summary: Get work orders by residence id from xpand

--- a/services/work-order/src/services/work-order-service/tests/adapters/odoo-adapter/index.test.ts
+++ b/services/work-order/src/services/work-order-service/tests/adapters/odoo-adapter/index.test.ts
@@ -23,7 +23,10 @@ jest.mock('@onecore/utilities', () => ({
   generateRouteMetadata: jest.fn(() => ({})),
 }))
 
-import { createWorkOrder } from '../../../adapters/odoo-adapter'
+import {
+  createWorkOrder,
+  getWorkOrderById,
+} from '../../../adapters/odoo-adapter'
 
 describe('odoo-adapter createWorkOrder', () => {
   const setupCreateMocks = () => {
@@ -155,5 +158,43 @@ describe('odoo-adapter createWorkOrder', () => {
       ),
     })
     expect(message).toMatch(/maintenance unit code provided but not found/i)
+  })
+})
+
+describe('odoo-adapter getWorkOrderById', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    odooMock.connect.mockResolvedValue(undefined)
+  })
+
+  it('returns the transformed work order with url and messages when found', async () => {
+    const odooWorkOrder = factory.odooWorkOrder.build({ id: 12345 })
+    const odooMessage = factory.odooWorkOrderMessage.build({ res_id: 12345 })
+
+    odooMock.searchRead
+      .mockResolvedValueOnce([odooWorkOrder]) // maintenance.request
+      .mockResolvedValueOnce([odooMessage]) // mail.message
+
+    const result = await getWorkOrderById(12345)
+
+    // maintenance.request queried by id
+    expect(odooMock.searchRead.mock.calls[0][0]).toBe('maintenance.request')
+    expect(odooMock.searchRead.mock.calls[0][1]).toEqual([['id', '=', 12345]])
+
+    expect(result).toMatchObject({
+      Code: 'od-12345',
+      Url: expect.stringContaining('id=12345'),
+    })
+    expect(result?.Messages).toHaveLength(1)
+  })
+
+  it('returns undefined when no work order matches the id', async () => {
+    odooMock.searchRead.mockResolvedValueOnce([]) // maintenance.request
+
+    const result = await getWorkOrderById(999)
+
+    expect(result).toBeUndefined()
+    // Should not query messages when there is no work order
+    expect(odooMock.searchRead).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## MIM-1874 — Söka på ärende från toppsök

Lets kundcenter/kvartersvärdar/bosociala jump straight to an Odoo errand
from the property-tree top search. Type `od-12345` (or `od-1`) and get a
validated **[ÄRENDE]** result that opens the errand in Odoo in a new tab.

### How it works
- **New lookup-by-id path:** work-order service `GET /workOrders/id/:id`
  → core `GET /work-orders/by-code/:code`. The `od-` code is just the Odoo
  record id, so no onecore-odoo changes were needed.
- **Detection:** an errand search must start with `od-` (`parseErrandNumber`).
  This disambiguates from other numeric input and clears the 3-char minimum.
- **Search behavior:** an `od-…` query hits **only** the errand endpoint —
  the property/contact backends aren't touched. Non-errand queries never hit
  Odoo. Each source is failure-isolated, so a slow/down source degrades to
  empty instead of blanking the whole palette.

### Testing
Run onecore + odoo locally. Search a real errand id as `od-<id>` → row appears → click
opens Odoo. A non-existent id correctly shows nothing.