### PR TITLE
Added ströfaktura to sidebar

### DIFF
--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -2992,6 +2992,48 @@ export interface paths {
       }
     }
   }
+  '/work-orders/by-code/{code}': {
+    /**
+     * Get a single work order by its errand code
+     * @description Retrieves a single Odoo work order (errand) by its code. The code may be provided with or without the `od-` prefix (e.g. `od-12345` or `12345`).
+     */
+    get: {
+      parameters: {
+        path: {
+          /** @description The errand code, with or without the `od-` prefix. */
+          code: string
+        }
+      }
+      responses: {
+        /** @description Successfully retrieved the work order. */
+        200: {
+          content: {
+            'application/json': {
+              content?: components['schemas']['WorkOrder']
+            }
+          }
+        }
+        /** @description Work order not found. */
+        404: {
+          content: {
+            'application/json': {
+              /** @example Work order not found */
+              error?: string
+            }
+          }
+        }
+        /** @description Internal server error. Failed to retrieve the work order. */
+        500: {
+          content: {
+            'application/json': {
+              /** @example Internal server error */
+              error?: string
+            }
+          }
+        }
+      }
+    }
+  }
   '/work-orders/xpand/{code}': {
     /**
      * Get work order details by rental property id from xpand

--- a/apps/property-tree/src/shared/routes/index.ts
+++ b/apps/property-tree/src/shared/routes/index.ts
@@ -27,6 +27,7 @@ export const routes = {
   rentalBlocks: '/sparrar',
   leases: '/hyreskontrakt',
   inspections: '/besiktningar',
+  economy: '/economy',
   components: '/komponenter',
   callback: '/callback',
 } as const

--- a/apps/property-tree/src/widgets/dashboard/config.ts
+++ b/apps/property-tree/src/widgets/dashboard/config.ts
@@ -162,7 +162,7 @@ export const dashboardCards: DashboardCard[] = [
     title: 'Skapa ströfaktura',
     icon: Receipt,
     description: 'Skapa ströfakturor',
-    path: '/economy',
+    path: routes.economy,
     isExternal: false,
     isDisabled: false,
   },

--- a/apps/property-tree/src/widgets/sidebar/ui/SidebarNavigation.tsx
+++ b/apps/property-tree/src/widgets/sidebar/ui/SidebarNavigation.tsx
@@ -12,6 +12,7 @@ import {
   FileText,
   Home,
   LayoutGrid,
+  Receipt,
   Settings,
   ShieldX,
 } from 'lucide-react'
@@ -158,6 +159,11 @@ function SidebarNavigationContent() {
           to={routes.inspections}
           icon={ClipboardList}
           label="Besiktningar"
+        />
+        <SidebarNavLink
+          to={routes.economy}
+          icon={Receipt}
+          label="Skapa ströfaktura"
         />
         <SidebarNavLink
           to={routes.components}


### PR DESCRIPTION
Add ströfaktura to the OneCore side menu.

New routes.economy constant (/economy), replacing the hardcoded path.
Sidebar link "Skapa ströfaktura" (Receipt icon) after Besiktningar.
Dashboard card now points at routes.economy too.
