### PR TITLE
communication log: reconstruct real parking-space email content

### DIFF
--- a/services/communication/src/services/infobip-service/adapters/email-adapter.ts
+++ b/services/communication/src/services/infobip-service/adapters/email-adapter.ts
@@ -13,19 +13,25 @@ import {
 import { logger } from '@onecore/utilities'
 
 import { EmailV4Message, EmailV4Response } from './types'
+import {
+  AcceptParkingSpaceOfferTemplateId,
+  AdditionalParkingSpaceOfferTemplateId,
+  NonScoredParkingSpaceApprovedTemplateId,
+  NonScoredParkingSpaceDeniedTemplateId,
+  ParkingSpaceAssignedToOtherTemplateId,
+  ReplaceParkingSpaceOfferTemplateId,
+  WorkOrderEmailTemplateId,
+  WorkOrderExternalContractorEmailTemplateId,
+} from './infobip-template-ids'
+import {
+  dateFormatter,
+  formatToSwedishCurrency,
+  getParkingSpaceImageUrl,
+} from './parking-space-formatting'
 
 // Response from POSTing to Infobip's /email/4/messages (outbound email send).
 // Order of `messages` matches the destinations array passed in.
 export type InfobipSendEmailResponse = EmailV4Response
-
-const AcceptParkingSpaceOfferTemplateId = 205000000030455
-const AdditionalParkingSpaceOfferTemplateId = 200000000092027
-const ReplaceParkingSpaceOfferTemplateId = 200000000094058
-const ParkingSpaceAssignedToOtherTemplateId = 200000000092051
-const WorkOrderEmailTemplateId = 200000000146435
-const WorkOrderExternalContractorEmailTemplateId = 200000000173744
-const NonScoredParkingSpaceApprovedTemplateId = 205000000040764
-const NonScoredParkingSpaceDeniedTemplateId = 205000000040765
 
 // Email sender identity
 const EMAIL_SENDER = 'Bostads Mimer AB <noreply@mimer.nu>'
@@ -86,11 +92,6 @@ export const sendEmail = async (message: Email) => {
     logger.error(error)
     throw error
   }
-}
-
-const getParkingSpaceImageUrl = (rentalObjectCode: string) => {
-  const identifier = rentalObjectCode.slice(0, 7)
-  return `https://pub.mimer.nu/bofaktablad/mediabank/Bilplatser/${identifier}.jpg`
 }
 
 export const sendParkingSpaceOffer = async (email: ParkingSpaceOfferEmail) => {
@@ -247,24 +248,6 @@ export const sendNonScoredParkingSpaceDenied = async (
     throw error
   }
 }
