### PR TITLE
fix(economy): handle null Xledger edges in invoice lookup (MIM-1913)

### DIFF
--- a/services/economy/src/services/common/adapters/xledger-adapter.ts
+++ b/services/economy/src/services/common/adapters/xledger-adapter.ts
@@ -795,7 +795,7 @@ export const getInvoicesByContactCode = async (
 
   const result = await makeXledgerRequest(query)
 
-  return result.data?.arTransactions?.edges.map(transformToInvoice) ?? []
+  return result.data?.arTransactions?.edges?.map(transformToInvoice) ?? []
 }
 
 export const getInvoices = async (from?: Date, to?: Date) => {
@@ -825,7 +825,7 @@ export const getInvoices = async (from?: Date, to?: Date) => {
   }
 
   const result = await makeXledgerRequest(query)
-  return result.data?.arTransactions?.edges.map(transformToInvoice) ?? []
+  return result.data?.arTransactions?.edges?.map(transformToInvoice) ?? []
 }
 
 export const getAllInvoicesWithMatchIds = async ({

--- a/services/economy/src/services/invoice-service/index.ts
+++ b/services/economy/src/services/invoice-service/index.ts
@@ -111,7 +111,7 @@ export const routes = (router: KoaRouter) => {
       ctx.body = makeSuccessResponseBody(invoicesWithRows, metadata)
     } catch (error: any) {
       logger.error(
-        { error, contactCode: contactCode },
+        { err: error, contactCode: contactCode },
         'Error getting invoices for contact code'
       )
       ctx.status = 500

--- a/services/economy/test/services/common/adapters/xledger-adapter.test.ts
+++ b/services/economy/test/services/common/adapters/xledger-adapter.test.ts
@@ -45,6 +45,31 @@ describe(adapter.getInvoicesByContactCode, () => {
     expect(result).toEqual([])
   })
 
+  it('returns [] when Xledger returns null edges', async () => {
+    nock(origin)
+      .post(pathname)
+      .reply(200, {
+        data: {
+          customers: {
+            edges: [{ node: { dbId: 1234 } }],
+          },
+        },
+      })
+
+    nock(origin)
+      .post(pathname)
+      .reply(200, {
+        data: {
+          arTransactions: {
+            edges: null,
+          },
+        },
+      })
+
+    const result = await adapter.getInvoicesByContactCode('P12345')
+    expect(result).toEqual([])
+  })
+
   it('returns invoices when customer exists and has invoices', async () => {
     // First POST: customers query → return a dbId
     nock(origin)


### PR DESCRIPTION
## Summary
- Fix crash in `GET /invoices/bycontactcode/:contactCode` when Xledger returns `arTransactions.edges: null` instead of an empty array
- Use Pino's `err` key for error logging so stack traces are visible in Elasticsearch
- Add regression test for the null edges case


Made with [Cursor](https://cursor.com)