### PR TITLE
fix(leasing): return 404 instead of 500 when contact is not a tenant …

### DIFF
--- a/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -150,6 +150,15 @@ const getTenantByContactCode = async (
 
     return { ok: true, data: result.content }
   } catch (err) {
+    if (err instanceof AxiosError && err.response?.status === 404) {
+      // Expected when the contact is not a tenant. The body `type` field
+      // distinguishes contact-not-found, contact-not-tenant and
+      // no-valid-housing-contract.
+      return { ok: false, err: err.response?.data?.type, statusCode: 404 }
+    }
+
+    // Core versions before MIM-1940 responded 500 for not-a-tenant outcomes,
+    // with the same `type` field in the body.
     if (err instanceof AxiosError && err.response?.status === 500) {
       return { ok: false, err: err.response?.data?.type, statusCode: 500 }
     }

--- a/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -150,11 +150,15 @@ const getTenantByContactCode = async (
 
     return { ok: true, data: result.content }
   } catch (err) {
-    if (err instanceof AxiosError && err.response?.status === 404) {
-      // Expected when the contact is not a tenant. The body `type` field
-      // distinguishes contact-not-found, contact-not-tenant and
-      // no-valid-housing-contract.
-      return { ok: false, err: err.response?.data?.type, statusCode: 404 }
+    if (err instanceof AxiosError && err.response?.data?.type) {
+      // 404 carries the expected not-a-tenant outcomes (contact-not-found,
+      // contact-not-tenant, no-valid-housing-contract); other statuses pass
+      // their semantic type through as well.
+      return {
+        ok: false,
+        err: err.response.data.type,
+        statusCode: err.response.status,
+      }
     }
 
     return { ok: false, err, statusCode: 500 }

--- a/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/adapters/core-adapter.ts
@@ -157,12 +157,6 @@ const getTenantByContactCode = async (
       return { ok: false, err: err.response?.data?.type, statusCode: 404 }
     }
 
-    // Core versions before MIM-1940 responded 500 for not-a-tenant outcomes,
-    // with the same `type` field in the body.
-    if (err instanceof AxiosError && err.response?.status === 500) {
-      return { ok: false, err: err.response?.data?.type, statusCode: 500 }
-    }
-
     return { ok: false, err, statusCode: 500 }
   }
 }

--- a/apps/internal-portal/backend/src/services/leasing-service/contacts.ts
+++ b/apps/internal-portal/backend/src/services/leasing-service/contacts.ts
@@ -114,6 +114,20 @@ export const routes = (router: KoaRouter) => {
       const getTenant = await coreAdapter.getTenantByContactCode(
         ctx.params.contactCode
       )
+      // 403 rather than 404: the frontend query only skips retries for
+      // 401/403, and a missing contact should not be retried.
+      if (!getTenant.ok && getTenant.err === 'contact-not-found') {
+        ctx.status = 403
+        ctx.body = {
+          type: getTenant.err,
+          title: 'Contact not found',
+          status: 403,
+          detail: 'No contact found with the given contact code.',
+          ...metadata,
+        } satisfies RouteErrorResponse
+        return
+      }
+
       if (!getTenant.ok && getTenant.err === 'no-valid-housing-contract') {
         ctx.status = 403
         ctx.body = {

--- a/core/src/adapters/leasing-adapter/index.ts
+++ b/core/src/adapters/leasing-adapter/index.ts
@@ -378,7 +378,19 @@ const getTenantByContactCode = async (
       }
       // 'contact-not-tenant' and 'contact-leases-not-found' both mean the
       // contact has no tenancy.
-      return { ok: false, err: 'contact-not-tenant' }
+      if (
+        res.data?.type === 'contact-not-tenant' ||
+        res.data?.type === 'contact-leases-not-found'
+      ) {
+        return { ok: false, err: 'contact-not-tenant' }
+      }
+      // A 404 without a recognized leasing error type is not a business
+      // outcome — e.g. a proxy/gateway 404 or a misrouted service URL.
+      logger.error(
+        { status: res.status, body: res.data },
+        'leasing-adapter.getTenantByContactCode: unrecognized 404 response'
+      )
+      return { ok: false, err: 'unknown' }
     }
 
     if (!res.data.content) {
@@ -390,9 +402,6 @@ const getTenantByContactCode = async (
     logger.error({ err }, 'leasing-adapter.getTenantByContactCode')
 
     if (err instanceof AxiosError) {
-      if (err.response?.data?.type === 'contact-leases-not-found') {
-        return { ok: false, err: 'contact-not-tenant' }
-      }
       return { ok: false, err: err.response?.data?.type }
     }
     return { ok: false, err: 'unknown' }

--- a/core/src/adapters/leasing-adapter/index.ts
+++ b/core/src/adapters/leasing-adapter/index.ts
@@ -367,7 +367,19 @@ const getTenantByContactCode = async (
       `${tenantsLeasesServiceUrl}/contacts/${contactCode}/tenant`
     )
 
-    if (res.status === 404) return { ok: false, err: 'contact-not-tenant' }
+    if (res.status === 404) {
+      // Expected outcome when the contact is not a tenant — not an error.
+      // Leasing distinguishes the cause via the `type` field in the body.
+      if (res.data?.type === 'contact-not-found') {
+        return { ok: false, err: 'contact-not-found' }
+      }
+      if (res.data?.type === 'no-valid-housing-contract') {
+        return { ok: false, err: 'no-valid-housing-contract' }
+      }
+      // 'contact-not-tenant' and 'contact-leases-not-found' both mean the
+      // contact has no tenancy.
+      return { ok: false, err: 'contact-not-tenant' }
+    }
 
     if (!res.data.content) {
       return { ok: false, err: 'unknown' }

--- a/core/src/adapters/tests/leasing-adapter/index.test.ts
+++ b/core/src/adapters/tests/leasing-adapter/index.test.ts
@@ -259,4 +259,68 @@ describe('leasing-adapter', () => {
       ).not.toThrow()
     })
   })
+
+  describe(leasingAdapter.getTenantByContactCode, () => {
+    it('returns tenant when leasing responds with 200', async () => {
+      const tenant = factory.tenant.build()
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(200, { content: JSON.parse(JSON.stringify(tenant)) })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      assert(result.ok)
+      expect(result.data.contactCode).toEqual(tenant.contactCode)
+    })
+
+    it('returns contact-not-found when leasing responds with 404 contact-not-found', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(404, { type: 'contact-not-found' })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'contact-not-found' })
+    })
+
+    it('returns contact-not-tenant when leasing responds with 404 contact-not-tenant', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(404, { type: 'contact-not-tenant' })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'contact-not-tenant' })
+    })
+
+    it('returns contact-not-tenant when leasing responds with 404 contact-leases-not-found', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(404, { type: 'contact-leases-not-found' })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'contact-not-tenant' })
+    })
+
+    it('returns no-valid-housing-contract when leasing responds with 404 no-valid-housing-contract', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(404, { type: 'no-valid-housing-contract' })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'no-valid-housing-contract' })
+    })
+
+    it('returns err from response body type when leasing responds with 500', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(500, { type: 'get-contact' })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'get-contact' })
+    })
+  })
 })