-
-const formatToSwedishCurrency = (numberStr: string) => {
-  const number = parseFloat(numberStr)
-
-  if (isNaN(number)) {
-    return '0 kr'
-  }
-
-  const formattedNumber = new Intl.NumberFormat('sv-SE', {
-    //render max 2 decimals if there are decimals, otherwise render 0 decimals
-    minimumFractionDigits: number % 1 === 0 ? 0 : 2,
-    maximumFractionDigits: number % 1 === 0 ? 0 : 2,
-  }).format(number)
-
-  return formattedNumber + ' kr'
-}
-
-const dateFormatter = new Intl.DateTimeFormat('sv-SE', { timeZone: 'UTC' })
 
 export const sendParkingSpaceAssignedToOther = async (
   emails: ParkingSpaceNotificationEmail[]

--- a/services/communication/src/services/infobip-service/adapters/email-template-render.ts
+++ b/services/communication/src/services/infobip-service/adapters/email-template-render.ts
@@ -1,0 +1,178 @@
+// fetch is stable in Node.js 20 LTS but eslint-plugin-n still flags it as experimental
+/* eslint-disable n/no-unsupported-features/node-builtins */
+import config from '../../../common/config'
+import { logger } from '@onecore/utilities'
+import type {
+  NonScoredParkingSpaceApprovedEmail,
+  ParkingSpaceOfferEmail,
+} from '@onecore/types'
+
+import {
+  dateFormatter,
+  formatToSwedishCurrency,
+  getParkingSpaceImageUrl,
+} from './parking-space-formatting'
+
+// Reconstructs a sent parking-space email as plaintext for the communication
+// log: fetch the template (Infobip only merges at send time), rebuild the same
+// placeholders, and substitute. The send path is untouched.
+
+// Infobip email template (GET /email/1/templates/{id}); {{tokens}} unmerged.
+export type EmailTemplate = { subject: string | null; html: string }
+
+// Fetches a template for the log only. Returns null on any failure (never
+// throws) so it can't fail a send that already went out.
+export const getEmailTemplate = async (
+  templateId: number
+): Promise<EmailTemplate | null> => {
+  try {
+    const baseUrl = config.infobip.baseUrl.replace(/\/$/, '')
+    const response = await fetch(`${baseUrl}/email/1/templates/${templateId}`, {
+      headers: {
+        Authorization: `App ${config.infobip.apiKey}`,
+        Accept: 'application/json',
+      },
+    })
+
+    if (!response.ok) {
+      logger.warn(
+        { templateId, status: response.status },
+        'Could not fetch Infobip email template for communication log'
+      )
+      return null
+    }
+
+    const json = (await response.json()) as { subject?: string; html?: string }
+    return { subject: json.subject ?? null, html: json.html ?? '' }
+  } catch (error) {
+    logger.warn(
+      { err: error, templateId },
+      'Error fetching Infobip email template for communication log'
+    )
+    return null
+  }
+}
+
+// Any parking-space email shape; the builder reads whatever fields are present.
+// Derived from the @onecore/types payloads (offer carries firstName/deadlineDate/
+// offerURL, non-scored carries leaseId) so a field rename surfaces here.
+type ParkingSpaceEmailLike = Partial<
+  Pick<
+    ParkingSpaceOfferEmail & NonScoredParkingSpaceApprovedEmail,
+    | 'address'
+    | 'firstName'
+    | 'availableFrom'
+    | 'deadlineDate'
+    | 'rent'
+    | 'type'
+    | 'parkingSpaceId'
+    | 'objectId'
+    | 'offerURL'
+    | 'leaseId'
+  >
+>
+
+// Rebuilds the sent placeholders (same formatting as the send path). Superset of
+// all templates' tokens; the renderer ignores ones a given template doesn't use.
+export const buildParkingSpacePlaceholders = (
+  email: ParkingSpaceEmailLike
+): Record<string, string> => {
+  const placeholders: Record<string, string> = {}
+  const set = (key: string, value: string | undefined) => {
+    if (value !== undefined) placeholders[key] = value
+  }
+
+  set('address', email.address)
+  set('firstName', email.firstName)
+  set('type', email.type)
+  set('parkingSpaceId', email.parkingSpaceId)
+  set('objectId', email.objectId)
+  set('offerURL', email.offerURL)
+  set('leaseId', email.leaseId)
+  if (email.availableFrom !== undefined) {
+    set('availableFrom', dateFormatter.format(new Date(email.availableFrom)))
+  }
+  if (email.deadlineDate !== undefined) {
+    set('deadlineDate', dateFormatter.format(new Date(email.deadlineDate)))
+  }
+  if (email.rent !== undefined) {
+    set('rent', formatToSwedishCurrency(email.rent))
+  }
+  if (email.parkingSpaceId !== undefined) {
+    set('parkingSpaceImage', getParkingSpaceImageUrl(email.parkingSpaceId))
+  }
+
+  return placeholders
+}
+
+const decodeEntities = (s: string): string =>
+  s
+    .replace(/&nbsp;|&#160;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+
+// Best-effort HTML → plaintext; {{tokens}} pass through for merging.
+export const htmlToText = (html: string): string =>
+  decodeEntities(
+    html
+      .replace(/<!--[\s\S]*?-->/g, '')
+      .replace(/<(head|style|script)[\s\S]*?<\/\1>/gi, '')
+      // Keep link targets that live only in the href (e.g. the offer link):
+      // "<a href="x">text</a>" → "text (x)". Skip mailto:/tel:, self-URL links,
+      // and Infobip {$...} system placeholders (e.g. {$unsubscribe}) we never
+      // resolve — for those the visible text alone is enough.
+      .replace(
+        /<a\b[^>]*?href=["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
+        (_m, href: string, text: string) =>
+          /^\s*(mailto:|tel:)/i.test(href) ||
+          /\{\$/.test(href) ||
+          text.trim() === href.trim()
+            ? text
+            : `${text} (${href})`
+      )
+      .replace(/<\/(p|div|tr|h[1-6]|li|table)>/gi, '\n')
+      // Cells share a line; separate them so "label" and "value" don't merge.
+      .replace(/<\/(td|th)>/gi, ' ')
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+  )
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\n[ \t]+/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+
+const TOKEN_RE = /\{\{\s*(\w+)\s*\}\}/g
+
+// Substitutes {{token}}; unknown token → empty, malformed {$x} left as-is.
+export const fillTokens = (
+  text: string,
+  placeholders: Record<string, string>
+): string =>
+  text.replace(TOKEN_RE, (_match, key: string) =>
+    key in placeholders ? placeholders[key] : ''
+  )
+
+// Merges rebuilt placeholders into a fetched template → plaintext. Returns null
+// on any failure (never throws) so it can't fail a send that already went out;
+// the route then falls back to the static label.
+export const renderTemplate = (
+  template: EmailTemplate,
+  email: ParkingSpaceEmailLike
+): { subject: string; body: string } | null => {
+  try {
+    const placeholders = buildParkingSpacePlaceholders(email)
+    return {
+      subject: fillTokens(template.subject ?? '', placeholders),
+      body: fillTokens(htmlToText(template.html), placeholders),
+    }
+  } catch (error) {
+    logger.warn(
+      { err: error },
+      'Failed to render Infobip email template for communication log'
+    )
+    return null
+  }
+}

--- a/services/communication/src/services/infobip-service/adapters/infobip-template-ids.ts
+++ b/services/communication/src/services/infobip-service/adapters/infobip-template-ids.ts
@@ -1,0 +1,11 @@
+// Infobip email template ids. Referenced by the send path (email-adapter.ts,
+// which picks the template to send) and the communication-log routes (which
+// fetch the same template to reconstruct the sent content for the log).
+export const AdditionalParkingSpaceOfferTemplateId = 200000000092027
+export const ReplaceParkingSpaceOfferTemplateId = 200000000094058
+export const AcceptParkingSpaceOfferTemplateId = 205000000030455
+export const NonScoredParkingSpaceApprovedTemplateId = 205000000040764
+export const NonScoredParkingSpaceDeniedTemplateId = 205000000040765
+export const ParkingSpaceAssignedToOtherTemplateId = 200000000092051
+export const WorkOrderEmailTemplateId = 200000000146435
+export const WorkOrderExternalContractorEmailTemplateId = 200000000173744

--- a/services/communication/src/services/infobip-service/adapters/parking-space-formatting.ts
+++ b/services/communication/src/services/infobip-service/adapters/parking-space-formatting.ts
@@ -1,0 +1,29 @@
+// Value formatting for parking-space email placeholders, shared by the send
+// path (email-adapter.ts) and the communication-log render path
+// (email-template-render.ts) so the logged copy is formatted exactly like the
+// email that was sent.
+
+export const dateFormatter = new Intl.DateTimeFormat('sv-SE', {
+  timeZone: 'UTC',
+})
+
+export const formatToSwedishCurrency = (numberStr: string) => {
+  const number = parseFloat(numberStr)
+
+  if (isNaN(number)) {
+    return '0 kr'
+  }
+
+  const formattedNumber = new Intl.NumberFormat('sv-SE', {
+    //render max 2 decimals if there are decimals, otherwise render 0 decimals
+    minimumFractionDigits: number % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: number % 1 === 0 ? 0 : 2,
+  }).format(number)
+
+  return formattedNumber + ' kr'
+}
+
+export const getParkingSpaceImageUrl = (rentalObjectCode: string) => {
+  const identifier = rentalObjectCode.slice(0, 7)
+  return `https://pub.mimer.nu/bofaktablad/mediabank/Bilplatser/${identifier}.jpg`
+}

--- a/services/communication/src/services/infobip-service/routes/email.ts
+++ b/services/communication/src/services/infobip-service/routes/email.ts
@@ -26,6 +26,17 @@ import {
   sendNonScoredParkingSpaceDenied,
 } from '../adapters/email-adapter'
 import {
+  getEmailTemplate,
+  renderTemplate,
+} from '../adapters/email-template-render'
+import {
+  AdditionalParkingSpaceOfferTemplateId,
+  ReplaceParkingSpaceOfferTemplateId,
+  AcceptParkingSpaceOfferTemplateId,
+  NonScoredParkingSpaceApprovedTemplateId,
+  NonScoredParkingSpaceDeniedTemplateId,
+} from '../adapters/infobip-template-ids'
+import {
   sendEmailInfobipSdk,
   sendInspectionProtocolEmail,
 } from '../adapters/infobip-adapter'
@@ -195,12 +206,20 @@ export const routes = (router: KoaRouter) => {
     }
     try {
       const result = await sendParkingSpaceOffer(emailData)
+      const templateId =
+        emailData.applicationType === 'Replace'
+          ? ReplaceParkingSpaceOfferTemplateId
+          : AdditionalParkingSpaceOfferTemplateId
+      const template = await getEmailTemplate(templateId)
+      const rendered = template ? renderTemplate(template, emailData) : null
       await logParkingSpaceEmail({
         messageType: 'parking_space_offer',
         to: emailData.to,
         contactCode: emailData.contactCode,
-        subject: emailData.subject,
-        body: emailData.text,
+        // `||` not `??`: an empty rendered subject/body (e.g. a template with no
+        // subject) is never the intended log value, so fall back to the label.
+        subject: rendered?.subject || emailData.subject,
+        body: rendered?.body || emailData.text,
         sendResult: result.data,
       })
       ctx.status = 200
@@ -236,12 +255,16 @@ export const routes = (router: KoaRouter) => {
 
       try {
         const result = await sendParkingSpaceAcceptOffer(body)
+        const template = await getEmailTemplate(
+          AcceptParkingSpaceOfferTemplateId
+        )
+        const rendered = template ? renderTemplate(template, body) : null
         await logParkingSpaceEmail({
           messageType: 'parking_space_accept_offer',
           to: body.to,
           contactCode: body.contactCode,
-          subject: body.subject,
-          body: body.text,
+          subject: rendered?.subject || body.subject,
+          body: rendered?.body || body.text,
           sendResult: result.data,
         })
         ctx.status = 204
@@ -283,13 +306,17 @@ export const routes = (router: KoaRouter) => {
 
       try {
         const result = await sendNonScoredParkingSpaceApproved(body)
+        const template = await getEmailTemplate(
+          NonScoredParkingSpaceApprovedTemplateId
+        )
+        const rendered = template ? renderTemplate(template, body) : null
         await logParkingSpaceEmail({
           messageType: 'non_scored_parking_space_approved',
           to: body.to,
           contactCode: body.contactCode,
           triggeredBy: body.triggeredBy,
-          subject: body.subject,
-          body: body.text,
+          subject: rendered?.subject || body.subject,
+          body: rendered?.body || body.text,
           sendResult: result.data,
         })
         ctx.status = 204
@@ -330,13 +357,17 @@ export const routes = (router: KoaRouter) => {
 
       try {
         const result = await sendNonScoredParkingSpaceDenied(body)
+        const template = await getEmailTemplate(
+          NonScoredParkingSpaceDeniedTemplateId
+        )
+        const rendered = template ? renderTemplate(template, body) : null
         await logParkingSpaceEmail({
           messageType: 'non_scored_parking_space_denied',
           to: body.to,
           contactCode: body.contactCode,
           triggeredBy: body.triggeredBy,
-          subject: body.subject,
-          body: body.text,
+          subject: rendered?.subject || body.subject,
+          body: rendered?.body || body.text,
           sendResult: result.data,
         })
         ctx.status = 204

--- a/services/communication/src/services/infobip-service/tests/email-template-render.test.ts
+++ b/services/communication/src/services/infobip-service/tests/email-template-render.test.ts
@@ -1,0 +1,140 @@
+import {
+  buildParkingSpacePlaceholders,
+  fillTokens,
+  htmlToText,
+  renderTemplate,
+} from '../adapters/email-template-render'
+
+describe('htmlToText', () => {
+  it('strips markup and turns block tags into line breaks', () => {
+    const html = '<p>Hej {{firstName}}!</p><p>Adress: {{address}}</p>'
+    expect(htmlToText(html)).toBe('Hej {{firstName}}!\nAdress: {{address}}')
+  })
+
+  it('decodes the entities Infobip emits and collapses whitespace', () => {
+    const html = '<p>Mimer&#160;&amp;&nbsp;co</p>Rad2'
+    expect(htmlToText(html)).toBe('Mimer & co\nRad2')
+  })
+
+  it('drops head/style/script and comments', () => {
+    const html = '<head><style>p{color:red}</style></head><!-- x --><p>Kvar</p>'
+    expect(htmlToText(html)).toBe('Kvar')
+  })
+
+  it('leaves placeholder tokens untouched', () => {
+    expect(htmlToText('<p>Hyra: {{rent}}</p>')).toContain('{{rent}}')
+  })
+
+  it('keeps href targets that would otherwise vanish with the tag', () => {
+    const html = '<p>Se erbjudandet: <a href="{{offerURL}}">här</a></p>'
+    expect(htmlToText(html)).toBe('Se erbjudandet: här ({{offerURL}})')
+  })
+
+  it('does not repeat mailto:/tel: links whose text is the address/number', () => {
+    const html =
+      '<p><a href="mailto:post@mimer.nu">post@mimer.nu</a>, ' +
+      '<a href="tel:+4621397000">021-39 70 00</a></p>'
+    expect(htmlToText(html)).toBe('post@mimer.nu, 021-39 70 00')
+  })
+
+  it('drops {$...} system-placeholder hrefs like the unsubscribe link', () => {
+    const html = '<p>Väljer du <a href="{$unsubscribe}">UNSUBSCRIBE</a></p>'
+    expect(htmlToText(html)).toBe('Väljer du UNSUBSCRIBE')
+  })
+
+  it('separates table cells so label and value do not run together', () => {
+    const html = '<table><tr><td>Hyra:</td><td>{{rent}}</td></tr></table>'
+    expect(htmlToText(html)).toBe('Hyra: {{rent}}')
+  })
+})
+
+describe('fillTokens', () => {
+  it('substitutes matching placeholders', () => {
+    expect(fillTokens('Hej {{firstName}}', { firstName: 'Anna' })).toBe(
+      'Hej Anna'
+    )
+  })
+
+  it('renders a token with no matching placeholder as empty', () => {
+    expect(fillTokens('Hej {{firstName}}!', {})).toBe('Hej !')
+  })
+
+  it('leaves malformed Infobip tokens like {$address} untouched', () => {
+    expect(fillTokens('på {$address}.', { address: 'Storgatan 1' })).toBe(
+      'på {$address}.'
+    )
+  })
+})
+
+describe('buildParkingSpacePlaceholders', () => {
+  it('formats rent and dates and maps the offer fields', () => {
+    const placeholders = buildParkingSpacePlaceholders({
+      address: 'Storgatan 1',
+      firstName: 'Anna',
+      availableFrom: '2026-08-01T00:00:00.000Z',
+      deadlineDate: '2026-07-20T00:00:00.000Z',
+      rent: '650',
+      type: 'Bilplats',
+      parkingSpaceId: '1234567',
+      objectId: '42',
+      offerURL: 'https://example.com/offer',
+    })
+
+    expect(placeholders).toMatchObject({
+      address: 'Storgatan 1',
+      firstName: 'Anna',
+      rent: '650 kr',
+      availableFrom: '2026-08-01',
+      deadlineDate: '2026-07-20',
+      offerURL: 'https://example.com/offer',
+    })
+    expect(placeholders.parkingSpaceImage).toContain('1234567')
+  })
+
+  it('omits fields that are absent on the email (one builder, all types)', () => {
+    const placeholders = buildParkingSpacePlaceholders({
+      address: 'Storgatan 1',
+      rent: '650',
+      type: 'Bilplats',
+      parkingSpaceId: '1234567',
+      objectId: '42',
+    })
+
+    expect(placeholders.rent).toBe('650 kr')
+    expect(placeholders).not.toHaveProperty('offerURL')
+    expect(placeholders).not.toHaveProperty('leaseId')
+    expect(placeholders).not.toHaveProperty('firstName')
+  })
+})
+
+describe('renderTemplate', () => {
+  it('merges the sent placeholders into the fetched template as plaintext', () => {
+    const rendered = renderTemplate(
+      {
+        subject: 'Erbjudande om bilplats',
+        html:
+          '<p>Hej {{firstName}}!</p><p>Adress: {{address}}</p>' +
+          '<p>Hyra: {{rent}}</p>',
+      },
+      { firstName: 'Anna', address: 'Storgatan 1', rent: '650' }
+    )
+
+    expect(rendered).toEqual({
+      subject: 'Erbjudande om bilplats',
+      body: 'Hej Anna!\nAdress: Storgatan 1\nHyra: 650 kr',
+    })
+  })
+
+  it('handles a null template subject', () => {
+    const rendered = renderTemplate({ subject: null, html: '<p>Hej</p>' }, {})
+    expect(rendered).toEqual({ subject: '', body: 'Hej' })
+  })
+
+  it('returns null (route falls back) when a field cannot be rendered', () => {
+    const rendered = renderTemplate(
+      { subject: 'x', html: '<p>{{availableFrom}}</p>' },
+      { availableFrom: 'not-a-date' }
+    )
+    expect(rendered).toBeNull()
+  })
+})

--- a/services/communication/src/services/infobip-service/tests/index.test.ts
+++ b/services/communication/src/services/infobip-service/tests/index.test.ts
@@ -2,10 +2,11 @@ import request from 'supertest'
 import KoaRouter from '@koa/router'
 import Koa from 'koa'
 import bodyParser from 'koa-bodyparser'
-import { Email, WorkOrderSms, BulkSms } from '@onecore/types'
+import { Email, WorkOrderSms } from '@onecore/types'
 
 import { isMessageEmail, isValidWorkOrderSms, isValidBulkSms } from '../index'
 import * as emailAdapter from '../adapters/email-adapter'
+import * as templateRender from '../adapters/email-template-render'
 import * as smsAdapter from '../adapters/sms-adapter'
 import { routes } from '../'
 import { logOutboundDispatch } from '../../communication-log-service/adapters/db'
@@ -541,9 +542,23 @@ describe('/sendBulkSms logging', () => {
 describe('parking space offer email logging', () => {
   const logOutboundDispatchMock = logOutboundDispatch as jest.Mock
 
+  // The route builds the templateId + placeholders from the request body (via
+  // parking-space-requests) and renders the log by fetching the Infobip
+  // template. Default to a generic template with the tokens the routes use;
+  // individual tests override it as needed.
+  let getTemplateMock: jest.SpyInstance
+
   beforeEach(() => {
     logOutboundDispatchMock.mockReset()
     logOutboundDispatchMock.mockResolvedValue({ dispatchId: 'test-id' })
+    getTemplateMock = jest
+      .spyOn(templateRender, 'getEmailTemplate')
+      .mockResolvedValue({
+        subject: 'Standardämne',
+        html:
+          '<p>Hej {{firstName}}!</p><p>Adress: {{address}}</p>' +
+          '<p>Hyra: {{rent}}</p><p>Kontraktsnummer: {{leaseId}}</p>',
+      })
   })
 
   const offerBody = {
@@ -563,7 +578,13 @@ describe('parking space offer email logging', () => {
     offerURL: 'https://example.com/offer/42',
   }
 
-  it('logs the offer email to the communication log with contactCode and messageId', async () => {
+  it('logs the offer email with content rendered from the fetched template', async () => {
+    getTemplateMock.mockResolvedValue({
+      subject: 'Du har fått ett erbjudande om en bilplats',
+      html:
+        '<p>Hej {{firstName}}!</p><p>Adress: {{address}}</p>' +
+        '<p>Hyra: {{rent}}</p>',
+    })
     jest
       .spyOn(emailAdapter, 'sendParkingSpaceOffer')
       .mockResolvedValue(emailSendResult('mid-offer'))
@@ -579,6 +600,9 @@ describe('parking space offer email logging', () => {
         channel: 'email',
         messageType: 'parking_space_offer',
         triggeredByUser: 'Automatiskt utskick',
+        // Rendered from the fetched Infobip template, not the static label.
+        subject: 'Du har fått ett erbjudande om en bilplats',
+        body: expect.stringContaining('Hej Test!'),
         recipients: [
           expect.objectContaining({
             contactCode: 'P123456',
@@ -587,6 +611,53 @@ describe('parking space offer email logging', () => {
             status: 'pending',
           }),
         ],
+      })
+    )
+    // The logged body carries the real details, not a repeated title.
+    const loggedBody = logOutboundDispatchMock.mock.calls[0][0].body as string
+    expect(loggedBody).toContain('Adress: Testgatan 1')
+    expect(loggedBody).toContain('Hyra: 500 kr')
+  })
+
+  it('falls back to the label when the template cannot be fetched', async () => {
+    getTemplateMock.mockResolvedValue(null)
+    jest
+      .spyOn(emailAdapter, 'sendParkingSpaceOffer')
+      .mockResolvedValue(emailSendResult('mid-offer'))
+
+    const res = await request(app.callback())
+      .post('/sendParkingSpaceOffer')
+      .send(offerBody)
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: offerBody.subject,
+        body: offerBody.text,
+      })
+    )
+  })
+
+  it('falls back to the label subject when the fetched template has no subject', async () => {
+    getTemplateMock.mockResolvedValue({
+      subject: '',
+      html: '<p>Hej {{firstName}}!</p>',
+    })
+    jest
+      .spyOn(emailAdapter, 'sendParkingSpaceOffer')
+      .mockResolvedValue(emailSendResult('mid-offer'))
+
+    const res = await request(app.callback())
+      .post('/sendParkingSpaceOffer')
+      .send(offerBody)
+
+    expect(res.status).toBe(200)
+    expect(logOutboundDispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // Empty rendered subject must not overwrite the meaningful label; the
+        // body still renders from the (non-empty) template html.
+        subject: offerBody.subject,
+        body: expect.stringContaining('Hej Test!'),
       })
     )
   })
@@ -661,6 +732,8 @@ describe('parking space offer email logging', () => {
     expect(logOutboundDispatchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         messageType: 'non_scored_parking_space_approved',
+        subject: 'Standardämne',
+        body: expect.stringContaining('Kontraktsnummer: L-1'),
       })
     )
   })


### PR DESCRIPTION
Now, after each parking-space send, fetch the sent template (GET /email/1/templates/{id}), rebuild the same placeholders, convert the HTML to plaintext, and store that as the dispatch subject/body. Falls back to the old label if the fetch fails, so logging stays non-blocking and the send path is untouched.

- infobip-template-ids.ts / parking-space-formatting.ts: template ids + value formatters shared by the send and log paths
- email-template-render.ts: getEmailTemplate + one buildParkingSpacePlaceholders
  + pure renderTemplate