### PR TITLE
Feature/mim 1925 bulk utskick kunna ta bort enskilda mottagare fore skick

### DIFF
--- a/apps/property-tree/src/pages/LeasesPage.tsx
+++ b/apps/property-tree/src/pages/LeasesPage.tsx
@@ -106,6 +106,7 @@ const LeasesPage = () => {
   const {
     allResultsSelected,
     selectedCount,
+    excludedRecipientsCount,
     toggleSelection,
     toggleSelectAll,
     clearSelection,
@@ -364,6 +365,7 @@ const LeasesPage = () => {
         onOpenChange={setShowSmsModal}
         recipients={smsRecipients}
         totalSelectedItems={selectedCount}
+        excludedRecipientsCount={excludedRecipientsCount}
         onSend={handleSendSms}
       />
 
@@ -372,6 +374,7 @@ const LeasesPage = () => {
         onOpenChange={setShowEmailModal}
         recipients={emailRecipients}
         totalSelectedItems={selectedCount}
+        excludedRecipientsCount={excludedRecipientsCount}
         onSend={handleSendEmail}
       />
     </ViewLayout>

--- a/apps/property-tree/src/pages/LeasesPage.tsx
+++ b/apps/property-tree/src/pages/LeasesPage.tsx
@@ -139,10 +139,9 @@ const LeasesPage = () => {
     sendBulkEmail: tenantService.sendBulkEmail,
   })
 
-  // Clear selection when the filtered result set changes. Keyed on the
-  // serialized filter values (sort excluded — same rows, different order)
-  // rather than object identity, since searchParams gets a new identity on
-  // ANY url change, including pagination, which must NOT wipe the selection.
+  // Clear selection when the filters change. Keyed on serialized values (sort
+  // excluded) — searchParams gets a new identity on any url change, and
+  // pagination/sorting must NOT wipe the selection.
   const filterKey = JSON.stringify({
     ...filters.searchParams,
     sortBy: undefined,
@@ -152,9 +151,8 @@ const LeasesPage = () => {
     clearSelection()
   }, [filterKey, clearSelection])
 
-  // Header checkbox: fully checked only when ALL results are selected with no
-  // exclusions; "indeterminate" when something (possibly on another page) is
-  // selected — clicking it then clears, which the dash-state communicates.
+  // Fully checked only when all results are selected with no exclusions;
+  // indeterminate when something (possibly on another page) is selected
   const totalRecords = filters.meta?.totalRecords ?? 0
   const headerCheckboxState =
     allResultsSelected && totalRecords > 0 && selectedCount === totalRecords

--- a/apps/property-tree/src/pages/LeasesPage.tsx
+++ b/apps/property-tree/src/pages/LeasesPage.tsx
@@ -104,7 +104,6 @@ const LeasesPage = () => {
   }
 
   const {
-    selectedIds: selectedLeaseIds,
     allResultsSelected,
     selectedCount,
     toggleSelection,
@@ -139,15 +138,35 @@ const LeasesPage = () => {
     sendBulkEmail: tenantService.sendBulkEmail,
   })
 
+  // Clear selection when the filtered result set changes. Keyed on the
+  // serialized filter values (sort excluded — same rows, different order)
+  // rather than object identity, since searchParams gets a new identity on
+  // ANY url change, including pagination, which must NOT wipe the selection.
+  const filterKey = JSON.stringify({
+    ...filters.searchParams,
+    sortBy: undefined,
+    sortOrder: undefined,
+  })
   useEffect(() => {
     clearSelection()
-  }, [filters.searchParams, clearSelection])
+  }, [filterKey, clearSelection])
+
+  // Header checkbox: fully checked only when ALL results are selected with no
+  // exclusions; "indeterminate" when something (possibly on another page) is
+  // selected — clicking it then clears, which the dash-state communicates.
+  const totalRecords = filters.meta?.totalRecords ?? 0
+  const headerCheckboxState =
+    allResultsSelected && totalRecords > 0 && selectedCount === totalRecords
+      ? true
+      : selectedCount > 0
+        ? ('indeterminate' as const)
+        : false
 
   const selectColumn = {
     key: 'select',
     label: (
       <Checkbox
-        checked={allResultsSelected || selectedLeaseIds.length > 0}
+        checked={headerCheckboxState}
         onCheckedChange={toggleSelectAll}
         aria-label="Välj alla"
       />

--- a/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
+++ b/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useToast } from '@/shared/hooks/useToast'
 import type { EmailRecipient } from '@/shared/ui/EmailModal'
@@ -46,6 +46,8 @@ export interface UseBulkMessagingReturn {
   selectedIds: string[]
   allResultsSelected: boolean
   selectedCount: number
+  /** Unique contacts excluded via row unchecking in all-results mode */
+  excludedRecipientsCount: number
 
   // Selection actions
   toggleSelection: (id: string) => void
@@ -95,12 +97,13 @@ export function useBulkMessaging<TItem>({
     new Map()
   )
   const [allResultsSelected, setAllResultsSelected] = useState(false)
-  // Rows unchecked while "all results" is selected: itemId -> contactCodes of
+  // Rows unchecked while "all results" is selected: itemId -> contacts of
   // that row, captured at uncheck time (the row is on-screen when unchecked).
   // A Map (not a Set) so re-checking a row removes exactly its contribution,
   // and a contact shared by two excluded rows stays excluded until both are
-  // re-checked.
-  const [excludedItems, setExcludedItems] = useState<Map<string, string[]>>(
+  // re-checked. Same shape as selectedItems so both toggles share one code
+  // path.
+  const [excludedItems, setExcludedItems] = useState<Map<string, Contact[]>>(
     new Map()
   )
 
@@ -132,47 +135,58 @@ export function useBulkMessaging<TItem>({
   // item, they are excluded from the send entirely. That matches the intent
   // ("don't message this person") and is what makes a frontend-only exclusion
   // possible, since fetched contacts carry no item association.
-  const excludedContactCodes = useMemo(() => {
-    const codes = new Set<string>()
-    excludedItems.forEach((contactCodes) => {
-      contactCodes.forEach((code) => codes.add(code))
-    })
-    return codes
-  }, [excludedItems])
+  const excludedContactCodes = useMemo(
+    () =>
+      new Set(
+        Array.from(excludedItems.values()).flatMap((contacts) =>
+          contacts.map((c) => c.contactCode)
+        )
+      ),
+    [excludedItems]
+  )
 
   // Toggle single item selection. In "all results" mode, unchecking a row
   // excludes it from the selection instead of collapsing the mode back to
   // the current page.
   const toggleSelection = useCallback(
     (id: string) => {
-      if (allResultsSelected) {
-        setExcludedItems((prev) => {
+      const currentMap = allResultsSelected ? excludedItems : selectedItems
+      const setMap = allResultsSelected ? setExcludedItems : setSelectedItems
+
+      if (currentMap.has(id)) {
+        setMap((prev) => {
           const next = new Map(prev)
-          if (next.has(id)) {
-            next.delete(id)
-          } else {
-            const item = items.find((i) => getItemId(i) === id)
-            next.set(
-              id,
-              item ? getContacts(item).map((c) => c.contactCode) : []
-            )
-          }
+          next.delete(id)
           return next
         })
         return
       }
-      setSelectedItems((prev) => {
-        const next = new Map(prev)
-        if (next.has(id)) {
-          next.delete(id)
-        } else {
-          const item = items.find((i) => getItemId(i) === id)
-          next.set(id, item ? getContacts(item) : [])
-        }
-        return next
-      })
+
+      const item = items.find((i) => getItemId(i) === id)
+      const contacts = item ? getContacts(item) : []
+      if (allResultsSelected && contacts.length === 0) {
+        // Exclusion works by filtering the row's contactCodes out of the
+        // fetched recipient list. With no captured contacts the exclusion
+        // would be a silent no-op (the tenant would still be messaged), so
+        // refuse the uncheck instead of pretending it worked.
+        toast({
+          title: 'Raden kan inte undantas',
+          description: 'Kontaktuppgifter saknas för raden.',
+          variant: 'destructive',
+        })
+        return
+      }
+      setMap((prev) => new Map(prev).set(id, contacts))
     },
-    [allResultsSelected, items, getItemId, getContacts]
+    [
+      allResultsSelected,
+      excludedItems,
+      selectedItems,
+      items,
+      getItemId,
+      getContacts,
+      toast,
+    ]
   )
 
   // Toggle select all (selects ALL results, not just current page)
@@ -203,110 +217,133 @@ export function useBulkMessaging<TItem>({
     [allResultsSelected, excludedItems, selectedItems]
   )
 
-  // Derive SMS recipients from the hand-picked selection (contacts captured
-  // at selection time, so the selection works across pages)
-  const smsRecipientsFromSelection: SmsRecipient[] = useMemo(() => {
-    const contactMap = new Map<string, SmsRecipient>()
-
+  // Unique contacts of the hand-picked selection (contacts captured at
+  // selection time, so the selection works across pages). First occurrence
+  // wins per contactCode. The exclusion filter is applied here too so every
+  // recipient path respects exclusions by construction — in hand-picked mode
+  // excludedContactCodes is always empty, making it a no-op there.
+  const uniqueSelectedContacts = useMemo(() => {
+    const byCode = new Map<string, Contact>()
     selectedItems.forEach((contacts) => {
       contacts.forEach((contact) => {
-        if (!contactMap.has(contact.contactCode)) {
-          contactMap.set(contact.contactCode, {
-            id: contact.contactCode,
-            name: contact.name,
-            phone: contact.phone,
-          })
+        if (!byCode.has(contact.contactCode)) {
+          byCode.set(contact.contactCode, contact)
         }
       })
     })
+    return Array.from(byCode.values()).filter(
+      (c) => !excludedContactCodes.has(c.contactCode)
+    )
+  }, [selectedItems, excludedContactCodes])
 
-    return Array.from(contactMap.values())
-  }, [selectedItems])
+  const smsRecipientsFromSelection: SmsRecipient[] = useMemo(
+    () =>
+      uniqueSelectedContacts.map((c) => ({
+        id: c.contactCode,
+        name: c.name,
+        phone: c.phone,
+      })),
+    [uniqueSelectedContacts]
+  )
 
-  // Derive email recipients from the hand-picked selection
-  const emailRecipientsFromSelection: EmailRecipient[] = useMemo(() => {
-    const contactMap = new Map<string, EmailRecipient>()
-
-    selectedItems.forEach((contacts) => {
-      contacts.forEach((contact) => {
-        if (!contactMap.has(contact.contactCode)) {
-          contactMap.set(contact.contactCode, {
-            id: contact.contactCode,
-            name: contact.name,
-            email: contact.email,
-          })
-        }
-      })
-    })
-
-    return Array.from(contactMap.values())
-  }, [selectedItems])
+  const emailRecipientsFromSelection: EmailRecipient[] = useMemo(
+    () =>
+      uniqueSelectedContacts.map((c) => ({
+        id: c.contactCode,
+        name: c.name,
+        email: c.email,
+      })),
+    [uniqueSelectedContacts]
+  )
 
   // Use fetched recipients if available, otherwise use selection-derived ones
   const smsRecipients = fetchedSmsRecipients ?? smsRecipientsFromSelection
   const emailRecipients = fetchedEmailRecipients ?? emailRecipientsFromSelection
 
-  // Open SMS modal - fetch all contacts if "all results" selected
-  const handleOpenSmsModal = useCallback(async () => {
-    if (allResultsSelected && fetchAllContacts) {
-      setIsLoadingContacts(true)
-      try {
-        const contacts = await fetchAllContacts()
-        const recipients: SmsRecipient[] = contacts
-          .filter((c) => !excludedContactCodes.has(c.contactCode))
-          .map((c) => ({
-            id: c.contactCode,
-            name: c.name,
-            phone: c.phone,
-          }))
-        setFetchedSmsRecipients(recipients)
-        setShowSmsModal(true)
-      } catch (error) {
-        toast({
-          title: 'Kunde inte hämta kontakter',
-          description:
-            error instanceof Error ? error.message : 'Ett fel uppstod',
-          variant: 'destructive',
-        })
-      } finally {
-        setIsLoadingContacts(false)
-      }
-    } else {
-      setFetchedSmsRecipients(null)
-      setShowSmsModal(true)
-    }
-  }, [allResultsSelected, fetchAllContacts, excludedContactCodes, toast])
+  // Guards for the async contact fetch below: the exclusion set is read
+  // through a ref so a fetch resolving AFTER the user unchecked another row
+  // filters against the current set, and a generation counter discards
+  // out-of-order responses (double-click) and resolutions after unmount.
+  const excludedContactCodesRef = useRef(excludedContactCodes)
+  excludedContactCodesRef.current = excludedContactCodes
+  const openRequestIdRef = useRef(0)
+  useEffect(
+    () => () => {
+      // Invalidate any in-flight fetch on unmount
+      openRequestIdRef.current++
+    },
+    []
+  )
 
-  // Open Email modal - fetch all contacts if "all results" selected
-  const handleOpenEmailModal = useCallback(async () => {
-    if (allResultsSelected && fetchAllContacts) {
-      setIsLoadingContacts(true)
-      try {
-        const contacts = await fetchAllContacts()
-        const recipients: EmailRecipient[] = contacts
-          .filter((c) => !excludedContactCodes.has(c.contactCode))
-          .map((c) => ({
-            id: c.contactCode,
-            name: c.name,
-            email: c.email,
-          }))
-        setFetchedEmailRecipients(recipients)
-        setShowEmailModal(true)
-      } catch (error) {
-        toast({
-          title: 'Kunde inte hämta kontakter',
-          description:
-            error instanceof Error ? error.message : 'Ett fel uppstod',
-          variant: 'destructive',
-        })
-      } finally {
-        setIsLoadingContacts(false)
+  // Open a bulk modal. In "all results" mode the full filtered contact list
+  // is fetched and exclusions are applied; otherwise recipients derive from
+  // the hand-picked selection. Shared by the SMS and email handlers, which
+  // differ only in how a Contact maps to their recipient shape.
+  const openBulkModal = useCallback(
+    async <R>(
+      toRecipient: (c: Contact) => R,
+      setFetchedRecipients: (recipients: R[] | null) => void,
+      setShowModal: (open: boolean) => void
+    ) => {
+      if (allResultsSelected && fetchAllContacts) {
+        const requestId = ++openRequestIdRef.current
+        setIsLoadingContacts(true)
+        try {
+          const contacts = await fetchAllContacts()
+          if (requestId !== openRequestIdRef.current) return
+          const recipients = contacts
+            .filter((c) => !excludedContactCodesRef.current.has(c.contactCode))
+            .map(toRecipient)
+          setFetchedRecipients(recipients)
+          setShowModal(true)
+        } catch (error) {
+          if (requestId !== openRequestIdRef.current) return
+          toast({
+            title: 'Kunde inte hämta kontakter',
+            description:
+              error instanceof Error ? error.message : 'Ett fel uppstod',
+            variant: 'destructive',
+          })
+        } finally {
+          if (requestId === openRequestIdRef.current) {
+            setIsLoadingContacts(false)
+          }
+        }
+      } else {
+        if (allResultsSelected) {
+          // Recipients then derive from selectedItems, which only holds the
+          // page captured at select-all time — a consumer bug, not a user
+          // flow, hence the dev-facing warning.
+          console.warn(
+            'useBulkMessaging: allResultsSelected without fetchAllContacts — recipients are limited to the captured page'
+          )
+        }
+        setFetchedRecipients(null)
+        setShowModal(true)
       }
-    } else {
-      setFetchedEmailRecipients(null)
-      setShowEmailModal(true)
-    }
-  }, [allResultsSelected, fetchAllContacts, excludedContactCodes, toast])
+    },
+    [allResultsSelected, fetchAllContacts, toast]
+  )
+
+  const handleOpenSmsModal = useCallback(
+    () =>
+      openBulkModal<SmsRecipient>(
+        (c) => ({ id: c.contactCode, name: c.name, phone: c.phone }),
+        setFetchedSmsRecipients,
+        setShowSmsModal
+      ),
+    [openBulkModal]
+  )
+
+  const handleOpenEmailModal = useCallback(
+    () =>
+      openBulkModal<EmailRecipient>(
+        (c) => ({ id: c.contactCode, name: c.name, email: c.email }),
+        setFetchedEmailRecipients,
+        setShowEmailModal
+      ),
+    [openBulkModal]
+  )
 
   // Handle modal close - clear fetched recipients
   const handleSetShowSmsModal = useCallback((open: boolean) => {
@@ -418,6 +455,7 @@ export function useBulkMessaging<TItem>({
     selectedIds,
     allResultsSelected,
     selectedCount,
+    excludedRecipientsCount: excludedContactCodes.size,
 
     // Selection actions
     toggleSelection,

--- a/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
+++ b/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
@@ -88,9 +88,21 @@ export function useBulkMessaging<TItem>({
 }: UseBulkMessagingOptions<TItem>): UseBulkMessagingReturn {
   const { toast } = useToast()
 
-  // Selection state
-  const [selectedIds, setSelectedIds] = useState<string[]>([])
+  // Selection state: itemId -> contacts of that row, captured at selection
+  // time. Carrying the contacts lets a selection survive pagination — the
+  // items of other pages are not available for lookup later.
+  const [selectedItems, setSelectedItems] = useState<Map<string, Contact[]>>(
+    new Map()
+  )
   const [allResultsSelected, setAllResultsSelected] = useState(false)
+  // Rows unchecked while "all results" is selected: itemId -> contactCodes of
+  // that row, captured at uncheck time (the row is on-screen when unchecked).
+  // A Map (not a Set) so re-checking a row removes exactly its contribution,
+  // and a contact shared by two excluded rows stays excluded until both are
+  // re-checked.
+  const [excludedItems, setExcludedItems] = useState<Map<string, string[]>>(
+    new Map()
+  )
 
   // Modal state
   const [showSmsModal, setShowSmsModal] = useState(false)
@@ -105,49 +117,99 @@ export function useBulkMessaging<TItem>({
     EmailRecipient[] | null
   >(null)
 
-  // Computed selection count
-  const selectedCount = allResultsSelected ? totalCount : selectedIds.length
+  const selectedIds = useMemo(
+    () => Array.from(selectedItems.keys()),
+    [selectedItems]
+  )
 
-  // Toggle single item selection
-  const toggleSelection = useCallback((id: string) => {
-    setAllResultsSelected(false)
-    setSelectedIds((prev) =>
-      prev.includes(id) ? prev.filter((i) => i !== id) : [...prev, id]
-    )
-  }, [])
+  // Computed selection count
+  const selectedCount = allResultsSelected
+    ? totalCount - excludedItems.size
+    : selectedItems.size
+
+  // ContactCodes of all excluded rows. Note: exclusion is effectively per
+  // CONTACT — if an excluded row's contact also appears on another selected
+  // item, they are excluded from the send entirely. That matches the intent
+  // ("don't message this person") and is what makes a frontend-only exclusion
+  // possible, since fetched contacts carry no item association.
+  const excludedContactCodes = useMemo(() => {
+    const codes = new Set<string>()
+    excludedItems.forEach((contactCodes) => {
+      contactCodes.forEach((code) => codes.add(code))
+    })
+    return codes
+  }, [excludedItems])
+
+  // Toggle single item selection. In "all results" mode, unchecking a row
+  // excludes it from the selection instead of collapsing the mode back to
+  // the current page.
+  const toggleSelection = useCallback(
+    (id: string) => {
+      if (allResultsSelected) {
+        setExcludedItems((prev) => {
+          const next = new Map(prev)
+          if (next.has(id)) {
+            next.delete(id)
+          } else {
+            const item = items.find((i) => getItemId(i) === id)
+            next.set(
+              id,
+              item ? getContacts(item).map((c) => c.contactCode) : []
+            )
+          }
+          return next
+        })
+        return
+      }
+      setSelectedItems((prev) => {
+        const next = new Map(prev)
+        if (next.has(id)) {
+          next.delete(id)
+        } else {
+          const item = items.find((i) => getItemId(i) === id)
+          next.set(id, item ? getContacts(item) : [])
+        }
+        return next
+      })
+    },
+    [allResultsSelected, items, getItemId, getContacts]
+  )
 
   // Toggle select all (selects ALL results, not just current page)
   const toggleSelectAll = useCallback(() => {
-    if (allResultsSelected || selectedIds.length > 0) {
-      setSelectedIds([])
+    setExcludedItems(new Map())
+    if (allResultsSelected || selectedItems.size > 0) {
+      setSelectedItems(new Map())
       setAllResultsSelected(false)
     } else {
       setAllResultsSelected(true)
-      setSelectedIds(items.map(getItemId))
+      setSelectedItems(
+        new Map(items.map((item) => [getItemId(item), getContacts(item)]))
+      )
     }
-  }, [allResultsSelected, selectedIds.length, items, getItemId])
+  }, [allResultsSelected, selectedItems.size, items, getItemId, getContacts])
 
   // Clear all selection
   const clearSelection = useCallback(() => {
-    setSelectedIds([])
+    setSelectedItems(new Map())
     setAllResultsSelected(false)
+    setExcludedItems(new Map())
   }, [])
 
   // Check if item is selected
   const isSelected = useCallback(
-    (id: string) => allResultsSelected || selectedIds.includes(id),
-    [allResultsSelected, selectedIds]
+    (id: string) =>
+      allResultsSelected ? !excludedItems.has(id) : selectedItems.has(id),
+    [allResultsSelected, excludedItems, selectedItems]
   )
 
-  // Derive SMS recipients from selected items on current page
-  const smsRecipientsFromPage: SmsRecipient[] = useMemo(() => {
-    const selectedItems = items.filter((item) =>
-      selectedIds.includes(getItemId(item))
-    )
+  // Derive SMS recipients from the hand-picked selection (contacts captured
+  // at selection time, so the selection works across pages)
+  const smsRecipientsFromSelection: SmsRecipient[] = useMemo(() => {
     const contactMap = new Map<string, SmsRecipient>()
 
-    selectedItems.forEach((item) => {
-      getContacts(item).forEach((contact) => {
+    selectedItems.forEach((contacts) => {
+      contacts.forEach((contact) => {
         if (!contactMap.has(contact.contactCode)) {
           contactMap.set(contact.contactCode, {
             id: contact.contactCode,
@@ -159,17 +221,14 @@ export function useBulkMessaging<TItem>({
     })
 
     return Array.from(contactMap.values())
-  }, [items, selectedIds, getItemId, getContacts])
+  }, [selectedItems])
 
-  // Derive email recipients from selected items on current page
-  const emailRecipientsFromPage: EmailRecipient[] = useMemo(() => {
-    const selectedItems = items.filter((item) =>
-      selectedIds.includes(getItemId(item))
-    )
+  // Derive email recipients from the hand-picked selection
+  const emailRecipientsFromSelection: EmailRecipient[] = useMemo(() => {
     const contactMap = new Map<string, EmailRecipient>()
 
-    selectedItems.forEach((item) => {
-      getContacts(item).forEach((contact) => {
+    selectedItems.forEach((contacts) => {
+      contacts.forEach((contact) => {
         if (!contactMap.has(contact.contactCode)) {
           contactMap.set(contact.contactCode, {
             id: contact.contactCode,
@@ -181,11 +240,11 @@ export function useBulkMessaging<TItem>({
     })
 
     return Array.from(contactMap.values())
-  }, [items, selectedIds, getItemId, getContacts])
+  }, [selectedItems])
 
-  // Use fetched recipients if available, otherwise use page-derived ones
-  const smsRecipients = fetchedSmsRecipients ?? smsRecipientsFromPage
-  const emailRecipients = fetchedEmailRecipients ?? emailRecipientsFromPage
+  // Use fetched recipients if available, otherwise use selection-derived ones
+  const smsRecipients = fetchedSmsRecipients ?? smsRecipientsFromSelection
+  const emailRecipients = fetchedEmailRecipients ?? emailRecipientsFromSelection
 
   // Open SMS modal - fetch all contacts if "all results" selected
   const handleOpenSmsModal = useCallback(async () => {
@@ -193,11 +252,13 @@ export function useBulkMessaging<TItem>({
       setIsLoadingContacts(true)
       try {
         const contacts = await fetchAllContacts()
-        const recipients: SmsRecipient[] = contacts.map((c) => ({
-          id: c.contactCode,
-          name: c.name,
-          phone: c.phone,
-        }))
+        const recipients: SmsRecipient[] = contacts
+          .filter((c) => !excludedContactCodes.has(c.contactCode))
+          .map((c) => ({
+            id: c.contactCode,
+            name: c.name,
+            phone: c.phone,
+          }))
         setFetchedSmsRecipients(recipients)
         setShowSmsModal(true)
       } catch (error) {
@@ -214,7 +275,7 @@ export function useBulkMessaging<TItem>({
       setFetchedSmsRecipients(null)
       setShowSmsModal(true)
     }
-  }, [allResultsSelected, fetchAllContacts, toast])
+  }, [allResultsSelected, fetchAllContacts, excludedContactCodes, toast])
 
   // Open Email modal - fetch all contacts if "all results" selected
   const handleOpenEmailModal = useCallback(async () => {
@@ -222,11 +283,13 @@ export function useBulkMessaging<TItem>({
       setIsLoadingContacts(true)
       try {
         const contacts = await fetchAllContacts()
-        const recipients: EmailRecipient[] = contacts.map((c) => ({
-          id: c.contactCode,
-          name: c.name,
-          email: c.email,
-        }))
+        const recipients: EmailRecipient[] = contacts
+          .filter((c) => !excludedContactCodes.has(c.contactCode))
+          .map((c) => ({
+            id: c.contactCode,
+            name: c.name,
+            email: c.email,
+          }))
         setFetchedEmailRecipients(recipients)
         setShowEmailModal(true)
       } catch (error) {
@@ -243,7 +306,7 @@ export function useBulkMessaging<TItem>({
       setFetchedEmailRecipients(null)
       setShowEmailModal(true)
     }
-  }, [allResultsSelected, fetchAllContacts, toast])
+  }, [allResultsSelected, fetchAllContacts, excludedContactCodes, toast])
 
   // Handle modal close - clear fetched recipients
   const handleSetShowSmsModal = useCallback((open: boolean) => {

--- a/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
+++ b/apps/property-tree/src/shared/hooks/useBulkMessaging.ts
@@ -90,19 +90,13 @@ export function useBulkMessaging<TItem>({
 }: UseBulkMessagingOptions<TItem>): UseBulkMessagingReturn {
   const { toast } = useToast()
 
-  // Selection state: itemId -> contacts of that row, captured at selection
-  // time. Carrying the contacts lets a selection survive pagination — the
-  // items of other pages are not available for lookup later.
+  // itemId -> contacts, captured at click time so selections survive pagination
   const [selectedItems, setSelectedItems] = useState<Map<string, Contact[]>>(
     new Map()
   )
   const [allResultsSelected, setAllResultsSelected] = useState(false)
-  // Rows unchecked while "all results" is selected: itemId -> contacts of
-  // that row, captured at uncheck time (the row is on-screen when unchecked).
-  // A Map (not a Set) so re-checking a row removes exactly its contribution,
-  // and a contact shared by two excluded rows stays excluded until both are
-  // re-checked. Same shape as selectedItems so both toggles share one code
-  // path.
+  // Rows unchecked in all-results mode (itemId -> contacts). A Map so
+  // re-checking a row removes exactly that row's contribution.
   const [excludedItems, setExcludedItems] = useState<Map<string, Contact[]>>(
     new Map()
   )
@@ -130,11 +124,8 @@ export function useBulkMessaging<TItem>({
     ? totalCount - excludedItems.size
     : selectedItems.size
 
-  // ContactCodes of all excluded rows. Note: exclusion is effectively per
-  // CONTACT — if an excluded row's contact also appears on another selected
-  // item, they are excluded from the send entirely. That matches the intent
-  // ("don't message this person") and is what makes a frontend-only exclusion
-  // possible, since fetched contacts carry no item association.
+  // Exclusion is per CONTACT: an excluded row's contact is dropped from the
+  // whole send, even if they appear on other selected contracts.
   const excludedContactCodes = useMemo(
     () =>
       new Set(
@@ -145,9 +136,8 @@ export function useBulkMessaging<TItem>({
     [excludedItems]
   )
 
-  // Toggle single item selection. In "all results" mode, unchecking a row
-  // excludes it from the selection instead of collapsing the mode back to
-  // the current page.
+  // In all-results mode, unchecking a row excludes it instead of collapsing
+  // the mode back to the current page.
   const toggleSelection = useCallback(
     (id: string) => {
       const currentMap = allResultsSelected ? excludedItems : selectedItems
@@ -165,10 +155,8 @@ export function useBulkMessaging<TItem>({
       const item = items.find((i) => getItemId(i) === id)
       const contacts = item ? getContacts(item) : []
       if (allResultsSelected && contacts.length === 0) {
-        // Exclusion works by filtering the row's contactCodes out of the
-        // fetched recipient list. With no captured contacts the exclusion
-        // would be a silent no-op (the tenant would still be messaged), so
-        // refuse the uncheck instead of pretending it worked.
+        // Without captured contacts the exclusion would be a silent no-op
+        // (the tenant would still be messaged) — refuse the uncheck
         toast({
           title: 'Raden kan inte undantas',
           description: 'Kontaktuppgifter saknas för raden.',
@@ -217,11 +205,8 @@ export function useBulkMessaging<TItem>({
     [allResultsSelected, excludedItems, selectedItems]
   )
 
-  // Unique contacts of the hand-picked selection (contacts captured at
-  // selection time, so the selection works across pages). First occurrence
-  // wins per contactCode. The exclusion filter is applied here too so every
-  // recipient path respects exclusions by construction — in hand-picked mode
-  // excludedContactCodes is always empty, making it a no-op there.
+  // Unique contacts of the hand-picked selection (first-wins per
+  // contactCode), minus exclusions
   const uniqueSelectedContacts = useMemo(() => {
     const byCode = new Map<string, Contact>()
     selectedItems.forEach((contacts) => {
@@ -260,25 +245,20 @@ export function useBulkMessaging<TItem>({
   const smsRecipients = fetchedSmsRecipients ?? smsRecipientsFromSelection
   const emailRecipients = fetchedEmailRecipients ?? emailRecipientsFromSelection
 
-  // Guards for the async contact fetch below: the exclusion set is read
-  // through a ref so a fetch resolving AFTER the user unchecked another row
-  // filters against the current set, and a generation counter discards
-  // out-of-order responses (double-click) and resolutions after unmount.
+  // Stale-fetch guards: exclusions are read via ref at resolve time, and a
+  // generation counter discards out-of-order/unmounted resolutions
   const excludedContactCodesRef = useRef(excludedContactCodes)
   excludedContactCodesRef.current = excludedContactCodes
   const openRequestIdRef = useRef(0)
   useEffect(
     () => () => {
-      // Invalidate any in-flight fetch on unmount
       openRequestIdRef.current++
     },
     []
   )
 
-  // Open a bulk modal. In "all results" mode the full filtered contact list
-  // is fetched and exclusions are applied; otherwise recipients derive from
-  // the hand-picked selection. Shared by the SMS and email handlers, which
-  // differ only in how a Contact maps to their recipient shape.
+  // Shared open handler: fetch the full contact list (all-results mode) and
+  // apply exclusions, else fall back to the hand-picked selection
   const openBulkModal = useCallback(
     async <R>(
       toRecipient: (c: Contact) => R,
@@ -311,9 +291,7 @@ export function useBulkMessaging<TItem>({
         }
       } else {
         if (allResultsSelected) {
-          // Recipients then derive from selectedItems, which only holds the
-          // page captured at select-all time — a consumer bug, not a user
-          // flow, hence the dev-facing warning.
+          // Consumer bug: recipients only cover the page captured at select-all
           console.warn(
             'useBulkMessaging: allResultsSelected without fetchAllContacts — recipients are limited to the captured page'
           )

--- a/apps/property-tree/src/shared/hooks/useRemovableRecipients.ts
+++ b/apps/property-tree/src/shared/hooks/useRemovableRecipients.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+/**
+ * Manual removal of recipients (the ✕ on recipient chips) for the bulk send
+ * modals. Removal state resets whenever the modal opens or closes, so a
+ * dismissed modal never leaks removals into the next send.
+ */
+export function useRemovableRecipients<T extends { id: string }>(
+  recipients: T[],
+  open: boolean
+) {
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    // Avoid a pointless allocation + re-render when nothing was removed
+    setRemovedIds((prev) => (prev.size === 0 ? prev : new Set()))
+  }, [open])
+
+  // Keep the input identity when nothing was removed so memoized consumers
+  // (e.g. the chip list) don't re-render for free
+  const activeRecipients = useMemo(
+    () =>
+      removedIds.size === 0
+        ? recipients
+        : recipients.filter((r) => !removedIds.has(r.id)),
+    [recipients, removedIds]
+  )
+
+  const removeRecipient = useCallback((id: string) => {
+    setRemovedIds((prev) => new Set(prev).add(id))
+  }, [])
+
+  return {
+    activeRecipients,
+    removedCount: recipients.length - activeRecipients.length,
+    removeRecipient,
+  }
+}

--- a/apps/property-tree/src/shared/hooks/useRemovableRecipients.ts
+++ b/apps/property-tree/src/shared/hooks/useRemovableRecipients.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 /**
- * Manual removal of recipients (the ✕ on recipient chips) for the bulk send
- * modals. Removal state resets whenever the modal opens or closes, so a
- * dismissed modal never leaks removals into the next send.
+ * Manual removal of recipients (the ✕ on chips) for the bulk send modals.
+ * Removal state resets on open/close so removals never leak into the next send.
  */
 export function useRemovableRecipients<T extends { id: string }>(
   recipients: T[],
@@ -12,12 +11,10 @@ export function useRemovableRecipients<T extends { id: string }>(
   const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
 
   useEffect(() => {
-    // Avoid a pointless allocation + re-render when nothing was removed
     setRemovedIds((prev) => (prev.size === 0 ? prev : new Set()))
   }, [open])
 
-  // Keep the input identity when nothing was removed so memoized consumers
-  // (e.g. the chip list) don't re-render for free
+  // Keeps input identity when nothing is removed, so memoized consumers skip
   const activeRecipients = useMemo(
     () =>
       removedIds.size === 0

--- a/apps/property-tree/src/shared/ui/Checkbox.tsx
+++ b/apps/property-tree/src/shared/ui/Checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox'
-import { Check } from 'lucide-react'
+import { Check, Minus } from 'lucide-react'
 
 import { cn } from '@/shared/lib/utils'
 
@@ -11,7 +11,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-[2px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-4 w-4 shrink-0 rounded-[2px] border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground',
       className
     )}
     {...props}
@@ -19,7 +19,11 @@ const Checkbox = React.forwardRef<
     <CheckboxPrimitive.Indicator
       className={cn('flex items-center justify-center text-current')}
     >
-      <Check className="h-4 w-4" />
+      {props.checked === 'indeterminate' ? (
+        <Minus className="h-4 w-4" />
+      ) : (
+        <Check className="h-4 w-4" />
+      )}
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/apps/property-tree/src/shared/ui/EmailModal.tsx
+++ b/apps/property-tree/src/shared/ui/EmailModal.tsx
@@ -62,10 +62,8 @@ export function EmailModal(props: EmailModalProps) {
   const [isSending, setIsSending] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
 
-  // Single reset path for all per-session state, on both open and close.
-  // Esc/overlay dismissal calls onOpenChange directly and bypasses
-  // handleClose, so nothing may rely on handleClose for cleanup.
-  // (useRemovableRecipients resets its removal state on `open` the same way.)
+  // Single reset path for per-session state — Esc/overlay dismissal bypasses
+  // handleClose, so resets must not live there
   useEffect(() => {
     setSubject('')
     setBody('')
@@ -138,8 +136,7 @@ export function EmailModal(props: EmailModalProps) {
     onOpenChange(false)
   }
 
-  // Contacts excluded via table-row unchecking, shown so the header numbers
-  // reconcile with the selected-contract count
+  // Contacts excluded via table-row unchecking
   const excludedSuffix =
     isBulk && props.excludedRecipientsCount
       ? ` \u00b7 ${props.excludedRecipientsCount} ${
@@ -147,9 +144,8 @@ export function EmailModal(props: EmailModalProps) {
         }`
       : ''
 
-  // Deliberately based on the ORIGINAL recipient list: this line explains the
-  // contracts\u2192contacts deduplication, which manual removals must not skew.
-  // Removals are surfaced separately next to the "Mottagare" label.
+  // Based on the ORIGINAL list: this line explains deduplication, which
+  // manual removals must not skew (removals shown at the "Mottagare" label)
   const description = isBulk
     ? (props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length

--- a/apps/property-tree/src/shared/ui/EmailModal.tsx
+++ b/apps/property-tree/src/shared/ui/EmailModal.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useState } from 'react'
-import { AlertTriangle, ChevronDown, Info, Mail, User } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, ChevronDown, Info, Mail, User, X } from 'lucide-react'
 
 import { cn } from '@/shared/lib/utils'
 import { Badge } from '@/shared/ui/Badge'
@@ -57,15 +57,38 @@ export function EmailModal(props: EmailModalProps) {
   const [body, setBody] = useState('')
   const [isSending, setIsSending] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
+  // Recipients manually removed via the ✕ on their chip (bulk mode only)
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
+
+  // Single reset path for all per-session state, on both open and close.
+  // Esc/overlay dismissal calls onOpenChange directly and bypasses
+  // handleClose, so nothing may rely on handleClose for cleanup.
+  useEffect(() => {
+    setSubject('')
+    setBody('')
+    setRemovedIds(new Set())
+    setShowAllInvalid(false)
+  }, [open])
 
   const recipients = props.recipients ?? []
 
+  const activeRecipients = useMemo(
+    () => recipients.filter((r) => !removedIds.has(r.id)),
+    [recipients, removedIds]
+  )
+
   const { validRecipients, invalidRecipients } = useMemo(() => {
     if (!isBulk) return { validRecipients: [], invalidRecipients: [] }
-    const valid = recipients.filter((r) => r.email)
-    const invalid = recipients.filter((r) => !r.email)
+    const valid = activeRecipients.filter((r) => r.email)
+    const invalid = activeRecipients.filter((r) => !r.email)
     return { validRecipients: valid, invalidRecipients: invalid }
-  }, [isBulk, recipients])
+  }, [isBulk, activeRecipients])
+
+  const removeRecipient = useCallback((id: string) => {
+    setRemovedIds((prev) => new Set(prev).add(id))
+  }, [])
+
+  const removedCount = recipients.length - activeRecipients.length
 
   const duplicatesRemoved =
     isBulk &&
@@ -118,11 +141,12 @@ export function EmailModal(props: EmailModalProps) {
   ])
 
   const handleClose = () => {
-    setSubject('')
-    setBody('')
     onOpenChange(false)
   }
 
+  // Deliberately based on the ORIGINAL recipient list: this line explains the
+  // contracts\u2192contacts deduplication, which manual removals must not skew.
+  // Removals are surfaced separately next to the "Mottagare" label.
   const description = isBulk
     ? props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length
@@ -147,6 +171,12 @@ export function EmailModal(props: EmailModalProps) {
               <div>
                 <Label className="text-sm font-medium">
                   Mottagare ({validRecipients.length})
+                  {removedCount > 0 && (
+                    <span className="ml-2 font-normal text-muted-foreground">
+                      {removedCount}{' '}
+                      {removedCount === 1 ? 'borttagen' : 'borttagna'}
+                    </span>
+                  )}
                 </Label>
                 <div className="mt-2 flex flex-wrap gap-2 max-h-24 overflow-y-auto p-2 border rounded-md bg-muted/30">
                   {validRecipients.map((recipient) => (
@@ -157,6 +187,14 @@ export function EmailModal(props: EmailModalProps) {
                     >
                       <User className="h-3 w-3" />
                       {recipient.name}
+                      <button
+                        type="button"
+                        aria-label={`Ta bort ${recipient.name}`}
+                        className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
+                        onClick={() => removeRecipient(recipient.id)}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
                     </Badge>
                   ))}
                 </div>

--- a/apps/property-tree/src/shared/ui/EmailModal.tsx
+++ b/apps/property-tree/src/shared/ui/EmailModal.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, ChevronDown, Info, Mail, User, X } from 'lucide-react'
+import { AlertTriangle, ChevronDown, Info, Mail } from 'lucide-react'
 
+import { useRemovableRecipients } from '@/shared/hooks/useRemovableRecipients'
 import { cn } from '@/shared/lib/utils'
-import { Badge } from '@/shared/ui/Badge'
 import { Button } from '@/shared/ui/Button'
 import {
   Dialog,
@@ -14,6 +14,7 @@ import {
 } from '@/shared/ui/Dialog'
 import { Input } from '@/shared/ui/Input'
 import { Label } from '@/shared/ui/Label'
+import { RecipientChipList } from '@/shared/ui/RecipientChipList'
 import { Textarea } from '@/shared/ui/Textarea'
 
 export interface EmailRecipient {
@@ -33,11 +34,14 @@ interface EmailModalSingleProps extends EmailModalBaseProps {
   onSend: (subject: string, body: string) => Promise<void>
   recipients?: undefined
   totalSelectedItems?: undefined
+  excludedRecipientsCount?: undefined
 }
 
 interface EmailModalBulkProps extends EmailModalBaseProps {
   recipients: EmailRecipient[]
   totalSelectedItems?: number
+  /** Contacts excluded by unchecking rows in the table (all-results mode) */
+  excludedRecipientsCount?: number
   onSend?: (
     subject: string,
     body: string,
@@ -57,25 +61,21 @@ export function EmailModal(props: EmailModalProps) {
   const [body, setBody] = useState('')
   const [isSending, setIsSending] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
-  // Recipients manually removed via the ✕ on their chip (bulk mode only)
-  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
 
   // Single reset path for all per-session state, on both open and close.
   // Esc/overlay dismissal calls onOpenChange directly and bypasses
   // handleClose, so nothing may rely on handleClose for cleanup.
+  // (useRemovableRecipients resets its removal state on `open` the same way.)
   useEffect(() => {
     setSubject('')
     setBody('')
-    setRemovedIds(new Set())
     setShowAllInvalid(false)
   }, [open])
 
   const recipients = props.recipients ?? []
 
-  const activeRecipients = useMemo(
-    () => recipients.filter((r) => !removedIds.has(r.id)),
-    [recipients, removedIds]
-  )
+  const { activeRecipients, removedCount, removeRecipient } =
+    useRemovableRecipients(recipients, open)
 
   const { validRecipients, invalidRecipients } = useMemo(() => {
     if (!isBulk) return { validRecipients: [], invalidRecipients: [] }
@@ -83,12 +83,6 @@ export function EmailModal(props: EmailModalProps) {
     const invalid = activeRecipients.filter((r) => !r.email)
     return { validRecipients: valid, invalidRecipients: invalid }
   }, [isBulk, activeRecipients])
-
-  const removeRecipient = useCallback((id: string) => {
-    setRemovedIds((prev) => new Set(prev).add(id))
-  }, [])
-
-  const removedCount = recipients.length - activeRecipients.length
 
   const duplicatesRemoved =
     isBulk &&
@@ -144,14 +138,24 @@ export function EmailModal(props: EmailModalProps) {
     onOpenChange(false)
   }
 
+  // Contacts excluded via table-row unchecking, shown so the header numbers
+  // reconcile with the selected-contract count
+  const excludedSuffix =
+    isBulk && props.excludedRecipientsCount
+      ? ` \u00b7 ${props.excludedRecipientsCount} ${
+          props.excludedRecipientsCount === 1 ? 'exkluderad' : 'exkluderade'
+        }`
+      : ''
+
   // Deliberately based on the ORIGINAL recipient list: this line explains the
   // contracts\u2192contacts deduplication, which manual removals must not skew.
   // Removals are surfaced separately next to the "Mottagare" label.
   const description = isBulk
-    ? props.totalSelectedItems != null &&
+    ? (props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length
-      ? `${props.totalSelectedItems} valda hyreskontrakt \u2192 ${recipients.length} unika kontakter`
-      : `Skicka mejl till ${validRecipients.length} av ${recipients.length} valda kunder`
+        ? `${props.totalSelectedItems} valda hyreskontrakt \u2192 ${recipients.length} unika kontakter`
+        : `Skicka mejl till ${validRecipients.length} av ${recipients.length} valda kunder`) +
+      excludedSuffix
     : `Till ${props.recipientName} (${props.emailAddress})`
 
   return (
@@ -178,26 +182,10 @@ export function EmailModal(props: EmailModalProps) {
                     </span>
                   )}
                 </Label>
-                <div className="mt-2 flex flex-wrap gap-2 max-h-24 overflow-y-auto p-2 border rounded-md bg-muted/30">
-                  {validRecipients.map((recipient) => (
-                    <Badge
-                      key={recipient.id}
-                      variant="secondary"
-                      className="flex items-center gap-1"
-                    >
-                      <User className="h-3 w-3" />
-                      {recipient.name}
-                      <button
-                        type="button"
-                        aria-label={`Ta bort ${recipient.name}`}
-                        className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
-                        onClick={() => removeRecipient(recipient.id)}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                </div>
+                <RecipientChipList
+                  recipients={validRecipients}
+                  onRemove={removeRecipient}
+                />
               </div>
 
               {(duplicatesRemoved > 0 || invalidRecipients.length > 0) && (

--- a/apps/property-tree/src/shared/ui/RecipientChipList.tsx
+++ b/apps/property-tree/src/shared/ui/RecipientChipList.tsx
@@ -1,0 +1,66 @@
+import { memo, useState } from 'react'
+import { User, X } from 'lucide-react'
+
+import { Badge } from '@/shared/ui/Badge'
+
+// Display cap: rendering thousands of chips freezes the UI for seconds
+// (measured ~9s at 12.7k chips), so only this many get DOM elements up
+// front. This is DISPLAY-ONLY — every recipient stays in state, in all
+// counters, and in the send payload regardless of what is rendered.
+const INITIAL_VISIBLE = 100
+const VISIBLE_INCREMENT = 200
+
+interface RecipientChipListProps {
+  recipients: { id: string; name: string }[]
+  onRemove: (id: string) => void
+}
+
+/**
+ * Chip list for bulk-send recipients with a remove button per chip.
+ * Memoized so keystrokes in the surrounding form can't re-render what may be
+ * a very large list.
+ */
+export const RecipientChipList = memo(function RecipientChipList({
+  recipients,
+  onRemove,
+}: RecipientChipListProps) {
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE)
+
+  const visibleRecipients =
+    recipients.length > visibleCount
+      ? recipients.slice(0, visibleCount)
+      : recipients
+  const hiddenCount = recipients.length - visibleRecipients.length
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-2 max-h-24 overflow-y-auto p-2 border rounded-md bg-muted/30">
+      {visibleRecipients.map((recipient) => (
+        <Badge
+          key={recipient.id}
+          variant="secondary"
+          className="flex items-center gap-1"
+        >
+          <User className="h-3 w-3" />
+          {recipient.name}
+          <button
+            type="button"
+            aria-label={`Ta bort ${recipient.name}`}
+            className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
+            onClick={() => onRemove(recipient.id)}
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </Badge>
+      ))}
+      {hiddenCount > 0 && (
+        <button
+          type="button"
+          className="text-sm text-muted-foreground underline hover:text-foreground"
+          onClick={() => setVisibleCount((c) => c + VISIBLE_INCREMENT)}
+        >
+          Visa fler ({hiddenCount.toLocaleString('sv-SE')} till)
+        </button>
+      )}
+    </div>
+  )
+})

--- a/apps/property-tree/src/shared/ui/RecipientChipList.tsx
+++ b/apps/property-tree/src/shared/ui/RecipientChipList.tsx
@@ -3,10 +3,8 @@ import { User, X } from 'lucide-react'
 
 import { Badge } from '@/shared/ui/Badge'
 
-// Display cap: rendering thousands of chips freezes the UI for seconds
-// (measured ~9s at 12.7k chips), so only this many get DOM elements up
-// front. This is DISPLAY-ONLY — every recipient stays in state, in all
-// counters, and in the send payload regardless of what is rendered.
+// Display-only cap — rendering thousands of chips freezes the UI. Every
+// recipient stays in state, counters and the send payload regardless.
 const INITIAL_VISIBLE = 100
 const VISIBLE_INCREMENT = 200
 
@@ -16,9 +14,8 @@ interface RecipientChipListProps {
 }
 
 /**
- * Chip list for bulk-send recipients with a remove button per chip.
- * Memoized so keystrokes in the surrounding form can't re-render what may be
- * a very large list.
+ * Bulk-send recipient chips with a remove button per chip. Memoized so
+ * keystrokes in the surrounding form don't re-render a large list.
  */
 export const RecipientChipList = memo(function RecipientChipList({
   recipients,

--- a/apps/property-tree/src/shared/ui/SmsModal.tsx
+++ b/apps/property-tree/src/shared/ui/SmsModal.tsx
@@ -64,10 +64,8 @@ export function SmsModal(props: SmsModalProps) {
   const [showCostConfirmation, setShowCostConfirmation] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
 
-  // Single reset path for all per-session state, on both open and close.
-  // Esc/overlay dismissal calls onOpenChange directly and bypasses
-  // handleClose, so nothing may rely on handleClose for cleanup.
-  // (useRemovableRecipients resets its removal state on `open` the same way.)
+  // Single reset path for per-session state — Esc/overlay dismissal bypasses
+  // handleClose, so resets must not live there
   useEffect(() => {
     setMessage('')
     setShowCostConfirmation(false)
@@ -147,8 +145,7 @@ export function SmsModal(props: SmsModalProps) {
     onOpenChange(false)
   }
 
-  // Contacts excluded via table-row unchecking, shown so the header numbers
-  // reconcile with the selected-contract count
+  // Contacts excluded via table-row unchecking
   const excludedSuffix =
     isBulk && props.excludedRecipientsCount
       ? ` \u00b7 ${props.excludedRecipientsCount} ${
@@ -156,9 +153,8 @@ export function SmsModal(props: SmsModalProps) {
         }`
       : ''
 
-  // Deliberately based on the ORIGINAL recipient list: this line explains the
-  // contracts\u2192contacts deduplication, which manual removals must not skew.
-  // Removals are surfaced separately next to the "Mottagare" label.
+  // Based on the ORIGINAL list: this line explains deduplication, which
+  // manual removals must not skew (removals shown at the "Mottagare" label)
   const description = isBulk
     ? (props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length

--- a/apps/property-tree/src/shared/ui/SmsModal.tsx
+++ b/apps/property-tree/src/shared/ui/SmsModal.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   AlertTriangle,
   ChevronDown,
   Info,
   MessageSquare,
   User,
+  X,
 } from 'lucide-react'
 
 import { cn } from '@/shared/lib/utils'
@@ -65,17 +66,40 @@ export function SmsModal(props: SmsModalProps) {
   const [isSending, setIsSending] = useState(false)
   const [showCostConfirmation, setShowCostConfirmation] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
+  // Recipients manually removed via the ✕ on their chip (bulk mode only)
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
+
+  // Single reset path for all per-session state, on both open and close.
+  // Esc/overlay dismissal calls onOpenChange directly and bypasses
+  // handleClose, so nothing may rely on handleClose for cleanup.
+  useEffect(() => {
+    setMessage('')
+    setShowCostConfirmation(false)
+    setRemovedIds(new Set())
+    setShowAllInvalid(false)
+  }, [open])
 
   const charactersLeft = MAX_SMS_LENGTH - message.length
 
   const recipients = props.recipients ?? []
 
+  const activeRecipients = useMemo(
+    () => recipients.filter((r) => !removedIds.has(r.id)),
+    [recipients, removedIds]
+  )
+
   const { validRecipients, invalidRecipients } = useMemo(() => {
     if (!isBulk) return { validRecipients: [], invalidRecipients: [] }
-    const valid = recipients.filter((r) => hasPhoneNumber(r.phone))
-    const invalid = recipients.filter((r) => !hasPhoneNumber(r.phone))
+    const valid = activeRecipients.filter((r) => hasPhoneNumber(r.phone))
+    const invalid = activeRecipients.filter((r) => !hasPhoneNumber(r.phone))
     return { validRecipients: valid, invalidRecipients: invalid }
-  }, [isBulk, recipients])
+  }, [isBulk, activeRecipients])
+
+  const removeRecipient = useCallback((id: string) => {
+    setRemovedIds((prev) => new Set(prev).add(id))
+  }, [])
+
+  const removedCount = recipients.length - activeRecipients.length
 
   const estimatedCost = validRecipients.length * SMS_COST_SEK
   const duplicatesRemoved =
@@ -133,11 +157,12 @@ export function SmsModal(props: SmsModalProps) {
   ])
 
   const handleClose = () => {
-    setMessage('')
-    setShowCostConfirmation(false)
     onOpenChange(false)
   }
 
+  // Deliberately based on the ORIGINAL recipient list: this line explains the
+  // contracts\u2192contacts deduplication, which manual removals must not skew.
+  // Removals are surfaced separately next to the "Mottagare" label.
   const description = isBulk
     ? props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length
@@ -162,6 +187,12 @@ export function SmsModal(props: SmsModalProps) {
               <div>
                 <label className="text-sm font-medium">
                   Mottagare ({validRecipients.length})
+                  {removedCount > 0 && (
+                    <span className="ml-2 font-normal text-muted-foreground">
+                      {removedCount}{' '}
+                      {removedCount === 1 ? 'borttagen' : 'borttagna'}
+                    </span>
+                  )}
                 </label>
                 <div className="mt-2 flex flex-wrap gap-2 max-h-24 overflow-y-auto p-2 border rounded-md bg-muted/30">
                   {validRecipients.map((recipient) => (
@@ -172,6 +203,14 @@ export function SmsModal(props: SmsModalProps) {
                     >
                       <User className="h-3 w-3" />
                       {recipient.name}
+                      <button
+                        type="button"
+                        aria-label={`Ta bort ${recipient.name}`}
+                        className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
+                        onClick={() => removeRecipient(recipient.id)}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
                     </Badge>
                   ))}
                 </div>

--- a/apps/property-tree/src/shared/ui/SmsModal.tsx
+++ b/apps/property-tree/src/shared/ui/SmsModal.tsx
@@ -1,15 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import {
-  AlertTriangle,
-  ChevronDown,
-  Info,
-  MessageSquare,
-  User,
-  X,
-} from 'lucide-react'
+import { AlertTriangle, ChevronDown, Info, MessageSquare } from 'lucide-react'
 
+import { useRemovableRecipients } from '@/shared/hooks/useRemovableRecipients'
 import { cn } from '@/shared/lib/utils'
-import { Badge } from '@/shared/ui/Badge'
 import { Button } from '@/shared/ui/Button'
 import {
   Dialog,
@@ -19,6 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/shared/ui/Dialog'
+import { RecipientChipList } from '@/shared/ui/RecipientChipList'
 import { Textarea } from '@/shared/ui/Textarea'
 
 const MAX_SMS_LENGTH = 1600
@@ -46,11 +40,14 @@ interface SmsModalSingleProps extends SmsModalBaseProps {
   onSend: (message: string) => Promise<void>
   recipients?: undefined
   totalSelectedItems?: undefined
+  excludedRecipientsCount?: undefined
 }
 
 interface SmsModalBulkProps extends SmsModalBaseProps {
   recipients: SmsRecipient[]
   totalSelectedItems?: number
+  /** Contacts excluded by unchecking rows in the table (all-results mode) */
+  excludedRecipientsCount?: number
   onSend?: (message: string, recipients: SmsRecipient[]) => Promise<void>
   recipientName?: undefined
   phoneNumber?: undefined
@@ -66,16 +63,14 @@ export function SmsModal(props: SmsModalProps) {
   const [isSending, setIsSending] = useState(false)
   const [showCostConfirmation, setShowCostConfirmation] = useState(false)
   const [showAllInvalid, setShowAllInvalid] = useState(false)
-  // Recipients manually removed via the ✕ on their chip (bulk mode only)
-  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set())
 
   // Single reset path for all per-session state, on both open and close.
   // Esc/overlay dismissal calls onOpenChange directly and bypasses
   // handleClose, so nothing may rely on handleClose for cleanup.
+  // (useRemovableRecipients resets its removal state on `open` the same way.)
   useEffect(() => {
     setMessage('')
     setShowCostConfirmation(false)
-    setRemovedIds(new Set())
     setShowAllInvalid(false)
   }, [open])
 
@@ -83,10 +78,8 @@ export function SmsModal(props: SmsModalProps) {
 
   const recipients = props.recipients ?? []
 
-  const activeRecipients = useMemo(
-    () => recipients.filter((r) => !removedIds.has(r.id)),
-    [recipients, removedIds]
-  )
+  const { activeRecipients, removedCount, removeRecipient } =
+    useRemovableRecipients(recipients, open)
 
   const { validRecipients, invalidRecipients } = useMemo(() => {
     if (!isBulk) return { validRecipients: [], invalidRecipients: [] }
@@ -94,12 +87,6 @@ export function SmsModal(props: SmsModalProps) {
     const invalid = activeRecipients.filter((r) => !hasPhoneNumber(r.phone))
     return { validRecipients: valid, invalidRecipients: invalid }
   }, [isBulk, activeRecipients])
-
-  const removeRecipient = useCallback((id: string) => {
-    setRemovedIds((prev) => new Set(prev).add(id))
-  }, [])
-
-  const removedCount = recipients.length - activeRecipients.length
 
   const estimatedCost = validRecipients.length * SMS_COST_SEK
   const duplicatesRemoved =
@@ -160,14 +147,24 @@ export function SmsModal(props: SmsModalProps) {
     onOpenChange(false)
   }
 
+  // Contacts excluded via table-row unchecking, shown so the header numbers
+  // reconcile with the selected-contract count
+  const excludedSuffix =
+    isBulk && props.excludedRecipientsCount
+      ? ` \u00b7 ${props.excludedRecipientsCount} ${
+          props.excludedRecipientsCount === 1 ? 'exkluderad' : 'exkluderade'
+        }`
+      : ''
+
   // Deliberately based on the ORIGINAL recipient list: this line explains the
   // contracts\u2192contacts deduplication, which manual removals must not skew.
   // Removals are surfaced separately next to the "Mottagare" label.
   const description = isBulk
-    ? props.totalSelectedItems != null &&
+    ? (props.totalSelectedItems != null &&
       props.totalSelectedItems !== recipients.length
-      ? `${props.totalSelectedItems} valda hyreskontrakt \u2192 ${recipients.length} unika kontakter`
-      : `Skicka SMS till ${validRecipients.length} av ${recipients.length} valda kunder`
+        ? `${props.totalSelectedItems} valda hyreskontrakt \u2192 ${recipients.length} unika kontakter`
+        : `Skicka SMS till ${validRecipients.length} av ${recipients.length} valda kunder`) +
+      excludedSuffix
     : `Till ${props.recipientName} (${props.phoneNumber})`
 
   return (
@@ -194,26 +191,10 @@ export function SmsModal(props: SmsModalProps) {
                     </span>
                   )}
                 </label>
-                <div className="mt-2 flex flex-wrap gap-2 max-h-24 overflow-y-auto p-2 border rounded-md bg-muted/30">
-                  {validRecipients.map((recipient) => (
-                    <Badge
-                      key={recipient.id}
-                      variant="secondary"
-                      className="flex items-center gap-1"
-                    >
-                      <User className="h-3 w-3" />
-                      {recipient.name}
-                      <button
-                        type="button"
-                        aria-label={`Ta bort ${recipient.name}`}
-                        className="ml-0.5 rounded-full hover:bg-muted-foreground/20"
-                        onClick={() => removeRecipient(recipient.id)}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </Badge>
-                  ))}
-                </div>
+                <RecipientChipList
+                  recipients={validRecipients}
+                  onRemove={removeRecipient}
+                />
               </div>
 
               {(duplicatesRemoved > 0 || invalidRecipients.length > 0) && (


### PR DESCRIPTION
## MIM-1925 — Bulk send: exclude individual recipients before sending

Solves "send to everyone in the selection except person X" ([MIM-1925](https://linear.app/mimer-onecore/issue/MIM-1925)) — previously you could either hand-pick rows on the current page or select all filtered results, but not combine them.

### What's new

- **Removable recipient chips** — each recipient in the Email/SMS modals has a ✕; counters, cost estimate and send button follow the filtered list, with a "N borttagna" indicator. Chips render max 100 at a time ("Visa fler") — display-only cap, all recipients stay in state and in the send.
- **Row exclusion in "Välj alla" mode** — unchecking a row excludes it (158 → uncheck 2 → 156) instead of collapsing the selection to the current page. Rows without contact data can't be unchecked (toast) since the exclusion would be a silent no-op.
- **Selection survives pagination/sorting** — fixed the identity bug where any URL change wiped the selection; hand-picked rows carry their contacts across pages, and the header checkbox got an indeterminate state so it can't misrepresent cross-page selections.

### Worth knowing for review

- **Exclusion is per person (contactCode), not per contract**: excluding one of a tenant's contracts excludes them from the whole send. Intentional — matches "don't message this person" and avoids the backend `excludeLeaseIds` chain.
- Modal state now has a single reset path on open/close — Esc/overlay dismissal previously kept stale state (incl. the >100-recipient cost confirmation).
- New shared pieces: `useRemovableRecipients`, `RecipientChipList`; `Checkbox` supports `indeterminate`.
