### PR TITLE
MIM-1825 - Flera filer i ströfaktura

### DIFF
--- a/apps/property-tree/package.json
+++ b/apps/property-tree/package.json
@@ -22,10 +22,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
     "@deck.gl/core": "^9.0.38",
     "@deck.gl/layers": "^9.0.38",
     "@deck.gl/react": "^9.0.38",
+    "@dnd-kit/core": "^6.3.1",
     "@headlessui/react": "^1.7.18",
     "@onecore/types": "workspace:*",
     "@radix-ui/react-accordion": "^1.2.12",
@@ -59,6 +59,7 @@
     "lucide-react": "^0.462.0",
     "maplibre-gl": "5.7.0",
     "nuqs": "^2.8.6",
+    "pdf-lib": "^1.17.1",
     "react": "^18.3.1",
     "react-day-picker": "^9.13.0",
     "react-dom": "^18.3.1",

--- a/apps/property-tree/src/features/economy/components/AdditionalInfoSection.tsx
+++ b/apps/property-tree/src/features/economy/components/AdditionalInfoSection.tsx
@@ -26,7 +26,7 @@ interface AdditionalInfoSectionProps {
   attachedFiles: File[]
 }
 
-const fileKey = (file: File) => `${file.name}:${file.size}`
+const fileKey = (file: File) => `${file.name}:${file.size}:${file.lastModified}`
 
 export function AdditionalInfoSection({
   selectedProject,
@@ -187,7 +187,13 @@ export function AdditionalInfoSection({
               id="file-upload"
               className="sr-only"
               multiple
-              accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
+              // A lone attachment may be of any type, so the picker is only
+              // restricted to mergeable types once a file is attached
+              accept={
+                attachedFiles.length === 0
+                  ? undefined
+                  : '.pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png'
+              }
               onChange={handleFileChange}
             />
             <label htmlFor="file-upload">

--- a/apps/property-tree/src/features/economy/components/AdditionalInfoSection.tsx
+++ b/apps/property-tree/src/features/economy/components/AdditionalInfoSection.tsx
@@ -1,8 +1,8 @@
-import { FileText, Paperclip, X } from 'lucide-react'
+import { useState } from 'react'
 import { XledgerProject } from '@onecore/types'
+import { FileText, Paperclip, X } from 'lucide-react'
 
 import { Button } from '@/shared/ui/Button'
-import { Input } from '@/shared/ui/Input'
 import { Label } from '@/shared/ui/Label'
 import {
   Select,
@@ -13,6 +13,8 @@ import {
 } from '@/shared/ui/Select'
 import { Textarea } from '@/shared/ui/Textarea'
 
+import { isMergeableFileType } from '../lib/mergeFilesToPdf'
+
 interface AdditionalInfoSectionProps {
   selectedProject: XledgerProject | null
   projects?: XledgerProject[]
@@ -20,9 +22,11 @@ interface AdditionalInfoSectionProps {
   comment: string
   onProjectChange: (project: XledgerProject | null) => void
   onCommentChange: (value: string) => void
-  onFileAttached: (file: File | null) => void
-  attachedFile?: File | null
+  onFilesChanged: (files: File[]) => void
+  attachedFiles: File[]
 }
+
+const fileKey = (file: File) => `${file.name}:${file.size}`
 
 export function AdditionalInfoSection({
   selectedProject,
@@ -31,9 +35,11 @@ export function AdditionalInfoSection({
   comment,
   onProjectChange,
   onCommentChange,
-  onFileAttached,
-  attachedFile,
+  onFilesChanged,
+  attachedFiles,
 }: AdditionalInfoSectionProps) {
+  const [fileError, setFileError] = useState<string | null>(null)
+
   const handleProjectSelect = (projectCode: string) => {
     if (projectCode === 'none') {
       onProjectChange(null)
@@ -44,15 +50,62 @@ export function AdditionalInfoSection({
   }
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      const file = e.target.files[0]
-      onFileAttached(file)
-    }
+    const pickedFiles = e.target.files ? Array.from(e.target.files) : []
+    // Reset so the same file can be picked again after removal
     e.target.value = ''
+
+    if (pickedFiles.length === 0) {
+      return
+    }
+
+    // A single attachment of any type is uploaded as-is (like before), but
+    // multiple attachments are merged into one PDF and must all be
+    // PDF/JPG/PNG. So the list is either one file of any type, or several
+    // mergeable files.
+    if (attachedFiles.length === 0 && pickedFiles.length === 1) {
+      setFileError(null)
+      onFilesChanged(pickedFiles)
+      return
+    }
+
+    const nonMergeableAttached = attachedFiles.find(
+      (file) => !isMergeableFileType(file)
+    )
+    if (nonMergeableAttached) {
+      setFileError(
+        `Fler filer kan inte läggas till eftersom "${nonMergeableAttached.name}" inte är en PDF-, JPG- eller PNG-fil. Ta bort den först.`
+      )
+      return
+    }
+
+    const unsupportedFiles = pickedFiles.filter(
+      (file) => !isMergeableFileType(file)
+    )
+    const supportedFiles = pickedFiles.filter(isMergeableFileType)
+
+    const existingKeys = new Set(attachedFiles.map(fileKey))
+    const newFiles = supportedFiles.filter(
+      (file) => !existingKeys.has(fileKey(file))
+    )
+
+    setFileError(
+      unsupportedFiles.length > 0
+        ? `Endast PDF-, JPG- och PNG-filer kan kombineras. Följande filer lades inte till: ${unsupportedFiles
+            .map((file) => file.name)
+            .join(', ')}`
+        : null
+    )
+
+    if (newFiles.length > 0) {
+      onFilesChanged([...attachedFiles, ...newFiles])
+    }
   }
 
-  const removeFile = () => {
-    onFileAttached(null)
+  const removeFile = (file: File) => {
+    setFileError(null)
+    onFilesChanged(
+      attachedFiles.filter((attached) => fileKey(attached) !== fileKey(file))
+    )
   }
 
   return (
@@ -100,30 +153,41 @@ export function AdditionalInfoSection({
       </div>
 
       <div className="space-y-2">
-        <Label>Bifogad fil</Label>
+        <Label>Bifogade filer</Label>
         <div className="space-y-2">
-          {attachedFile && (
-            <div className="flex items-center justify-between gap-2 rounded-md border border-input bg-muted/50 px-3 py-2 text-sm">
+          {attachedFiles.map((file) => (
+            <div
+              key={fileKey(file)}
+              className="flex items-center justify-between gap-2 rounded-md border border-input bg-muted/50 px-3 py-2 text-sm"
+            >
               <div className="flex items-center gap-2 min-w-0">
                 <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="truncate">{attachedFile.name}</span>
+                <span className="truncate">{file.name}</span>
               </div>
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 shrink-0"
-                onClick={removeFile}
+                onClick={() => removeFile(file)}
               >
                 <X className="h-4 w-4" />
               </Button>
             </div>
+          ))}
+          {attachedFiles.length > 1 && (
+            <p className="text-xs text-muted-foreground">
+              Filerna slås ihop till en PDF när underlaget skickas.
+            </p>
           )}
+          {fileError && <p className="text-sm text-destructive">{fileError}</p>}
           <div>
             <input
               type="file"
               id="file-upload"
               className="sr-only"
+              multiple
+              accept=".pdf,.jpg,.jpeg,.png,application/pdf,image/jpeg,image/png"
               onChange={handleFileChange}
             />
             <label htmlFor="file-upload">
@@ -136,7 +200,7 @@ export function AdditionalInfoSection({
               >
                 <span>
                   <Paperclip className="h-4 w-4 mr-2" />
-                  Bifoga fil
+                  Bifoga filer
                 </span>
               </Button>
             </label>

--- a/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
+++ b/apps/property-tree/src/features/economy/components/MiscellaneousInvoiceForm.tsx
@@ -35,6 +35,7 @@ import { getArticleById } from '@/data/articles/miscellaneousInvoiceArticles'
 import { useMiscellaneousInvoiceDataForLease } from '../hooks/useMiscellaneousInvoiceDataForLease'
 import { useXledgerContacts } from '../hooks/useXledgerContacts'
 import { useXledgerProjects } from '../hooks/useXledgerProjects'
+import { MergeFileError, mergeFilesToPdf } from '../lib/mergeFilesToPdf'
 import { AdditionalInfoSection } from './AdditionalInfoSection'
 import { ArticleSection } from './ArticleSection'
 import { LeaseContractSection } from './LeaseContractSection'
@@ -122,7 +123,7 @@ export function MiscellaneousInvoiceForm() {
   )
   const [comment, setComment] = useState('')
   const [administrativeCosts, setAdministrativeCosts] = useState(false)
-  const [attachedFile, setAttachedFile] = useState<File | null>(null)
+  const [attachedFiles, setAttachedFiles] = useState<File[]>([])
 
   const setContactCodeParam = useCallback(
     (code: string | null) => {
@@ -246,7 +247,7 @@ export function MiscellaneousInvoiceForm() {
     return Object.keys(newErrors).length === 0
   }
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
     if (!validateForm()) {
@@ -284,6 +285,28 @@ export function MiscellaneousInvoiceForm() {
 
     setIsSubmitting(true)
 
+    // Xledger only accepts one attachment, so multiple files are merged into
+    // a single PDF. A single file is sent as-is, whatever its type.
+    let attachment: File | undefined
+    if (attachedFiles.length === 1) {
+      attachment = attachedFiles[0]
+    } else if (attachedFiles.length > 1) {
+      try {
+        attachment = await mergeFilesToPdf(attachedFiles)
+      } catch (error) {
+        toast({
+          title: 'Fel',
+          description:
+            error instanceof MergeFileError
+              ? `${error.message}. Underlaget skickades inte.`
+              : 'Filerna kunde inte slås ihop. Underlaget skickades inte.',
+          variant: 'destructive',
+        })
+        setIsSubmitting(false)
+        return
+      }
+    }
+
     const invoicePayload: MiscellaneousInvoicePayload = {
       reference: reference?.dbId || '',
       invoiceDate: invoiceDate,
@@ -296,7 +319,7 @@ export function MiscellaneousInvoiceForm() {
       comment: comment,
       invoiceRows: rows,
       administrativeCosts: administrativeCosts,
-      attachment: attachedFile ?? undefined,
+      attachment,
     }
 
     submitInvoiceMutation.mutate(invoicePayload)
@@ -311,7 +334,7 @@ export function MiscellaneousInvoiceForm() {
     setSelectedProject(null)
     setComment('')
     setAdministrativeCosts(false)
-    setAttachedFile(null)
+    setAttachedFiles([])
     setErrors({})
     setContactCodeParam(null)
 
@@ -450,8 +473,8 @@ export function MiscellaneousInvoiceForm() {
               comment={comment}
               onProjectChange={setSelectedProject}
               onCommentChange={setComment}
-              onFileAttached={setAttachedFile}
-              attachedFile={attachedFile}
+              onFilesChanged={setAttachedFiles}
+              attachedFiles={attachedFiles}
             />
           </div>
 

--- a/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
+++ b/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
@@ -14,9 +14,38 @@ const A4_WIDTH_POINTS = 595.28
 const A4_HEIGHT_POINTS = 841.89
 
 export class MergeFileError extends Error {
-  constructor(public readonly fileName: string) {
+  constructor(fileName: string) {
     super(`Kunde inte läsa filen "${fileName}"`)
     this.name = 'MergeFileError'
+  }
+}
+
+// pdf-lib's embedJpg ignores EXIF rotation, so portrait phone photos would
+// render sideways. Redrawing through a canvas applies the orientation.
+async function normalizeJpeg(bytes: ArrayBuffer): Promise<ArrayBuffer> {
+  const bitmap = await createImageBitmap(new Blob([bytes]), {
+    imageOrientation: 'from-image',
+  })
+  try {
+    const canvas = document.createElement('canvas')
+    canvas.width = bitmap.width
+    canvas.height = bitmap.height
+    const context = canvas.getContext('2d')
+    if (!context) {
+      throw new Error('Could not get canvas context')
+    }
+    context.drawImage(bitmap, 0, 0)
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (result) =>
+          result ? resolve(result) : reject(new Error('canvas.toBlob failed')),
+        'image/jpeg',
+        0.92
+      )
+    })
+    return await blob.arrayBuffer()
+  } finally {
+    bitmap.close()
   }
 }
 
@@ -49,7 +78,7 @@ export async function mergeFilesToPdf(files: File[]): Promise<File> {
         const image =
           file.type === 'image/png'
             ? await mergedDocument.embedPng(bytes)
-            : await mergedDocument.embedJpg(bytes)
+            : await mergedDocument.embedJpg(await normalizeJpeg(bytes))
         // Scale down to fit within A4 (1 px = 1 pt would make photos huge),
         // but never upscale small images
         const scale = Math.min(
@@ -69,6 +98,8 @@ export async function mergeFilesToPdf(files: File[]): Promise<File> {
 
   const mergedBytes = await mergedDocument.save()
 
+  // The copy re-types pdf-lib's Uint8Array<ArrayBufferLike> as ArrayBuffer-
+  // backed, which BlobPart requires
   return new File([new Uint8Array(mergedBytes)], 'strofaktura-bilagor.pdf', {
     type: 'application/pdf',
   })

--- a/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
+++ b/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
@@ -20,6 +20,52 @@ export class MergeFileError extends Error {
   }
 }
 
+/**
+ * Reads the EXIF orientation tag from JPEG bytes. Returns 1 (upright) when
+ * the tag is absent, and 0 when the structure can't be parsed (caller should
+ * treat unknown as possibly-rotated).
+ */
+function readJpegOrientation(bytes: ArrayBuffer): number {
+  try {
+    const view = new DataView(bytes)
+    if (view.byteLength < 4 || view.getUint16(0) !== 0xffd8) return 1
+
+    // Walk the JPEG segment markers looking for APP1 (EXIF)
+    let offset = 2
+    while (offset + 4 <= view.byteLength) {
+      const marker = view.getUint16(offset)
+      if ((marker & 0xff00) !== 0xff00) return 1
+      const size = view.getUint16(offset + 2)
+      if (marker === 0xffe1) {
+        // "Exif\0\0" signature, then the TIFF header
+        if (
+          offset + 10 > view.byteLength ||
+          view.getUint32(offset + 4) !== 0x45786966
+        ) {
+          return 1
+        }
+        const tiff = offset + 10
+        const littleEndian = view.getUint16(tiff, false) === 0x4949
+        const ifdOffset = view.getUint32(tiff + 4, littleEndian)
+        let entry = tiff + ifdOffset + 2
+        const entryCount = view.getUint16(tiff + ifdOffset, littleEndian)
+        for (let i = 0; i < entryCount; i++, entry += 12) {
+          if (entry + 12 > view.byteLength) return 0
+          // 0x0112 = orientation tag; its value is at entry offset 8
+          if (view.getUint16(entry, littleEndian) === 0x0112) {
+            return view.getUint16(entry + 8, littleEndian)
+          }
+        }
+        return 1
+      }
+      offset += 2 + size
+    }
+    return 1
+  } catch {
+    return 0
+  }
+}
+
 // pdf-lib's embedJpg ignores EXIF rotation, so portrait phone photos would
 // render sideways. Redrawing through a canvas applies the orientation.
 async function normalizeJpeg(bytes: ArrayBuffer): Promise<ArrayBuffer> {
@@ -75,10 +121,16 @@ export async function mergeFilesToPdf(files: File[]): Promise<File> {
         )
         pages.forEach((page) => mergedDocument.addPage(page))
       } else {
+        // Only round-trip JPEGs through canvas when a rotation flag is
+        // present (or parsing failed) — re-encoding costs a little quality
+        const jpegBytes =
+          file.type === 'image/jpeg' && readJpegOrientation(bytes) !== 1
+            ? await normalizeJpeg(bytes)
+            : bytes
         const image =
           file.type === 'image/png'
             ? await mergedDocument.embedPng(bytes)
-            : await mergedDocument.embedJpg(await normalizeJpeg(bytes))
+            : await mergedDocument.embedJpg(jpegBytes)
         // Scale down to fit within A4 (1 px = 1 pt would make photos huge),
         // but never upscale small images
         const scale = Math.min(

--- a/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
+++ b/apps/property-tree/src/features/economy/lib/mergeFilesToPdf.ts
@@ -1,0 +1,75 @@
+export const MERGEABLE_FILE_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+] as const
+
+export type MergeableFileType = (typeof MERGEABLE_FILE_TYPES)[number]
+
+export function isMergeableFileType(file: File): boolean {
+  return MERGEABLE_FILE_TYPES.includes(file.type as MergeableFileType)
+}
+
+const A4_WIDTH_POINTS = 595.28
+const A4_HEIGHT_POINTS = 841.89
+
+export class MergeFileError extends Error {
+  constructor(public readonly fileName: string) {
+    super(`Kunde inte läsa filen "${fileName}"`)
+    this.name = 'MergeFileError'
+  }
+}
+
+/**
+ * Merges PDF, JPEG and PNG files into a single PDF document. Xledger only
+ * accepts one attachment per invoice base item, so multiple user-selected
+ * files are combined client-side before upload.
+ *
+ * Throws MergeFileError naming the file if one of them cannot be read
+ * (e.g. an encrypted or corrupt PDF).
+ */
+export async function mergeFilesToPdf(files: File[]): Promise<File> {
+  // Dynamic import keeps pdf-lib out of the main bundle
+  const { PDFDocument } = await import('pdf-lib')
+
+  const mergedDocument = await PDFDocument.create()
+
+  for (const file of files) {
+    try {
+      const bytes = await file.arrayBuffer()
+
+      if (file.type === 'application/pdf') {
+        const sourceDocument = await PDFDocument.load(bytes)
+        const pages = await mergedDocument.copyPages(
+          sourceDocument,
+          sourceDocument.getPageIndices()
+        )
+        pages.forEach((page) => mergedDocument.addPage(page))
+      } else {
+        const image =
+          file.type === 'image/png'
+            ? await mergedDocument.embedPng(bytes)
+            : await mergedDocument.embedJpg(bytes)
+        // Scale down to fit within A4 (1 px = 1 pt would make photos huge),
+        // but never upscale small images
+        const scale = Math.min(
+          1,
+          A4_WIDTH_POINTS / image.width,
+          A4_HEIGHT_POINTS / image.height
+        )
+        const width = image.width * scale
+        const height = image.height * scale
+        const page = mergedDocument.addPage([width, height])
+        page.drawImage(image, { x: 0, y: 0, width, height })
+      }
+    } catch {
+      throw new MergeFileError(file.name)
+    }
+  }
+
+  const mergedBytes = await mergedDocument.save()
+
+  return new File([new Uint8Array(mergedBytes)], 'strofaktura-bilagor.pdf', {
+    type: 'application/pdf',
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@6.30.1(react@18.3.1))(react@18.3.1)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1130,13 +1133,13 @@ importers:
         version: 4.4.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
+        version: 29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
       knex:
         specifier: ^3.1.0
         version: 3.1.0(tedious@18.6.1)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.2)
+        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2)))(typescript@5.9.2)
       tsup:
         specifier: ^8.0.2
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
@@ -19844,25 +19847,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
@@ -20196,18 +20180,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22886,26 +22858,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
       jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.2
-      type-fest: 4.41.0
-      typescript: 5.9.2
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.3
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.3)
-      jest-util: 29.7.0
-
-  ts-jest@29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.2):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,9 +716,6 @@ importers:
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@6.30.1(react@18.3.1))(react@18.3.1)
-      pdf-lib:
-        specifier: ^1.17.1
-        version: 1.17.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1133,13 +1130,13 @@ importers:
         version: 4.4.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+        version: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
       knex:
         specifier: ^3.1.0
         version: 3.1.0(tedious@18.6.1)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.2)
       tsup:
         specifier: ^8.0.2
         version: 8.5.0(jiti@1.21.7)(postcss@8.5.6)(tsx@4.20.5)(typescript@5.9.2)(yaml@2.8.1)
@@ -19847,6 +19844,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
@@ -20180,6 +20196,18 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.19.11)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.19.11)(typescript@5.9.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22858,6 +22886,26 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
       jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.3.0)(typescript@5.9.2))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.2
+      type-fest: 4.41.0
+      typescript: 5.9.2
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.3
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.3)
+      jest-util: 29.7.0
+
+  ts-jest@29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0))(typescript@5.9.2):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@24.3.0)(babel-plugin-macros@3.1.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       nuqs:
         specifier: ^2.8.6
         version: 2.8.6(react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@6.30.1(react@18.3.1))(react@18.3.1)
+      pdf-lib:
+        specifier: ^1.17.1
+        version: 1.17.1
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## MIM-1825 — Flera filer i ströfaktura

Users can now attach multiple files to a miscellaneous invoice (ströfaktura).
Since Xledger only accepts a single file per invoice base item (see Lina's
comment on the card), the files are merged into one PDF client-side before
submit. The entire backend chain
(core → economy → Xledger) is untouched and still receives exactly one file.

### How it works

- New helper `mergeFilesToPdf.ts` (property-tree): merges PDF/JPG/PNG into a
  single `strofaktura-bilagor.pdf` using `pdf-lib` (same version already used
  in keys-portal and services/keys). Dynamically imported so it stays out of
  the main bundle. Images are scaled down to fit A4 (never upscaled).
- `AdditionalInfoSection`: multi-file picker, one row per file with remove,
  dedupe by name+size, inline validation messages.
- `MiscellaneousInvoiceForm`: 0 files → no attachment; 1 file → sent as-is,
  untouched (today's behavior, any file type); ≥2 files → merged before
  submit. If a file can't be read (encrypted/corrupt PDF), the submit is
  aborted with a toast naming the file — never silently partial.

### Behavior change to be aware of

Multi-file selections are restricted to **PDF/JPG/PNG** — forced by
mergeability. A *single* attachment of any type still works exactly as
before. The invariant: the attachment list is either one file of any type,
or several mergeable files.

### Testing

- [x] Multiple files merged into one PDF and submitted — invoice base item
      created in Xledger demo (200 end-to-end, attachment referenced in the
      GraphQL mutation)
- [x] Visual check of the merged PDF inside Xledger demo, opened the invoice
      base item (2026-08-03) and verified the attachment: all pages present
      and the image page scaled to A4
- [x] Typecheck (repo root) and lint clean
