### PR TITLE
write canonical inspector identity "Name (YYxxxx)" from Keycloak empl…

### DIFF
--- a/apps/property-tree/src/entities/user/types.ts
+++ b/apps/property-tree/src/entities/user/types.ts
@@ -2,5 +2,8 @@ export type User = {
   id: string
   name: string
   email: string
+  // Xpand signature (e.g. "YY2333") from the Keycloak employeeId token claim.
+  // Absent until the token mapper is configured for the realm (MIM-1851).
+  employeeId?: string
   roles: string[]
 }

--- a/apps/property-tree/src/features/inspections/constants/tableColumns.tsx
+++ b/apps/property-tree/src/features/inspections/constants/tableColumns.tsx
@@ -29,6 +29,7 @@ import {
   isXpandSource,
   XPAND_ACTION_LABEL,
 } from './statuses'
+import { formatInspectorName } from '../lib/inspectorIdentity'
 
 type Inspection = components['schemas']['InspectionWithSource']
 type KeycloakUser = components['schemas']['KeycloakUser']
@@ -85,11 +86,16 @@ export function createInspectorColumn(
           onValueChange={(value) => onUpdateInspector(inspection.id, value)}
         >
           <SelectTrigger className="h-8 w-[180px] py-6">
-            <SelectValue placeholder="Välj besiktningsman" />
+            {/* Render the stored value directly: rows written before the
+                canonical "Name (YYxxxx)" format (MIM-1851) hold bare names
+                that no longer match any option value and would show blank. */}
+            <SelectValue placeholder="Välj besiktningsman">
+              {inspection.inspector || null}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {inspectors.map((user) => {
-              const name = `${user.firstName} ${user.lastName}`
+              const name = formatInspectorName(user)
               return (
                 <SelectItem key={user.id} value={name}>
                   {name}

--- a/apps/property-tree/src/features/inspections/lib/inspectorIdentity.ts
+++ b/apps/property-tree/src/features/inspections/lib/inspectorIdentity.ts
@@ -1,0 +1,28 @@
+import type { components } from '@/services/api/core/generated/api-types'
+
+type KeycloakUser = components['schemas']['KeycloakUser']
+
+// Canonical inspector identity (MIM-1851): "Vincent Cheron (YY2333)" — the
+// same format Xpand uses in cmctc.cmctcben — so rows from both sources
+// compare equal with plain string equality. Every writer AND every filter of
+// inspection.inspector must build the string through this function; a format
+// drift between sites silently breaks the exact-match filtering. Falls back
+// to the bare name until the employeeId reaches the user.
+export function formatInspectorIdentity(
+  name: string,
+  employeeId?: string
+): string {
+  return employeeId ? `${name} (${employeeId})` : name
+}
+
+// Same identity built from a Keycloak admin-API user (the inspector
+// dropdowns). Keycloak stores attributes as string arrays; employeeId holds
+// the inspector's Xpand signature.
+export function formatInspectorName(
+  user: Pick<KeycloakUser, 'firstName' | 'lastName' | 'attributes'>
+): string {
+  return formatInspectorIdentity(
+    `${user.firstName} ${user.lastName}`,
+    user.attributes?.employeeId?.[0]
+  )
+}

--- a/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
+++ b/apps/property-tree/src/features/inspections/ui/CreateInspectionDialog.tsx
@@ -29,6 +29,7 @@ import {
 import { INSPECTION_STATUS } from '../constants/statuses'
 import { useCreateInspection } from '../hooks/useCreateInspection'
 import { useInspectors } from '../hooks/useInspectors'
+import { formatInspectorName } from '../lib/inspectorIdentity'
 
 type CreateInspectionRequest = components['schemas']['CreateInspectionRequest']
 type DetailedInspection = components['schemas']['DetailedInspection']
@@ -229,7 +230,7 @@ export function CreateInspectionDialog({
                 </SelectTrigger>
                 <SelectContent>
                   {inspectors?.map((user) => {
-                    const name = `${user.firstName} ${user.lastName}`
+                    const name = formatInspectorName(user)
                     return (
                       <SelectItem key={user.id} value={name}>
                         {name}

--- a/apps/property-tree/src/features/inspections/ui/InspectionDetailsCard.tsx
+++ b/apps/property-tree/src/features/inspections/ui/InspectionDetailsCard.tsx
@@ -17,6 +17,7 @@ import {
   type InspectionType,
 } from '../constants/inspectionTypes'
 import { useInspectors } from '../hooks/useInspectors'
+import { formatInspectorName } from '../lib/inspectorIdentity'
 
 interface InspectionDetailsCardProps {
   inspectorName: string
@@ -93,7 +94,7 @@ export function InspectionDetailsCard({
             </SelectTrigger>
             <SelectContent>
               {inspectors?.map((user) => {
-                const name = `${user.firstName} ${user.lastName}`
+                const name = formatInspectorName(user)
                 return (
                   <SelectItem key={user.id} value={name}>
                     <div className="flex items-center gap-2">

--- a/apps/property-tree/src/pages/InspectionsPage.tsx
+++ b/apps/property-tree/src/pages/InspectionsPage.tsx
@@ -5,6 +5,7 @@ import { InspectionsTable } from '@/features/inspections'
 import { INSPECTION_STATUS_FILTER } from '@/features/inspections/constants/inspectionTypes'
 import { useInspectionFilters } from '@/features/inspections/hooks/useInspectionFilters'
 import { useInspections } from '@/features/inspections/hooks/useInspections'
+import { formatInspectorIdentity } from '@/features/inspections/lib/inspectorIdentity'
 
 import { useUser } from '@/entities/user/hooks/useUser'
 
@@ -34,7 +35,15 @@ const MY_INSPECTIONS_TAB = 'mine' as const
 
 export default function InspectionsPage() {
   const userState = useUser()
-  const userName = userState.tag === 'success' ? userState.user.name : undefined
+  const user = userState.tag === 'success' ? userState.user : undefined
+  // Canonical inspector identity, matching the format written by the
+  // inspection forms and by Xpand's cmctc.cmctcben ("Name (YY1234)") — so
+  // the "Mina besiktningar" tab also matches Xpand-assigned inspections.
+  // Falls back to the bare name while the employeeId claim is absent
+  // (MIM-1851).
+  const userName = user
+    ? formatInspectorIdentity(user.name, user.employeeId)
+    : undefined
 
   const [activeTab, setActiveTab] = useState<string>(
     INSPECTION_STATUS_FILTER.ONGOING

--- a/core/src/middlewares/keycloak-auth.ts
+++ b/core/src/middlewares/keycloak-auth.ts
@@ -27,6 +27,10 @@ async function verifyKeycloakToken(ctx: Context, next: Next) {
       email: verifiedToken.email,
       name: verifiedToken.name,
       preferred_username: verifiedToken.preferred_username,
+      // Xpand signature (e.g. "YY2333") from the employeeId user attribute.
+      // Requires the realm's employeeId token mapper — undefined until the
+      // claim is present in the token (MIM-1851).
+      employeeId: verifiedToken.employeeId,
       source: 'keycloak',
       realm_access: verifiedToken.realm_access,
     }


### PR DESCRIPTION
Inspectors existed under two formats, Keycloak name ("Vincent Cheron")
in ONECore rows and cmctc.cmctcben ("Vincent Cheron (YY2333)") in Xpand,
splitting one person into two dropdown entries and hiding half their work.

Instead of teaching every layer to match both formats, ONECore now writes
the canonical Xpand format everywhere:

- keycloak-auth passes the employeeId JWT claim into ctx.state.user,
  exposed via /auth/profile (requires the realm token mapper; falls back
  to bare names while absent)
- all three inspector selects (create dialog, conduct dialog, Tilldelad
  column) build values via the new inspectorIdentity helper; the table
  select renders stored legacy values verbatim instead of blank
- "Mina besiktningar" filters by the canonical identity so Xpand-assigned
  inspections appear too

No backend filter or schema changes. Deploy notes (prod token mapper,
employeeId attribute audit, legacy-row cleanup) are on the Linear card.