--- a/core/src/adapters/tests/leasing-adapter/index.test.ts
+++ b/core/src/adapters/tests/leasing-adapter/index.test.ts
@@ -313,6 +313,18 @@ describe('leasing-adapter', () => {
       expect(result).toEqual({ ok: false, err: 'no-valid-housing-contract' })
     })
 
+    it('returns unknown when the 404 has no recognized error type', async () => {
+      nock(config.tenantsLeasesService.url)
+        .get('/contacts/P123456/tenant')
+        .reply(404, '<html>gateway not found</html>', {
+          'Content-Type': 'text/html',
+        })
+
+      const result = await leasingAdapter.getTenantByContactCode('P123456')
+
+      expect(result).toEqual({ ok: false, err: 'unknown' })
+    })
+
     it('returns err from response body type when leasing responds with 500', async () => {
       nock(config.tenantsLeasesService.url)
         .get('/contacts/P123456/tenant')

--- a/core/src/services/lease-service/index.ts
+++ b/core/src/services/lease-service/index.ts
@@ -1566,7 +1566,10 @@ export const routes = (router: KoaRouter) => {
    *                   type: object
    *                   description: The tenant data.
    *       404:
-   *         description: Not found.
+   *         description: >
+   *           No tenant found for this contact code. The response body `type`
+   *           distinguishes the cause: `contact-not-found`, `contact-not-tenant`
+   *           or `no-valid-housing-contract`.
    *       500:
    *         description: Internal server error. Failed to retrieve Tenant information.
    *     security:
@@ -1591,11 +1594,11 @@ export const routes = (router: KoaRouter) => {
       }
 
       if (res.err === 'no-valid-housing-contract') {
-        ctx.status = 500
+        ctx.status = 404
         ctx.body = {
           type: res.err,
           title: 'No valid housing contract found',
-          status: 500,
+          status: 404,
           detail: 'No active or upcoming contract found.',
           ...metadata,
         } satisfies RouteErrorResponse
@@ -1604,11 +1607,11 @@ export const routes = (router: KoaRouter) => {
       }
 
       if (res.err === 'contact-not-tenant') {
-        ctx.status = 500
+        ctx.status = 404
         ctx.body = {
           type: res.err,
           title: 'Contact is not a tenant',
-          status: 500,
+          status: 404,
           detail: 'No active or upcoming contract found.',
           ...metadata,
         } satisfies RouteErrorResponse

--- a/services/leasing/src/services/lease-service/get-tenant.ts
+++ b/services/leasing/src/services/lease-service/get-tenant.ts
@@ -18,15 +18,31 @@ type GetTenantError =
 
 type NonEmptyArray<T> = [T, ...T[]]
 
+// Expected outcomes when the contact simply is not a (current) tenant — not
+// system failures, so they must not be logged as errors.
+const NOT_TENANT_ERRORS: GetTenantError[] = [
+  'contact-not-found',
+  'contact-not-tenant',
+  'contact-leases-not-found',
+  'no-valid-housing-contract',
+]
+
 export async function getTenant(params: {
   contactCode: string
 }): Promise<AdapterResult<Tenant, GetTenantError>> {
   const result = await fetchTenant(params)
   if (!result.ok) {
-    logger.error(
-      { errorCode: result.err },
-      `Failed to fetch tenant by contact code: ${params.contactCode}`
-    )
+    if (NOT_TENANT_ERRORS.includes(result.err)) {
+      logger.info(
+        { errorCode: result.err },
+        `No tenant found for contact code: ${params.contactCode}`
+      )
+    } else {
+      logger.error(
+        { errorCode: result.err },
+        `Failed to fetch tenant by contact code: ${params.contactCode}`
+      )
+    }
   }
 
   return result

--- a/services/leasing/src/services/lease-service/routes/contacts.ts
+++ b/services/leasing/src/services/lease-service/routes/contacts.ts
@@ -443,7 +443,10 @@ export const routes = (router: KoaRouter) => {
    *                   type: object
    *                   description: The tenant data.
    *       404:
-   *         description: Not found.
+   *         description: >
+   *           No tenant found for this contact code. The response body `type`
+   *           distinguishes the cause: `contact-not-found`, `contact-not-tenant`,
+   *           `contact-leases-not-found` or `no-valid-housing-contract`.
    *       500:
    *         description: Internal server error. Failed to retrieve Tenant information.
    */
@@ -464,11 +467,11 @@ export const routes = (router: KoaRouter) => {
       }
 
       if (result.err === 'no-valid-housing-contract') {
-        ctx.status = 500
+        ctx.status = 404
         ctx.body = {
           type: result.err,
           title: 'No valid housing contract found',
-          status: 500,
+          status: 404,
           detail: 'No active or upcoming contract found.',
           ...metadata,
         } satisfies RouteErrorResponse
@@ -476,12 +479,24 @@ export const routes = (router: KoaRouter) => {
       }
 
       if (result.err === 'contact-not-tenant') {
-        ctx.status = 500
+        ctx.status = 404
         ctx.body = {
           type: result.err,
           title: 'Contact is not a tenant',
-          status: 500,
+          status: 404,
           detail: 'No active or upcoming contract found.',
+          ...metadata,
+        } satisfies RouteErrorResponse
+        return
+      }
+
+      if (result.err === 'contact-leases-not-found') {
+        ctx.status = 404
+        ctx.body = {
+          type: result.err,
+          title: 'Contact has no leases',
+          status: 404,
+          detail: 'No leases found for contact.',
           ...metadata,
         } satisfies RouteErrorResponse
         return

--- a/services/leasing/src/services/lease-service/tests/routes/contacts.test.ts
+++ b/services/leasing/src/services/lease-service/tests/routes/contacts.test.ts
@@ -385,7 +385,7 @@ describe('GET /contacts/:contactCode/tenant', () => {
     expect(JSON.stringify(res.body.content)).toEqual(JSON.stringify(tenant))
   })
 
-  it("responds with 500 and an error with the correct info when tenant doesn't have a valid housing contract", async () => {
+  it("responds with 404 and an error with the correct info when tenant doesn't have a valid housing contract", async () => {
     jest.spyOn(tenants, 'getTenant').mockResolvedValueOnce({
       ok: false,
       err: 'no-valid-housing-contract',
@@ -393,10 +393,47 @@ describe('GET /contacts/:contactCode/tenant', () => {
 
     const res = await request(app.callback()).get('/contacts/1231234/tenant')
 
-    expect(res.status).toBe(500)
+    expect(res.status).toBe(404)
     expect(res.body.type).toEqual('no-valid-housing-contract')
     expect(res.body.title).toEqual('No valid housing contract found')
-    expect(res.body.status).toEqual(500)
+    expect(res.body.status).toEqual(404)
     expect(res.body.detail).toEqual('No active or upcoming contract found.')
+  })
+
+  it('responds with 404 and an error with the correct info when contact is not a tenant', async () => {
+    jest.spyOn(tenants, 'getTenant').mockResolvedValueOnce({
+      ok: false,
+      err: 'contact-not-tenant',
+    })
+
+    const res = await request(app.callback()).get('/contacts/1231234/tenant')
+
+    expect(res.status).toBe(404)
+    expect(res.body.type).toEqual('contact-not-tenant')
+    expect(res.body.title).toEqual('Contact is not a tenant')
+    expect(res.body.status).toEqual(404)
+  })
+
+  it('responds with 404 when contact has no leases', async () => {
+    jest.spyOn(tenants, 'getTenant').mockResolvedValueOnce({
+      ok: false,
+      err: 'contact-leases-not-found',
+    })
+
+    const res = await request(app.callback()).get('/contacts/1231234/tenant')
+
+    expect(res.status).toBe(404)
+    expect(res.body.type).toEqual('contact-leases-not-found')
+  })
+
+  it('responds with 500 on unexpected errors', async () => {
+    jest.spyOn(tenants, 'getTenant').mockResolvedValueOnce({
+      ok: false,
+      err: 'get-contact',
+    })
+
+    const res = await request(app.callback()).get('/contacts/1231234/tenant')
+
+    expect(res.status).toBe(500)
   })
 })


### PR DESCRIPTION
### Problem

Searching for a contact in property-tree calls core's `GET /tenants/by-contact-code`, which in turn calls leasing's `GET /contacts/:contactCode/tenant`. When the contact isn't a tenant (e.g. P089052), leasing responded **500**, which propagated as ERROR logs in both leasing and core on every normal search — even though "contact is not a tenant" is an expected outcome.

### Changes

- **leasing**: the tenant endpoint now responds **404** for the expected not-a-tenant outcomes (`contact-not-tenant`, `no-valid-housing-contract`, `contact-leases-not-found`), with the semantic code in the body's `type` field. Genuine failures still respond 500. These outcomes are now logged as `info` instead of `error`.
- **core**: `leasing-adapter.getTenantByContactCode` maps the 404 body `type` to its existing error union without error-logging, and `/tenants/by-contact-code` propagates 404 (previously re-mapped to 500). Only the known leasing error types are accepted on 404 — an unrecognized 404 (e.g. a proxy/gateway 404 or misrouted service URL) is logged as an error and returned as `unknown`, so an infrastructure fault can't masquerade as "not a tenant". The now-obsolete `contact-leases-not-found` mapping in the catch path was removed (during deploy skew that case simply falls through to the pre-existing 500 behavior).
- **internal-portal (backend)**: the core adapter reads the error `type` from 404 responses, in addition to the existing 500 handling (kept for compatibility with core versions that predate this change). The `validate-tentant` route also got an explicit `contact-not-found` branch (403 with a proper body) — previously that case was masked as `contact-not-tenant` by core's adapter; without the new branch it would have surfaced as a bodyless 500 with client retries.

### Consumers verified

All consumers of the endpoint chain were mapped and verified:

- **Parking-space rental flow** (internal-portal `validate-tentant`): distinguishes non-tenants by error code and blocks with 403 — the codes are preserved end-to-end through the 404 body, so the flow behaves exactly as before. Verified this flow does **not** rely on the error/500 to permit or deny anything it shouldn't.
- **Core `/listings` filtering**: already treats these codes as expected soft-fails — unaffected. Note: `contact-not-found` now reaches this code path under its true name (it was previously collapsed into `contact-not-tenant`) and is error-logged there by existing design — kept as-is since that log is intentional for authenticated contacts.
- **Work-order creation**: treats any adapter error as 500 regardless of code — unaffected.
- **Property-tree contact search**: falls back to `/contacts/:contactCode` on any error — same behavior, without the log spam.

### Follow-up (not in this PR)

The tenant error codes are string literals maintained in leasing, core and internal-portal separately. A shared `GetTenantErrorCodes` in `libs/types/src/error-types` (following the existing `CreateOfferErrorCodes` pattern) would make the mapping compile-time-checked across packages.
