### PR TITLE
allow editing own listing comments (MIM-1688)

### DIFF
--- a/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -610,6 +610,31 @@ const removeComment = async (
   }
 }
 
+type UpdateCommentRequest = z.infer<
+  typeof leasing.v1.UpdateCommentRequestParamsSchema
+>
+
+const updateComment = async (
+  threadId: CommentThreadId,
+  commentId: number,
+  comment: UpdateCommentRequest
+): Promise<AdapterResult<Comment, 'unknown' | 'not-found'>> => {
+  try {
+    const response = await getFromCore<{ content: Comment }>({
+      method: 'put',
+      url: `${coreBaseUrl}/comments/${threadId.targetType}/thread/${threadId.targetId}/${commentId}`,
+      data: comment,
+    })
+
+    return { ok: true, data: response.data.content }
+  } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 404) {
+      return { ok: false, err: 'not-found', statusCode: 404 }
+    }
+    return { ok: false, err: 'unknown', statusCode: 500 }
+  }
+}
+
 const getVacantParkingSpaces = async (): Promise<
   AdapterResult<RentalObject[], unknown>
 > => {
@@ -818,6 +843,7 @@ const getRentalPropertyByCode = async (
 export {
   addComment,
   removeComment,
+  updateComment,
   getListingsWithApplicants,
   getListingWithApplicants,
   removeApplicant,

--- a/apps/internal-portal/backend/src/services/leasing-service/comments.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/comments.ts
@@ -92,6 +92,7 @@ export const routes = (router: KoaRouter) => {
       } else if (comment.authorId !== ctx.session?.account.username) {
         ctx.status = 401
         ctx.body = { error: 'access-denied', ...metadata }
+        return
       }
 
       const result = await coreAdapter.removeComment(threadId, commentId)
@@ -104,6 +105,66 @@ export const routes = (router: KoaRouter) => {
 
       ctx.status = 200
       ctx.body = { content: null, ...metadata }
+    }
+  )
+
+  router.put(
+    '(.*)/comments/:targetType/thread/:targetId/:commentId',
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+      const { targetType, targetId } = ctx.params
+      const threadId = { targetType, targetId: Number(targetId) }
+      const commentId = Number(ctx.params.commentId)
+
+      const parseResult = leasing.v1.UpdateCommentRequestParamsSchema.safeParse(
+        ctx.request.body
+      )
+
+      if (!parseResult.success) {
+        ctx.status = 400
+        ctx.body = {
+          error: 'Invalid request body',
+          invalid: ctx.request.body,
+          detail: parseResult.error,
+          ...metadata,
+        }
+        return
+      }
+
+      const threadResult = await coreAdapter.getCommentThread(threadId)
+      if (!threadResult.ok) {
+        ctx.status = threadResult.statusCode || 500
+        ctx.body = { error: threadResult.err, ...metadata }
+        return
+      }
+
+      const comment = threadResult.data.comments.find(
+        (c: Comment) => c.id === commentId
+      )
+      if (!comment) {
+        ctx.status = 404
+        ctx.body = { error: 'not-found', ...metadata }
+        return
+      } else if (comment.authorId !== ctx.session?.account.username) {
+        ctx.status = 401
+        ctx.body = { error: 'access-denied', ...metadata }
+        return
+      }
+
+      const result = await coreAdapter.updateComment(
+        threadId,
+        commentId,
+        parseResult.data
+      )
+
+      if (!result.ok) {
+        ctx.status = result.statusCode
+        ctx.body = { error: result.err, ...metadata }
+        return
+      }
+
+      ctx.status = 200
+      ctx.body = { content: result.data, ...metadata }
     }
   )
 }

--- a/apps/internal-portal/backend/src/services/leasing-service/comments.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/comments.ts
@@ -1,7 +1,41 @@
 import KoaRouter from '@koa/router'
 import * as coreAdapter from './adapters/core-adapter'
 import { generateRouteMetadata } from '@onecore/utilities'
