### PR TITLE
UTH-344: preserve query params during auth redirect

### DIFF
--- a/apps/keys-portal/src/auth/ProtectedRoute.tsx
+++ b/apps/keys-portal/src/auth/ProtectedRoute.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useLocation } from 'react-router-dom'
 import { match } from 'ts-pattern'
 
 import { useAuth } from './useAuth'
@@ -7,12 +8,13 @@ import { useUser } from './useUser'
 export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { login } = useAuth()
   const user = useUser()
+  const location = useLocation()
 
   React.useEffect(() => {
     if (user.tag === 'error' && user.error === 'unauthenticated') {
-      login(location.pathname)
+      login(`${location.pathname}${location.search}`)
     }
-  }, [login, user])
+  }, [login, user, location.pathname, location.search])
 
   return match(user)
     .with({ tag: 'loading' }, () => (

--- a/apps/property-tree/src/app/ProtectedRoute.tsx
+++ b/apps/property-tree/src/app/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Outlet } from 'react-router-dom'
+import { Outlet, useLocation } from 'react-router-dom'
 import { match } from 'ts-pattern'
 
 import { useAuth } from '@/features/auth'
@@ -9,12 +9,13 @@ import { useUser } from '@/entities/user'
 export function ProtectedRoute({ children }: { children?: React.ReactNode }) {
   const { login } = useAuth()
   const user = useUser()
+  const location = useLocation()
 
   React.useEffect(() => {
     if (user.tag === 'error' && user.error === 'unauthenticated') {
-      login(location.pathname)
+      login(`${location.pathname}${location.search}`)
     }
-  }, [login, user])
+  }, [login, user, location.pathname, location.search])
 
   return match(user)
     .with({ tag: 'loading' }, () => (


### PR DESCRIPTION
Return users to the full deep link after login by including search params in the OAuth state path.