### PR TITLE
Fix:MIM-1888 Correct Acquisition Date in PropertyDetailsSchema

### DIFF
--- a/services/property/src/types/property.ts
+++ b/services/property/src/types/property.ts
@@ -70,7 +70,7 @@ export const PropertyDetailsSchema = z.object({
   consolidationNumber: z.string().nullable(),
   ownershipType: z.string(),
   registrationDate: z.date().nullable(),
-  acquisitionDate: z.string().nullable(),
+  acquisitionDate: z.date().nullable(),
   isLeasehold: z.number().int(),
   leaseholdTerminationDate: z.string().nullable(),
   area: z.string().nullable(),


### PR DESCRIPTION
`acquisitionDate` was typed as `z.string()` in `PropertyDetailsSchema` but
  Prisma returns it as a `Date` object, causing a parse error on GET /properties/:code.

  Changed to `z.date()` to match the actual runtime type, consistent with how
  `registrationDate` is already typed in the same schema.