-import { Comment, leasing } from '@onecore/types'
+import { Comment, CommentThreadId, leasing } from '@onecore/types'
+
+// Looks up the comment and verifies it was authored by the signed-in user.
+// On failure the error response (404 not-found / 403 access-denied) is written
+// to ctx and undefined is returned; callers must return immediately.
+const getOwnComment = async (
+  ctx: KoaRouter.RouterContext,
+  threadId: CommentThreadId,
+  commentId: number,
+  metadata: ReturnType<typeof generateRouteMetadata>
+): Promise<Comment | undefined> => {
+  const threadResult = await coreAdapter.getCommentThread(threadId)
+  if (!threadResult.ok) {
+    ctx.status = threadResult.statusCode || 500
+    ctx.body = { error: threadResult.err, ...metadata }
+    return undefined
+  }
+
+  const comment = threadResult.data.comments.find(
+    (c: Comment) => c.id === commentId
+  )
+  if (!comment) {
+    ctx.status = 404
+    ctx.body = { error: 'not-found', ...metadata }
+    return undefined
+  }
+
+  if (comment.authorId !== ctx.session?.account.username) {
+    ctx.status = 403
+    ctx.body = { error: 'access-denied', ...metadata }
+    return undefined
+  }
+
+  return comment
+}
 
 export const routes = (router: KoaRouter) => {
   router.get('(.*)/comments/:targetType/thread/:targetId', async (ctx) => {
@@ -75,23 +109,8 @@ export const routes = (router: KoaRouter) => {
       const threadId = { targetType, targetId: Number(targetId) }
       const commentId = Number(ctx.params.commentId)
 
-      const threadResult = await coreAdapter.getCommentThread(threadId)
-      if (!threadResult.ok) {
-        ctx.status = threadResult.statusCode || 500
-        ctx.body = { error: threadResult.err, ...metadata }
-        return
-      }
-
-      const comment = threadResult.data.comments.find(
-        (c: Comment) => c.id === commentId
-      )
+      const comment = await getOwnComment(ctx, threadId, commentId, metadata)
       if (!comment) {
-        ctx.status = 404
-        ctx.body = { error: 'not-found', ...metadata }
-        return
-      } else if (comment.authorId !== ctx.session?.account.username) {
-        ctx.status = 401
-        ctx.body = { error: 'access-denied', ...metadata }
         return
       }
 
@@ -131,23 +150,8 @@ export const routes = (router: KoaRouter) => {
         return
       }
 
-      const threadResult = await coreAdapter.getCommentThread(threadId)
-      if (!threadResult.ok) {
-        ctx.status = threadResult.statusCode || 500
-        ctx.body = { error: threadResult.err, ...metadata }
-        return
-      }
-
-      const comment = threadResult.data.comments.find(
-        (c: Comment) => c.id === commentId
-      )
+      const comment = await getOwnComment(ctx, threadId, commentId, metadata)
       if (!comment) {
-        ctx.status = 404
-        ctx.body = { error: 'not-found', ...metadata }
-        return
-      } else if (comment.authorId !== ctx.session?.account.username) {
-        ctx.status = 401
-        ctx.body = { error: 'access-denied', ...metadata }
         return
       }
 

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/components/CommentSection.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/components/CommentSection.tsx
@@ -28,9 +28,12 @@ import { CommentThreadId, Comment, CommentType } from '@onecore/types'
 import { toast } from 'react-toastify'
 
 import { useProfile, Account } from '../../../common/hooks/useProfile'
+import { RequestError } from '../../../types'
 import { useCommentThread } from '../hooks/useCommentThread'
 import { useAddComment } from '../hooks/useAddComment'
 import { useRemoveComment } from '../hooks/useRemoveComment'
+import { useUpdateComment } from '../hooks/useUpdateComment'
+import { UpdateCommentRequestErrorCodes } from '../hooks/updateCommentRequestErrors'
 
 dayjs.extend(relativeTime)
 dayjs.locale('sv')
@@ -58,53 +61,157 @@ const CommentCard = ({
   comment,
   isOwnComment,
   onDeleteClick,
+  onEditSave,
 }: {
   comment: Comment
   isOwnComment: boolean
   onDeleteClick: (id: number) => void
-}) => (
-  <Paper
-    sx={{
-      padding: '8px',
-      marginTop: '16px',
-      backgroundColor: commentTypeColors[comment.type],
-    }}
-  >
-    <Box
-      className="invisible-parent"
-      display="flex"
-      columnGap={1}
-      justifyContent="space-between"
-      alignItems="flex-start"
+  onEditSave: (
+    id: number,
+    values: { comment: string; type: CommentType }
+  ) => Promise<void>
+}) => {
+  const [isEditing, setIsEditing] = useState(false)
+  const [editComment, setEditComment] = useState(comment.comment)
+  const [editType, setEditType] = useState<CommentType>(comment.type)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleStartEdit = () => {
+    // Reseed from the current comment so a background refetch that landed
+    // while the card was mounted can't leave stale text in the editor.
+    setEditComment(comment.comment)
+    setEditType(comment.type)
+    setIsEditing(true)
+  }
+
+  const handleCancel = () => {
+    setEditComment(comment.comment)
+    setEditType(comment.type)
+    setIsEditing(false)
+  }
+
+  const handleSave = async () => {
+    if (!editComment.trim()) return
+    setIsSaving(true)
+    try {
+      await onEditSave(comment.id, { comment: editComment, type: editType })
+      setIsEditing(false)
+    } catch {
+      // Keep edit mode open; the error is surfaced to the user by the parent.
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <Paper
+      sx={{
+        padding: '8px',
+        marginTop: '16px',
+        backgroundColor: commentTypeColors[isEditing ? editType : comment.type],
+      }}
     >
-      <Box display="flex" columnGap={1} flexGrow={1}>
-        {commentIcons[comment.type]}
-        <div>
-          <Typography variant="body2">
-            {dayjs(comment.createdAt).fromNow()}
-          </Typography>
-          <Typography variant="subtitle2" fontWeight="bold">
-            {comment.authorName}
-          </Typography>
-          <Typography variant="body1">{comment.comment}</Typography>
-        </div>
+      <Box
+        className="invisible-parent"
+        display="flex"
+        columnGap={1}
+        justifyContent="space-between"
+        alignItems="flex-start"
+      >
+        <Box display="flex" columnGap={1} flexGrow={1}>
+          {commentIcons[isEditing ? editType : comment.type]}
+          <Box flexGrow={1}>
+            <Typography variant="body2">
+              {dayjs(comment.createdAt).fromNow()}
+              {comment.updatedAt && ' (redigerad)'}
+            </Typography>
+            <Typography variant="subtitle2" fontWeight="bold">
+              {comment.authorName}
+            </Typography>
+            {isEditing ? (
+              <Box
+                display="flex"
+                flexDirection="column"
+                rowGap={1}
+                marginTop={1}
+              >
+                <ToggleButtonGroup
+                  value={editType}
+                  exclusive
+                  size="small"
+                  onChange={(_, val) => val && setEditType(val)}
+                  aria-label="Typ av kommentar"
+                >
+                  <ToggleButton value="COMMENT" aria-label="Kommentar">
+                    <ChatBubbleOutlineIcon />
+                  </ToggleButton>
+                  <ToggleButton value="WARNING" aria-label="Varning">
+                    <WarningAmberIcon />
+                  </ToggleButton>
+                  <ToggleButton value="STOP" aria-label="Allvarlig varning">
+                    <BlockIcon />
+                  </ToggleButton>
+                </ToggleButtonGroup>
+                <TextareaAutosize
+                  minRows={3}
+                  value={editComment}
+                  onChange={(e) => setEditComment(e.target.value)}
+                />
+              </Box>
+            ) : (
+              <Typography variant="body1">{comment.comment}</Typography>
+            )}
+          </Box>
+        </Box>
+        <Box display="flex" columnGap={1}>
+          {isOwnComment &&
+            (isEditing ? (
+              <>
+                <Button
+                  variant="dark-outlined-utility"
+                  size="small"
+                  color="primary"
+                  onClick={handleCancel}
+                  disabled={isSaving}
+                >
+                  Avbryt
+                </Button>
+                <LoadingButton
+                  variant="dark"
+                  size="small"
+                  onClick={handleSave}
+                  loading={isSaving}
+                >
+                  Spara
+                </LoadingButton>
+              </>
+            ) : (
+              <>
+                <Button
+                  className="invisible-child"
+                  variant="dark-outlined-utility"
+                  size="small"
+                  color="primary"
+                  onClick={handleStartEdit}
+                >
+                  Redigera
+                </Button>
+                <Button
+                  className="invisible-child"
+                  variant="dark-outlined-utility"
+                  size="small"
+                  color="primary"
+                  onClick={() => onDeleteClick(comment.id)}
+                >
+                  Ta bort
+                </Button>
+              </>
+            ))}
+        </Box>
       </Box>
-      <div>
-        {isOwnComment && (
-          <Button
-            className="invisible-child"
-            variant="dark-outlined-utility"
-            size="small"
-            color="primary"
-            onClick={() => onDeleteClick(comment.id)}
-          >
-            Ta bort
-          </Button>
-        )}
-      </div>
-    </Box>
-  </Paper>
-)
+    </Paper>
+  )
+}
 
 const CommentSection = (props: { threadId: CommentThreadId }) => {
   const { data: profile } = useProfile()
@@ -149,14 +256,45 @@ const CommentSection = (props: { threadId: CommentThreadId }) => {
           setComments([newComment, ...comments])
           reset({ type: 'COMMENT', comment: '' })
         },
-        onError: () => {
-          toast('Ett fel inträffade när din kommentar skulle sparas.', {
-            type: 'error',
-            hideProgressBar: true,
-          })
+        onError: (error) => {
+          toast(
+            error?.errorMessage ??
+              'Ett fel inträffade när din kommentar skulle sparas.',
+            {
+              type: 'error',
+              hideProgressBar: true,
+            }
+          )
         },
       }
     )
+  }
+
+  const updateComment = useUpdateComment()
+  const handleEditSave = async (
+    id: number,
+    values: { comment: string; type: CommentType }
+  ): Promise<void> => {
+    try {
+      const updated = await updateComment.mutateAsync({
+        threadId,
+        commentId: id,
+        comment: values,
+      })
+      setComments((current) => current.map((c) => (c.id === id ? updated : c)))
+    } catch (error) {
+      const mapped = error as RequestError<UpdateCommentRequestErrorCodes>
+      toast(
+        mapped?.errorMessage ??
+          'Ett fel inträffade när din kommentar skulle uppdateras.',
+        {
+          type: 'error',
+          hideProgressBar: true,
+        }
+      )
+      // Rethrow so the card keeps edit mode open with the user's changes.
+      throw error
+    }
   }
 
   const removeComment = useRemoveComment()
@@ -170,6 +308,17 @@ const CommentSection = (props: { threadId: CommentThreadId }) => {
         onSuccess: () => {
           setDeleteDialog({ open: false })
           setComments((comments) => comments.filter((c) => c.id !== id))
+        },
+        onError: (error) => {
+          setDeleteDialog({ open: false })
+          toast(
+            error?.errorMessage ??
+              'Ett fel inträffade när kommentaren skulle tas bort.',
+            {
+              type: 'error',
+              hideProgressBar: true,
+            }
+          )
         },
       }
     )
@@ -290,6 +439,7 @@ const CommentSection = (props: { threadId: CommentThreadId }) => {
                     comment={comment}
                     isOwnComment={account?.username === comment.authorId}
                     onDeleteClick={() => handleDeleteClick(comment.id)}
+                    onEditSave={handleEditSave}
                   />
                 </Collapse>
               ))}

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/components/CommentSection.tsx
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/components/CommentSection.tsx
@@ -181,6 +181,7 @@ const CommentCard = ({
                   size="small"
                   onClick={handleSave}
                   loading={isSaving}
+                  disabled={!editComment.trim()}
                 >
                   Spara
                 </LoadingButton>

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/addCommentRequestErrors.ts
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/addCommentRequestErrors.ts
@@ -2,7 +2,7 @@ import { AxiosError } from 'axios'
 
 import { RequestError } from '../../../types'
 
-export declare enum AddCommentRequestErrorCodes {
+export enum AddCommentRequestErrorCodes {
   EmptyComment = 'empty-comment',
   Unknown = 'unknown',
 }

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/updateCommentRequestErrors.ts
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/updateCommentRequestErrors.ts
@@ -2,31 +2,31 @@ import { AxiosError } from 'axios'
 
 import { RequestError } from '../../../types'
 
-export enum RemoveCommentRequestErrorCodes {
+export enum UpdateCommentRequestErrorCodes {
   AccessDenied = 'access-denied',
   Unknown = 'unknown',
 }
 
-export function mapRemoveCommentErrors(
+export function mapUpdateCommentErrors(
   e: AxiosError<{
-    error?: RemoveCommentRequestErrorCodes
+    error?: UpdateCommentRequestErrorCodes
     errorMessage: string
   }>
-): RequestError<RemoveCommentRequestErrorCodes> {
+): RequestError<UpdateCommentRequestErrorCodes> {
   switch (e.response?.data?.error) {
-    case RemoveCommentRequestErrorCodes.AccessDenied:
+    case UpdateCommentRequestErrorCodes.AccessDenied:
       return {
         status: e.response.status,
         errorHeading: 'Ej tillåtet',
-        errorCode: RemoveCommentRequestErrorCodes.AccessDenied,
-        errorMessage: 'Du kan endast ta bort dina egna kommentarer.',
+        errorCode: UpdateCommentRequestErrorCodes.AccessDenied,
+        errorMessage: 'Du kan endast redigera dina egna kommentarer.',
       }
-    case RemoveCommentRequestErrorCodes.Unknown:
+    case UpdateCommentRequestErrorCodes.Unknown:
     default:
       return {
         status: 500,
         errorHeading: 'Något gick fel...',
-        errorCode: RemoveCommentRequestErrorCodes.Unknown,
+        errorCode: UpdateCommentRequestErrorCodes.Unknown,
         errorMessage: 'Försök igen eller kontakta support',
       }
   }

--- a/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/useUpdateComment.ts
+++ b/apps/internal-portal/frontend/src/pages/ParkingSpace/hooks/useUpdateComment.ts
@@ -1,0 +1,36 @@
+import { useMutation } from '@tanstack/react-query'
+import { CommentThreadId, Comment, CommentType } from '@onecore/types'
+
+import apiClient from '../../../utils/api-client'
+import { RequestError } from '../../../types'
+import {
+  UpdateCommentRequestErrorCodes,
+  mapUpdateCommentErrors,
+} from './updateCommentRequestErrors'
+
+export type UpdateCommentRequest = {
+  threadId: CommentThreadId
+  commentId: number
+  comment: { comment: string; type: CommentType }
+}
+
+export const useUpdateComment = () => {
+  return useMutation<
+    Comment,
+    RequestError<UpdateCommentRequestErrorCodes>,
+    UpdateCommentRequest
+  >({
+    mutationFn: (params) => {
+      const { targetType, targetId } = params.threadId
+      return apiClient
+        .put<{ content: Comment }>(
+          `/comments/${targetType}/thread/${targetId}/${params.commentId}`,
+          params.comment
+        )
+        .then((res) => res.data.content)
+        .catch((error) => {
+          return Promise.reject(mapUpdateCommentErrors(error))
+        })
+    },
+  })
+}

--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -510,7 +510,11 @@ export interface paths {
       }
       requestBody: {
         content: {
-          'application/json': Record<string, never>
+          'application/json': {
+            /** @enum {string} */
+            type: 'COMMENT' | 'WARNING' | 'STOP'
+            comment: string
+          }
         }
       }
       responses: {
@@ -522,6 +526,10 @@ export interface paths {
               content?: Record<string, never>
             }
           }
+        }
+        /** @description Invalid request body */
+        400: {
+          content: never
         }
         /** @description The comment was not found in the given thread */
         404: {

--- a/apps/keys-portal/src/services/api/core/generated/api-types.ts
+++ b/apps/keys-portal/src/services/api/core/generated/api-types.ts
@@ -491,6 +491,49 @@ export interface paths {
       }
     }
   }
+  '/comments/{targetType}/thread/{targetId}/{commentId}': {
+    /**
+     * Update a comment in a comment thread
+     * @description Update the text and/or type of an existing comment in the comment
+     * thread identified by targetType/targetId and the comment id.
+     */
+    put: {
+      parameters: {
+        path: {
+          /** @description The object type that the comment thread belongs to. */
+          targetType: string
+          /** @description The object id that the comment thread belongs to. */
+          targetId: number
+          /** @description The unique ID of the comment to update. */
+          commentId: number
+        }
+      }
+      requestBody: {
+        content: {
+          'application/json': Record<string, never>
+        }
+      }
+      responses: {
+        /** @description The updated comment */
+        200: {
+          content: {
+            'application/json': {
+              /** @description The updated comment */
+              content?: Record<string, never>
+            }
+          }
+        }
+        /** @description The comment was not found in the given thread */
+        404: {
+          content: never
+        }
+        /** @description Internal server error */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
   '/leases/search': {
     /**
      * Search and filter leases

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -510,7 +510,11 @@ export interface paths {
       }
       requestBody: {
         content: {
-          'application/json': Record<string, never>
+          'application/json': {
+            /** @enum {string} */
+            type: 'COMMENT' | 'WARNING' | 'STOP'
+            comment: string
+          }
         }
       }
       responses: {
@@ -522,6 +526,10 @@ export interface paths {
               content?: Record<string, never>
             }
           }
+        }
+        /** @description Invalid request body */
+        400: {
+          content: never
         }
         /** @description The comment was not found in the given thread */
         404: {

--- a/apps/property-tree/src/services/api/core/generated/api-types.ts
+++ b/apps/property-tree/src/services/api/core/generated/api-types.ts
@@ -491,6 +491,49 @@ export interface paths {
       }
     }
   }
+  '/comments/{targetType}/thread/{targetId}/{commentId}': {
+    /**
+     * Update a comment in a comment thread
+     * @description Update the text and/or type of an existing comment in the comment
+     * thread identified by targetType/targetId and the comment id.
+     */
+    put: {
+      parameters: {
+        path: {
+          /** @description The object type that the comment thread belongs to. */
+          targetType: string
+          /** @description The object id that the comment thread belongs to. */
+          targetId: number
+          /** @description The unique ID of the comment to update. */
+          commentId: number
+        }
+      }
+      requestBody: {
+        content: {
+          'application/json': Record<string, never>
+        }
+      }
+      responses: {
+        /** @description The updated comment */
+        200: {
+          content: {
+            'application/json': {
+              /** @description The updated comment */
+              content?: Record<string, never>
+            }
+          }
+        }
+        /** @description The comment was not found in the given thread */
+        404: {
+          content: never
+        }
+        /** @description Internal server error */
+        500: {
+          content: never
+        }
+      }
+    }
+  }
   '/leases/search': {
     /**
      * Search and filter leases

--- a/core/src/adapters/leasing-adapter/comments.ts
+++ b/core/src/adapters/leasing-adapter/comments.ts
@@ -4,6 +4,7 @@ import {
   CommentThreadId,
   leasing,
 } from '@onecore/types'
+import { AxiosError } from 'axios'
 import { loggedAxios as axios } from '@onecore/utilities'
 import z from 'zod'
 import { AdapterResult } from '../types'
@@ -76,21 +77,25 @@ const updateComment = async (
   threadId: CommentThreadId,
   commentId: number,
   comment: UpdateCommentRequest
-): Promise<AdapterResult<Comment, 'unknown'>> => {
-  const response = await axios.put<{ content: Comment }>(
-    `${tenantsLeasesServiceUrl}/comments/${threadId.targetType}/thread/${threadId.targetId}/${commentId}`,
-    comment
-  )
+): Promise<AdapterResult<Comment, 'not-found' | 'unknown'>> => {
+  try {
+    const response = await axios.put<{ content: Comment }>(
+      `${tenantsLeasesServiceUrl}/comments/${threadId.targetType}/thread/${threadId.targetId}/${commentId}`,
+      comment
+    )
 
-  if (response.status === 200) {
     return {
       ok: true,
       data: response.data.content,
       statusCode: response.status,
     }
-  }
+  } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 404) {
+      return { ok: false, err: 'not-found', statusCode: 404 }
+    }
 
-  return { ok: false, err: 'unknown', statusCode: response.status }
+    return { ok: false, err: 'unknown', statusCode: 500 }
+  }
 }
 
 export { addComment, getCommentThread, removeComment, updateComment }

--- a/core/src/adapters/leasing-adapter/comments.ts
+++ b/core/src/adapters/leasing-adapter/comments.ts
@@ -68,4 +68,29 @@ const removeComment = async (
   return { ok: false, err: 'unknown', statusCode: response.status }
 }
 
-export { addComment, getCommentThread, removeComment }
+type UpdateCommentRequest = z.infer<
+  typeof leasing.v1.UpdateCommentRequestParamsSchema
+>
+
+const updateComment = async (
+  threadId: CommentThreadId,
+  commentId: number,
+  comment: UpdateCommentRequest
+): Promise<AdapterResult<Comment, 'unknown'>> => {
+  const response = await axios.put<{ content: Comment }>(
+    `${tenantsLeasesServiceUrl}/comments/${threadId.targetType}/thread/${threadId.targetId}/${commentId}`,
+    comment
+  )
+
+  if (response.status === 200) {
+    return {
+      ok: true,
+      data: response.data.content,
+      statusCode: response.status,
+    }
+  }
+
+  return { ok: false, err: 'unknown', statusCode: response.status }
+}
+
+export { addComment, getCommentThread, removeComment, updateComment }

--- a/core/src/adapters/leasing-adapter/index.ts
+++ b/core/src/adapters/leasing-adapter/index.ts
@@ -1094,7 +1094,12 @@ export {
   updateOfferSentAt,
 } from './offers'
 
-export { getCommentThread, addComment, removeComment } from './comments'
+export {
+  getCommentThread,
+  addComment,
+  removeComment,
+  updateComment,
+} from './comments'
 
 export {
   getAllVacantParkingSpaces,

--- a/core/src/services/lease-service/comments.ts
+++ b/core/src/services/lease-service/comments.ts
@@ -29,10 +29,6 @@ export const routes = (router: KoaRouter) => {
     typeof leasing.v1.AddCommentRequestParamsSchema
   >
 
-  type UpdateCommentRequest = z.infer<
-    typeof leasing.v1.UpdateCommentRequestParamsSchema
-  >
-
   router.post('(.*)/comments/:targetType/thread/:targetId', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
 
@@ -112,6 +108,15 @@ export const routes = (router: KoaRouter) => {
    *          application/json:
    *             schema:
    *               type: object
+   *               required:
+   *                 - type
+   *                 - comment
+   *               properties:
+   *                 type:
+   *                   type: string
+   *                   enum: [COMMENT, WARNING, STOP]
+   *                 comment:
+   *                   type: string
    *     responses:
    *       200:
    *         description: The updated comment
@@ -123,6 +128,8 @@ export const routes = (router: KoaRouter) => {
    *                 content:
    *                   type: object
    *                   description: The updated comment
+   *       400:
+   *         description: Invalid request body
    *       404:
    *         description: The comment was not found in the given thread
    *       500:
@@ -137,12 +144,26 @@ export const routes = (router: KoaRouter) => {
 
       const { targetType, targetId, commentId } = ctx.params
       const threadId = { targetType, targetId: Number(targetId) }
-      const comment = <UpdateCommentRequest>ctx.request.body
+
+      const parseResult = leasing.v1.UpdateCommentRequestParamsSchema.safeParse(
+        ctx.request.body
+      )
+
+      if (!parseResult.success) {
+        ctx.status = 400
+        ctx.body = {
+          error: 'Invalid request body',
+          invalid: ctx.request.body,
+          detail: parseResult.error,
+          ...metadata,
+        }
+        return
+      }
 
       const result = await leasingAdapter.updateComment(
         threadId,
         Number(commentId),
-        comment
+        parseResult.data
       )
 
       if (!result.ok) {

--- a/core/src/services/lease-service/comments.ts
+++ b/core/src/services/lease-service/comments.ts
@@ -29,6 +29,10 @@ export const routes = (router: KoaRouter) => {
     typeof leasing.v1.AddCommentRequestParamsSchema
   >
 
+  type UpdateCommentRequest = z.infer<
+    typeof leasing.v1.UpdateCommentRequestParamsSchema
+  >
+
   router.post('(.*)/comments/:targetType/thread/:targetId', async (ctx) => {
     const metadata = generateRouteMetadata(ctx)
 
@@ -71,6 +75,84 @@ export const routes = (router: KoaRouter) => {
 
       ctx.status = 200
       ctx.body = { content: null, ...metadata }
+    }
+  )
+
+  /**
+   * @swagger
+   * /comments/{targetType}/thread/{targetId}/{commentId}:
+   *   put:
+   *     summary: Update a comment in a comment thread
+   *     description: |
+   *       Update the text and/or type of an existing comment in the comment
+   *       thread identified by targetType/targetId and the comment id.
+   *     tags: [Comment]
+   *     parameters:
+   *       - in: path
+   *         name: targetType
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The object type that the comment thread belongs to.
+   *       - in: path
+   *         name: targetId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: The object id that the comment thread belongs to.
+   *       - in: path
+   *         name: commentId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: The unique ID of the comment to update.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *          application/json:
+   *             schema:
+   *               type: object
+   *     responses:
+   *       200:
+   *         description: The updated comment
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 content:
+   *                   type: object
+   *                   description: The updated comment
+   *       404:
+   *         description: The comment was not found in the given thread
+   *       500:
+   *         description: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.put(
+    '(.*)/comments/:targetType/thread/:targetId/:commentId',
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+
+      const { targetType, targetId, commentId } = ctx.params
+      const threadId = { targetType, targetId: Number(targetId) }
+      const comment = <UpdateCommentRequest>ctx.request.body
+
+      const result = await leasingAdapter.updateComment(
+        threadId,
+        Number(commentId),
+        comment
+      )
+
+      if (!result.ok) {
+        ctx.status = result.statusCode || 500
+        ctx.body = { error: result.err, ...metadata }
+        return
+      }
+
+      ctx.status = 200
+      ctx.body = { content: result.data, ...metadata }
     }
   )
 }

--- a/libs/types/src/leasing/v1/comment.ts
+++ b/libs/types/src/leasing/v1/comment.ts
@@ -6,3 +6,8 @@ export const AddCommentRequestParamsSchema = CommentSchema.pick({
   authorName: true,
   authorId: true,
 })
+
+export const UpdateCommentRequestParamsSchema = CommentSchema.pick({
+  type: true,
+  comment: true,
+})

--- a/libs/types/src/schemas/v1/comment.ts
+++ b/libs/types/src/schemas/v1/comment.ts
@@ -14,6 +14,7 @@ export const CommentSchema = z.object({
   authorId: z.string(),
   comment: z.string(),
   createdAt: z.date(),
+  updatedAt: z.date().optional(),
 })
 
 export const CommentThreadSchema = z.object({

--- a/services/leasing/migrations/20260727120000_add-updatedat-to-comments.js
+++ b/services/leasing/migrations/20260727120000_add-updatedat-to-comments.js
@@ -1,0 +1,25 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+      ALTER TABLE comment
+      ADD updatedAt datetimeoffset NULL;
+    `)
+  })
+}
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.transaction(async (trx) => {
+    await trx.raw(`
+      ALTER TABLE comment
+      DROP COLUMN updatedAt;
+    `)
+  })
+}

--- a/services/leasing/src/services/lease-service/adapters/comment-adapter.ts
+++ b/services/leasing/src/services/lease-service/adapters/comment-adapter.ts
@@ -1,4 +1,5 @@
 import { Comment, CommentThread, CommentThreadId } from '@onecore/types'
+import { logger } from '@onecore/utilities'
 import { DbComment } from './types'
 import { leasing } from '@onecore/types'
 import z from 'zod'
@@ -14,6 +15,7 @@ const getCommentThreadById = async (
     .select<Array<DbComment>>(
       'c.id AS Id',
       'c.createdAt AS CreatedAt',
+      'c.updatedAt AS UpdatedAt',
       'c.type AS Type',
       'c.authorId AS AuthorId',
       'c.authorName AS AuthorName',
@@ -35,6 +37,7 @@ const getCommentThreadById = async (
         type: c.Type,
         comment: c.Comment,
         createdAt: c.CreatedAt,
+        updatedAt: c.UpdatedAt ?? undefined,
       }
     }),
   }
@@ -88,4 +91,53 @@ const removeComment = async (
   return
 }
 
-export default { getCommentThreadById, addComment, removeComment }
+type UpdateCommentRequest = z.infer<
+  typeof leasing.v1.UpdateCommentRequestParamsSchema
+>
+
+const updateComment = async (
+  threadId: CommentThreadId,
+  commentId: number,
+  comment: UpdateCommentRequest,
+  dbConnection = db
+): Promise<Comment | undefined> => {
+  try {
+    const [updated] = await dbConnection
+      .table('comment')
+      .where({
+        Id: commentId,
+        TargetType: threadId.targetType,
+        TargetId: threadId.targetId,
+      })
+      .update({
+        Type: comment.type,
+        Comment: comment.comment,
+        UpdatedAt: dbConnection.raw('SYSDATETIMEOFFSET()'),
+      })
+      .returning('*')
+
+    if (!updated) {
+      return undefined
+    }
+
+    return {
+      id: updated.id,
+      authorName: updated.authorName,
+      authorId: updated.authorId,
+      type: updated.type,
+      comment: updated.comment,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt ?? undefined,
+    }
+  } catch (err) {
+    logger.error({ err }, 'commentAdapter.updateComment')
+    throw err
+  }
+}
+
+export default {
+  getCommentThreadById,
+  addComment,
+  removeComment,
+  updateComment,
+}

--- a/services/leasing/src/services/lease-service/adapters/types.ts
+++ b/services/leasing/src/services/lease-service/adapters/types.ts
@@ -75,6 +75,7 @@ export type DbComment = {
   AuthorName: string
   AuthorId: string
   CreatedAt: Date
+  UpdatedAt: Date | null
   Type: 'COMMENT' | 'WARNING' | 'STOP'
   Comment: string
 }

--- a/services/leasing/src/services/lease-service/routes/comments.ts
+++ b/services/leasing/src/services/lease-service/routes/comments.ts
@@ -206,4 +206,102 @@ export const routes = (router: KoaRouter) => {
       }
     }
   )
+
+  /**
+   * @swagger
+   * /comments/{targetType}/thread/{targetId}/{commentId}:
+   *   put:
+   *     summary: Update a Comment in a CommentThread
+   *     description: |
+   *       Update the text and/or type of an existing comment in a comment
+   *       thread, identified by the logical threadId of targetType/targetId
+   *       together with the comment id.
+   *     tags: [Comment]
+   *     parameters:
+   *       - in: path
+   *         name: targetType
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: |
+   *           The object type that the comment thread belongs to.
+   *       - in: path
+   *         name: targetId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The object id that the comment thread belongs to.
+   *       - in: path
+   *         name: commentId
+   *         required: true
+   *         schema:
+   *           type: number
+   *         description: |
+   *           The unique ID of the comment to update.
+   *     requestBody:
+   *       required: true
+   *       content:
+   *          application/json:
+   *             schema:
+   *               type: object
+   *     responses:
+   *       200:
+   *         description: The comment was successfully updated
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 data:
+   *                   type: object
+   *                   description: The updated comment
+   *       400:
+   *         description: Invalid request body
+   *       404:
+   *         description: The comment was not found in the given thread
+   *       500:
+   *         description: Internal server error
+   *     security:
+   *       - bearerAuth: []
+   */
+  router.put(
+    '(.*)/comments/:targetType/thread/:targetId/:commentId',
+    async (ctx) => {
+      const metadata = generateRouteMetadata(ctx)
+
+      const { targetType, targetId, commentId } = ctx.params
+      const threadId = { targetType, targetId: Number(targetId) }
+
+      const parseResult = leasing.v1.UpdateCommentRequestParamsSchema.safeParse(
+        ctx.request.body
+      )
+
+      if (!parseResult.success) {
+        ctx.status = 400
+        ctx.body = {
+          error: 'Invalid request body',
+          invalid: ctx.request.body,
+          detail: parseResult.error,
+          ...metadata,
+        }
+        return
+      }
+
+      const updated = await commentAdapter.updateComment(
+        threadId,
+        Number(commentId),
+        parseResult.data
+      )
+
+      if (!updated) {
+        ctx.status = 404
+        ctx.body = { error: 'not-found', ...metadata }
+        return
+      }
+
+      ctx.status = 200
+      ctx.body = { content: updated, ...metadata }
+    }
+  )
 }

--- a/services/leasing/src/services/lease-service/routes/comments.ts
+++ b/services/leasing/src/services/lease-service/routes/comments.ts
@@ -245,6 +245,15 @@ export const routes = (router: KoaRouter) => {
    *          application/json:
    *             schema:
    *               type: object
+   *               required:
+   *                 - type
+   *                 - comment
+   *               properties:
+   *                 type:
+   *                   type: string
+   *                   enum: [COMMENT, WARNING, STOP]
+   *                 comment:
+   *                   type: string
    *     responses:
    *       200:
    *         description: The comment was successfully updated

--- a/services/leasing/src/services/lease-service/tests/routes/comments.test.ts
+++ b/services/leasing/src/services/lease-service/tests/routes/comments.test.ts
@@ -1,0 +1,88 @@
+import request from 'supertest'
+import Koa from 'koa'
+import KoaRouter from '@koa/router'
+import bodyParser from 'koa-bodyparser'
+import { Comment } from '@onecore/types'
+
+import { routes } from '../../routes/comments'
+import commentAdapter from '../../adapters/comment-adapter'
+
+const app = new Koa()
+const router = new KoaRouter()
+routes(router)
+app.use(bodyParser())
+app.use(router.routes())
+
+beforeEach(jest.restoreAllMocks)
+
+const buildComment = (overrides: Partial<Comment> = {}): Comment => ({
+  id: 45,
+  type: 'COMMENT',
+  authorName: 'Test Author',
+  authorId: 'test-user',
+  comment: 'Updated text',
+  createdAt: new Date('2026-07-01T10:00:00Z'),
+  updatedAt: new Date('2026-07-27T10:00:00Z'),
+  ...overrides,
+})
+
+describe('comments routes', () => {
+  describe('PUT /comments/:targetType/thread/:targetId/:commentId', () => {
+    it('responds with 200 and the updated comment on success', async () => {
+      const updated = buildComment({ type: 'WARNING' })
+      const spy = jest
+        .spyOn(commentAdapter, 'updateComment')
+        .mockResolvedValueOnce(updated)
+
+      const res = await request(app.callback())
+        .put('/comments/parkingspace/thread/123/45')
+        .send({ type: 'WARNING', comment: 'Updated text' })
+
+      expect(res.status).toBe(200)
+      expect(res.body.content.id).toBe(updated.id)
+      expect(res.body.content.type).toBe('WARNING')
+      expect(spy).toHaveBeenCalledWith(
+        { targetType: 'parkingspace', targetId: 123 },
+        45,
+        { type: 'WARNING', comment: 'Updated text' }
+      )
+    })
+
+    it('responds with 404 when no comment matched the thread', async () => {
+      jest
+        .spyOn(commentAdapter, 'updateComment')
+        .mockResolvedValueOnce(undefined)
+
+      const res = await request(app.callback())
+        .put('/comments/parkingspace/thread/123/999')
+        .send({ type: 'COMMENT', comment: 'Whatever' })
+
+      expect(res.status).toBe(404)
+      expect(res.body.error).toBe('not-found')
+    })
+
+    it('responds with 400 for an invalid comment type', async () => {
+      const spy = jest.spyOn(commentAdapter, 'updateComment')
+
+      const res = await request(app.callback())
+        .put('/comments/parkingspace/thread/123/45')
+        .send({ type: 'NOT_A_TYPE', comment: 'Updated text' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('Invalid request body')
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('responds with 400 when the comment text is missing', async () => {
+      const spy = jest.spyOn(commentAdapter, 'updateComment')
+
+      const res = await request(app.callback())
+        .put('/comments/parkingspace/thread/123/45')
+        .send({ type: 'COMMENT' })
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('Invalid request body')
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## What & why

MIM-1688: adds the ability to **edit a posted comment** in the parking-space
listing "Notering/kommentar" log. Previously users could only create and
delete comments. Requested by Uthyrningen (edit own comments; not the event log).

## Changes

- New `PUT /comments/:targetType/thread/:targetId/:commentId` threaded through
  every tier: **leasing service → core → internal-portal backend → frontend**,
  mirroring the existing DELETE handler.
- **Ownership enforced in the backend** — only the comment's author can edit
  (401 `access-denied` otherwise); the "Redigera" button shows only on your own
  comments.
- New nullable `updatedAt` column (migration included) drives a subtle
  **"(redigerad)"** marker on edited comments.
- Inline edit UI in `CommentSection` (text + type), with local state kept in
  sync so an edit can't overwrite newer server content.

## Fixes made along the way (found while reviewing this change)

- **Auth bypass in DELETE:** the handler set `ctx.status = 401` for non-authors
  but was missing a `return`, so it deleted anyway. Now guarded (PUT enforces the
  same check).
- **Dead error mappers:** the comment error mappers used `declare enum` (no
  runtime object), so tailored messages never applied. Switched add/remove/update
  to real enums and surfaced the mapped messages in the add/edit/delete toasts.
- Removed an unreachable 404 branch in the core update adapter.

## Notes / out of scope

- `createdAt`/`updatedAt` are typed `z.date()` but cross services as JSON strings;
  latent only (nothing re-parses transported comments today) — left as-is.

